### PR TITLE
Streamline QuotaDescriptor.

### DIFF
--- a/mixer/v1/config/descriptor/quota_descriptor.proto
+++ b/mixer/v1/config/descriptor/quota_descriptor.proto
@@ -52,23 +52,8 @@ message QuotaDescriptor {
   // The default imposed maximum amount for values of this quota.
   int64 max_amount = 6;
 
-  // The type of quota behavior expected, defaults to ALLOCATION_LIMIT if not specified
-  QuotaKind kind = 7;
-
-  // Whether the quota's current value is tracked precisely or not.
-  // Precisely tracked quotas only allow a relatively modest level of
-  // scaling, whereas imprecise quotas can support a nearly unbounded
-  // level of scaling at the cost of potential accounting inaccuracies.
-  bool precise = 8;
-
-  enum QuotaKind {
-    // Quota values are always explicitly manipulated via API calls.
-    ALLOCATION_LIMIT = 0;
-
-    // Quota limit expresses a maximum amount over a rolling time interval
-    PER_SECOND_LIMIT = 1;
-
-    // Quota limit expresses a maximum amount over a rolling time interval
-    PER_MINUTE_LIMIT = 2;
-  }
+  // The amount of time allocated quota remains valid before it is
+  // automatically released. If this is 0, then allocated quota is
+  // not automatically released.
+  int32 expiration_seconds = 7;
 }

--- a/mixer/v1/quota.proto
+++ b/mixer/v1/quota.proto
@@ -26,9 +26,6 @@ message QuotaRequest {
   // The attributes to use for this request
   Attributes attribute_update = 2;
 
-  // what kind of quota operation to perform
-  OperationKind kind = 3;
-
   // Used for deduplicating quota allocation/free calls in the case of
   // failed RPCs and retries. This should be a UUID per call, where the same
   // UUID is used for retries of the same quota allocation or release call.
@@ -45,9 +42,6 @@ message QuotaRequest {
 
     // Release from 0 to the specified amount, never fails.
     RELEASE_BEST_EFFORT = 3;
-
-    // Return the current content of the quota value cell.
-    QUERY = 4;
   }
 }
 
@@ -60,13 +54,6 @@ message QuotaResponse {
   // Index of the request this response is associated with
   int64 request_index = 1;
 
-  // Results, one for each operation in the request.
-  // This map is indexed by the quota_operation_id of the individual quota operations.
-  oneof result {
-    // The effective amount of quota
-    uint64 effective_amount = 2;
-
-    // An error indication in case the quota operation failed
-    google.rpc.Status error = 3;
-  }
+  // Indicates whether or not the quota operation succeeded.
+  google.rpc.Status result = 2;
 }


### PR DESCRIPTION
This generalizes refresh windows and eliminates the API level distinction between allocation and rate quotas.

Allocated quota now just has an expiration period which determines when how long an allocation 'survives' until it is automatically freed. If you specify a expiration time of 0, then the quota is never freed.

This removes the notion of precise/imprecise quotas. That was just a leftover of how things are handled in GCP and isn't really an appropriate top-level concern.