### PR TITLE
Fix enum in quota descriptor

### DIFF
--- a/mixer/v1/config/descriptor/quota_descriptor.proto
+++ b/mixer/v1/config/descriptor/quota_descriptor.proto
@@ -69,6 +69,6 @@ message QuotaDescriptor {
     PER_SECOND_LIMIT = 1;
 
     // Quota limit expresses a maximum amount over a rolling time interval
-    PER_MINUTE_LIMIT = 1;
+    PER_MINUTE_LIMIT = 2;
   }
 }


### PR DESCRIPTION
PER_SECOND_LIMIT and PER_MINUTE_LIMIT cannot both have an index of 1.