### PR TITLE
Add unary API surface for use by mixer and proxy.

### DIFF
--- a/mixer/api/v1/check.proto
+++ b/mixer/api/v1/check.proto
@@ -21,6 +21,17 @@ import "mixer/api/v1/attributes.proto";
 
 // Used to verify preconditions before performing an action.
 message CheckRequest {
+    // The attributes to use for this request
+    map<string, string> attributes = 1;
+}
+
+message CheckResponse {
+    // Indicates whether or not the preconditions succeeded
+    google.rpc.Status result = 1;
+}
+
+// Used to verify preconditions before performing an action.
+message StreamingCheckRequest {
   // Index within the stream for this request, used to match to responses
   int64 request_index = 1;
 
@@ -28,7 +39,7 @@ message CheckRequest {
   Attributes attribute_update = 2;
 }
 
-message CheckResponse {
+message StreamingCheckResponse {
   // Index of the request this response is associated with
   int64 request_index = 1;
 

--- a/mixer/api/v1/quota.proto
+++ b/mixer/api/v1/quota.proto
@@ -19,22 +19,9 @@ package istio.mixer.v1;
 import "google/rpc/status.proto";
 import "mixer/api/v1/attributes.proto";
 
-message QuotaRequest {
-  // Index within the stream for this request, used to match to responses
-  int64 request_index = 1;
-
-  // The attributes to use for this request
-  Attributes attribute_update = 2;
-
-  // what kind of quota operation to perform
-  OperationKind kind = 3;
-
-  // Used for deduplicating quota allocation/free calls in the case of
-  // failed RPCs are retries. This should be a UUID per call, where the same
-  // UUID is used for retries of the same quota allocation or release call.
-  string deduplication_id = 4;
-
-  enum OperationKind {
+// Describes the type of quota operation to apply for an incoming request
+enum QuotaOperationKind {
+    // Allocation mode not specified.
     QUOTA_MODE_UNSPECIFIED = 0;
 
     // Allocate the specified amount, fail if insufficient resources available.
@@ -48,7 +35,19 @@ message QuotaRequest {
 
     // Return the current content of the quota value cell.
     QUERY = 4;
-  }
+}
+
+message QuotaRequest {
+    // The attributes to use for this request
+    map<string, string> attributes = 1;
+
+    // what kind of quota operation to perform
+    QuotaOperationKind operation_kind = 2;
+
+    // Used for deduplicating quota allocation/free calls in the case of
+    // failed RPCs are retries. This should be a UUID per call, where the same
+    // UUID is used for retries of the same quota allocation or release call.
+    string deduplication_id = 4;
 }
 
 // Used to update quota values before and/or after performing an action.
@@ -57,16 +56,48 @@ message QuotaRequest {
 // Quotas can also be used to impose upper limits on the number of specific
 // resources exposed by a service to its consumers.
 message QuotaResponse {
-  // Index of the request this response is associated with
-  int64 request_index = 1;
+    // Result of the requested quota operation
+    oneof result {
+        // The effective amount of quota
+        uint64 effective_amount = 2;
 
-  // Results, one for each operation in the request.
-  // This map is indexed by the quota_operation_id of the individual quota operations.
-  oneof result {
-    // The effective amount of quota
-    uint64 effective_amount = 2;
+        // An error indication in case the quota operation failed
+        google.rpc.Status error = 3;
+    }
+}
 
-    // An error indication in case the quota operation failed
-    google.rpc.Status error = 3;
-  }
+message StreamingQuotaRequest {
+    // Index within the stream for this request, used to match to responses
+    int64 request_index = 1;
+
+    // The attributes to use for this request
+    Attributes attribute_update = 2;
+
+    // what kind of quota operation to perform
+    QuotaOperationKind kind = 3;
+
+    // Used for deduplicating quota allocation/free calls in the case of
+    // failed RPCs are retries. This should be a UUID per call, where the same
+    // UUID is used for retries of the same quota allocation or release call.
+    string deduplication_id = 4;
+}
+
+// Used to update quota values before and/or after performing an action.
+//
+// A common use case for quotas is to implement rate limits within a service.
+// Quotas can also be used to impose upper limits on the number of specific
+// resources exposed by a service to its consumers.
+message StreamingQuotaResponse {
+    // Index of the request this response is associated with
+    int64 request_index = 1;
+
+    // Results, one for each operation in the request.
+    // This map is indexed by the quota_operation_id of the individual quota operations.
+    oneof result {
+        // The effective amount of quota
+        uint64 effective_amount = 2;
+
+        // An error indication in case the quota operation failed
+        google.rpc.Status error = 3;
+    }
 }

--- a/mixer/api/v1/report.proto
+++ b/mixer/api/v1/report.proto
@@ -21,17 +21,28 @@ import "mixer/api/v1/attributes.proto";
 
 // Used to report telemetry after performing an action.
 message ReportRequest {
-  // Index within the stream for this request, used to match to responses
-  int64 request_index = 1;
-
-  // The attributes to use for this request
-  Attributes attribute_update = 2;
+    // The set of attributes to use for this request.
+    map<string, string> attributes = 1;
 }
 
 message ReportResponse {
-  // Index of the request this response is associated with
-  int64 request_index = 1;
+    // Indicates whether the report was successfully processed or not
+    google.rpc.Status result = 1;
+}
 
-  // Indicates whether the report was processed or not
-  google.rpc.Status result = 2;
+// Used to report telemetry after performing an action.
+message StreamingReportRequest {
+    // Index within the stream for this request, used to match to responses
+    int64 request_index = 1;
+
+    // The attributes to use for this request
+    Attributes attribute_update = 2;
+}
+
+message StreamingReportResponse {
+    // Index of the request this response is associated with
+    int64 request_index = 1;
+
+    // Indicates whether the report was processed or not
+    google.rpc.Status result = 2;
 }

--- a/mixer/api/v1/service.proto
+++ b/mixer/api/v1/service.proto
@@ -22,16 +22,41 @@ import "mixer/api/v1/quota.proto";
 
 // The Istio Mixer API
 service Mixer {
-  // Checks preconditions before performing an operation.
-  // The preconditions enforced depend on the set of supplied attributes
-  // and the active configuration.
-  rpc Check(stream CheckRequest) returns (stream CheckResponse) {}
+    // Checks preconditions before performing an operation.
+    // The preconditions enforced depend on the set of supplied attributes
+    // and the active configuration.
+    rpc Check (CheckRequest) returns (CheckResponse) {
+    }
 
-  // Reports telemetry, such as logs and metrics.
-  // The reported information depends on the set of supplied attributes
-  // and the active configuration.
-  rpc Report(stream ReportRequest) returns (stream ReportResponse) {}
+    // Reports telemetry, such as logs and metrics.
+    // The reported information depends on the set of supplied attributes
+    // and the active configuration.
+    rpc Report (ReportRequest) returns (ReportResponse) {
+    }
 
-  // Quota allocates and releases quota.
-  rpc Quota(stream QuotaRequest) returns (stream QuotaResponse) {}
+    // Quota allocates and releases quota.
+    rpc Quota (QuotaRequest) returns (QuotaResponse) {
+    }
+
+    // WARNING: The Streaming* RPCs are considering EXPERIMENTAL and are not
+    // supported at this time.
+
+    // EXPERIMENTAL: DO NOT USE
+    // Checks preconditions before performing an operation.
+    // The preconditions enforced depend on the set of supplied attributes
+    // and the active configuration.
+    rpc StreamingCheck (stream StreamingCheckRequest) returns (stream StreamingCheckResponse) {
+    }
+
+    // EXPERIMENTAL: DO NOT USE
+    // Reports telemetry, such as logs and metrics.
+    // The reported information depends on the set of supplied attributes
+    // and the active configuration.
+    rpc StreamingReport (stream StreamingReportRequest) returns (stream StreamingReportResponse) {
+    }
+
+    // EXPERIMENTAL: DO NOT USE
+    // Quota allocates and releases quota.
+    rpc StreamingQuota (stream StreamingQuotaRequest) returns (stream StreamingQuotaResponse) {
+    }
 }


### PR DESCRIPTION
This is a strawman proposal for non-streaming interface for mixer that can be used by the proxy.