### PR TITLE
Add logger aspect config

### DIFF
--- a/mixer/v1/config/aspect/logger_config.proto
+++ b/mixer/v1/config/aspect/logger_config.proto
@@ -1,0 +1,36 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.mixer.v1.config.aspect;
+
+// Configures an individual logger aspect implementation.
+//
+// Example usage:
+// kind: istio/logger
+// params:
+//    log_name: "endpoint_log"
+//    log_entry_descriptor_names: "application_log_entry", "action_log_entry"
+//
+message LoggerConfig {
+    // Provides a way to identify a collection of related log entries.
+    string log_name = 1;
+
+    // A list of names of istio.mixer.v1.config.descriptor.LogEntryDescriptors
+    // for log entries that will be generated for a Report() call. If no
+    // LogEntryDescriptor is named in the config, the logger will not generate
+    // any log entries.
+    repeated string log_entry_descriptor_names = 2;
+}

--- a/mixer/v1/config/descriptor/log_entry_descriptor.proto
+++ b/mixer/v1/config/descriptor/log_entry_descriptor.proto
@@ -33,17 +33,4 @@ message LogEntryDescriptor {
 
     // The name of the attribute to treat as the payload of the log entry.
     string payload_attribute = 5;
-
-    // PayloadFormat details the currently supported logging payload formats.
-    // TEXT is the default payload format.
-    enum PayloadFormat {
-        // Indicates a payload format of raw text.
-        TEXT = 0;
-
-        // Indicates a structured payload (JSON object).
-        STRUCTURED = 1;
-    }
-
-    // Format of the value of the payload attribute.
-    PayloadFormat payload_format = 6;
 }

--- a/mixer/v1/config/descriptor/log_entry_descriptor.proto
+++ b/mixer/v1/config/descriptor/log_entry_descriptor.proto
@@ -18,16 +18,32 @@ package istio.mixer.v1;
 
 // Defines the format of a single log entry.
 message LogEntryDescriptor {
-  // The name of this descriptor.
-  string name = 1;
+    // The name of this descriptor.
+    string name = 1;
 
-  // An optional concise name for the log entry type, which can be displayed in user interfaces.
-  // Use sentence case without an ending period, for example "Request count".
-  string display_name = 2;
+    // An optional concise name for the log entry type, which can be displayed in user interfaces.
+    // Use sentence case without an ending period, for example "Request count".
+    string display_name = 2;
 
-  // An optional description of the log entry type, which can be used in documentation.
-  string description = 3;
+    // An optional description of the log entry type, which can be used in documentation.
+    string description = 3;
 
-  // The set of attributes that are necessary to describe a log entry of this type.
-  repeated string attributes = 4;
+    // The set of attributes that are necessary to describe a log entry of this type.
+    repeated string attributes = 4;
+
+    // The name of the attribute to treat as the payload of the log entry.
+    string payload_attribute = 5;
+
+    // PayloadFormat details the currently supported logging payload formats.
+    // TEXT is the default payload format.
+    enum PayloadFormat {
+        // Indicates a payload format of raw text.
+        TEXT = 0;
+
+        // Indicates a structured payload (JSON object).
+        STRUCTURED = 1;
+    }
+
+    // Format of the value of the payload attribute.
+    PayloadFormat payload_format = 6;
 }


### PR DESCRIPTION
LoggerConfig, for the moment, will consist of name for the logs collection and a list of descriptor names for log entries.

The log_entry_descriptor is also updated to include metadata about a special payload attribute. Non-payload attributes will be considered metadata attributes about the detail provided in the payload.