### PR TITLE
Add payload format to LogEntryDescriptor.

### DIFF
--- a/mixer/v1/config/descriptor/log_entry_descriptor.proto
+++ b/mixer/v1/config/descriptor/log_entry_descriptor.proto
@@ -33,4 +33,18 @@ message LogEntryDescriptor {
 
     // The name of the attribute to treat as the payload of the log entry.
     string payload_attribute = 5;
+
+    // PayloadFormat details the currently supported logging payload formats.
+    // TEXT is the default payload format.
+    enum PayloadFormat {
+
+        // Indicates a payload format of raw text.
+        TEXT = 0;
+
+        // Indicates a structured payload (JSON object).
+        STRUCTURED = 1;
+    }
+
+    // Format of the value of the payload attribute.
+    PayloadFormat payload_format = 6;
 }

--- a/mixer/v1/config/descriptor/log_entry_descriptor.proto
+++ b/mixer/v1/config/descriptor/log_entry_descriptor.proto
@@ -41,8 +41,8 @@ message LogEntryDescriptor {
         // Indicates a payload format of raw text.
         TEXT = 0;
 
-        // Indicates a structured payload (JSON object).
-        STRUCTURED = 1;
+        // Indicates that the payload is a serialized JSON object.
+        JSON = 1;
     }
 
     // Format of the value of the payload attribute.


### PR DESCRIPTION
At the moment, there is no way to distinguish the formats of various payloads sent via the payload attribute to mixer to enable better processing of the payloads.

This PR establishes support for structured payloads (serialized JSON). This will enable structured loggers to better include the payload in their generated logs.