### PR TITLE
add STRING_MAP value type

### DIFF
--- a/mixer/v1/config/descriptor/value_type.proto
+++ b/mixer/v1/config/descriptor/value_type.proto
@@ -52,4 +52,7 @@ enum ValueType {
 
     // A span between two points in time.
     DURATION = 10;
+
+    // A map string -> string, typically used by headers.
+    STRING_MAP = 1;
 }


### PR DESCRIPTION
Adds STRING_MAP value type.
Typically used by headers.