### PR TITLE
Move fault injection into route rule

### DIFF
--- a/proxy/v1/config/cfg.md
+++ b/proxy/v1/config/cfg.md
@@ -84,7 +84,7 @@ Match condition specifies a set of criterion to be met in order for the
 | source_tags | [MatchCondition.SourceTagsEntry](#istio.proxy.v1alpha.config.MatchCondition.SourceTagsEntry) | repeated | Identifies the source service version. The identifier is interpreted by the platform to match a service version for the source service.N.B. The map is used instead of pstruct due to lack of serialization supportin golang protobuf library (see https://github.com/golang/protobuf/pull/208) |
 | tcp | [L4MatchAttributes](#istio.proxy.v1alpha.config.L4MatchAttributes) | optional | Set of layer 4 match conditions based on the IP ranges. INCOMPLETE implementation |
 | udp | [L4MatchAttributes](#istio.proxy.v1alpha.config.L4MatchAttributes) | optional |  |
-| httpHeaders | [MatchCondition.HttpEntry](#istio.proxy.v1alpha.config.MatchCondition.HttpEntry) | repeated | Set of HTTP match conditions based on HTTP/1.1, HTTP/2, GRPC request metadata, such as "uri", "scheme", "authority". The header keys are case-insensitive. |
+| http_headers | [MatchCondition.HttpEntry](#istio.proxy.v1alpha.config.MatchCondition.HttpEntry) | repeated | Set of HTTP match conditions based on HTTP/1.1, HTTP/2, GRPC request metadata, such as "uri", "scheme", "authority". The header keys are case-insensitive. |
 
 
 <a name="istio.proxy.v1alpha.config.MatchCondition.HttpEntry"/>

--- a/proxy/v1/config/cfg.md
+++ b/proxy/v1/config/cfg.md
@@ -298,7 +298,6 @@ Abort Http request attempts and return error codes back to downstream
 | grpc_status | [string](#string) | optional |  |
 | http2_error | [string](#string) | optional |  |
 | http_status | [int32](#int32) | optional |  |
-| override_header_name | [string](#string) | optional |  |
 
 
 <a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Delay"/>
@@ -308,39 +307,6 @@ MUST specify either a fixed delay or exponential delay. Exponential
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| fixed_delay | [HTTPFaultInjection.FixedDelay](#istio.proxy.v1alpha.config.HTTPFaultInjection.FixedDelay) | optional |  |
-| exp_delay | [HTTPFaultInjection.ExponentialDelay](#istio.proxy.v1alpha.config.HTTPFaultInjection.ExponentialDelay) | optional |  |
-| override_header_name | [string](#string) | optional |  |
-
-
-<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.ExponentialDelay"/>
-### HTTPFaultInjection.ExponentialDelay
-Add a delay (based on an exponential function) before forwarding the
- request
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
 | percent | [float](#float) | optional | percentage of requests on which the delay will be injected |
-| mean_delay_seconds | [double](#double) | optional | mean delay needed to derive the exponential delay values |
-
-
-<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.FixedDelay"/>
-### HTTPFaultInjection.FixedDelay
-Add a fixed delay before forwarding the request
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| percent | [float](#float) | optional | percentage of requests on which the delay will be injected |
-| fixed_delay_seconds | [double](#double) | optional | delay duration in seconds.nanoseconds |
-
-
-<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.HeadersEntry"/>
-### HTTPFaultInjection.HeadersEntry
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [string](#string) | optional |  |
-| value | [StringMatch](#istio.proxy.v1alpha.config.StringMatch) | optional |  |
-
-
+| fixed_delay_seconds | [double](#double) | optional | Add a fixed delay before forwarding the request. Delay duration in seconds.nanoseconds |
+| exponential_delay_seconds | [double](#double) | optional | Add a delay (based on an exponential function) before forwarding the request. mean delay needed to derive the exponential delay values |

--- a/proxy/v1/config/cfg.md
+++ b/proxy/v1/config/cfg.md
@@ -269,8 +269,9 @@ Circuit breaker configuration.
 | http_max_requests | [int32](#int32) | optional | Maximum number of requests to a backend. |
 | sleep_window | [double](#double) | optional | Minimum time the circuit will be closed. In floating point seconds format. |
 | http_consecutive_errors | [int32](#int32) | optional | Number of 5XX errors before circuit is opened. |
-| http_detection_interval | [int32](#int32) | optional | Interval for checking state of hystrix circuit. |
+| http_detection_interval_seconds | [double](#int32) | optional | Interval for checking state of hystrix circuit. |
 | http_max_requests_per_connection | [int32](#int32) | optional | Maximum number of requests per connection to a backend. |
+| http_max_ejection_percent | [int32](#int32) | optional | Maximum percentage of hosts in the destination service that can be ejected due to circuit breaking. Defaults to 10%. |
 
 
 <a name="istio.proxy.v1alpha.config.HTTPFaultInjection"/>

--- a/proxy/v1/config/cfg.md
+++ b/proxy/v1/config/cfg.md
@@ -267,7 +267,7 @@ Circuit breaker configuration.
 | max_connections | [int32](#int32) | optional | Maximum number of connections to a backend. |
 | http_max_pending_requests | [int32](#int32) | optional | Maximum number of pending requests to a backend. |
 | http_max_requests | [int32](#int32) | optional | Maximum number of requests to a backend. |
-| sleep_window | [string](#string) | optional | Minimum time the circuit will be closed. |
+| sleep_window | [double](#double) | optional | Minimum time the circuit will be closed. In floating point seconds format. |
 | http_consecutive_errors | [int32](#int32) | optional | Number of 5XX errors before circuit is opened. |
 | http_detection_interval | [int32](#int32) | optional | Interval for checking state of hystrix circuit. |
 | http_max_requests_per_connection | [int32](#int32) | optional | Maximum number of requests per connection to a backend. |

--- a/proxy/v1/config/cfg.md
+++ b/proxy/v1/config/cfg.md
@@ -8,10 +8,10 @@
     * [Weighted Routing to Different Destination Service Versions](#istio.proxy.v1alpha.config.DestinationWeight)
     * [HTTP Req Retries](#istio.proxy.v1alpha.config.HTTPRetry)
     * [HTTP Req Timeouts](#istio.proxy.v1alpha.config.HTTPTimeout)
+    * [HTTP Fault Injection](#istio.proxy.v1alpha.config.HTTPFaultInjection)    
   * [Destination Policies](#istio.proxy.v1alpha.config.DestinationPolicy)
     * [Load Balancing](#istio.proxy.v1alpha.config.LoadBalancing)
     * [Circuit Breakers](#istio.proxy.v1alpha.config.CircuitBreaker)
-    * [Fault Injection](#istio.proxy.v1alpha.config.HTTPFaultInjection)
 
 <a name="cfg.proto"/>
 <p align="right"><a href="#top">Top</a></p>
@@ -68,7 +68,7 @@ not apply to TCP traffic towards the destination service.
 | route | [DestinationWeight](#istio.proxy.v1alpha.config.DestinationWeight) | repeated | Each routing rule is associated with one or more service version destinations (see glossary in beginning of document). Weights associated with the service version determine the proportion of traffic it receives. |
 | http_req_timeout | [HTTPTimeout](#istio.proxy.v1alpha.config.HTTPTimeout) | optional | Timeout policy for HTTP requests. |
 | http_req_retries | [HTTPRetry](#istio.proxy.v1alpha.config.HTTPRetry) | optional | Retry policy for HTTP requests. |
-
+| http_fault | [HTTPFaultInjection](#istio.proxy.v1alpha.config.HTTPFaultInjection) | optional | L7 fault injection policy applies to Http traffic |
 
 <a name="istio.proxy.v1alpha.config.MatchCondition"/>
 ### Match Conditions
@@ -84,7 +84,7 @@ Match condition specifies a set of criterion to be met in order for the
 | source_tags | [MatchCondition.SourceTagsEntry](#istio.proxy.v1alpha.config.MatchCondition.SourceTagsEntry) | repeated | Identifies the source service version. The identifier is interpreted by the platform to match a service version for the source service.N.B. The map is used instead of pstruct due to lack of serialization supportin golang protobuf library (see https://github.com/golang/protobuf/pull/208) |
 | tcp | [L4MatchAttributes](#istio.proxy.v1alpha.config.L4MatchAttributes) | optional | Set of layer 4 match conditions based on the IP ranges. INCOMPLETE implementation |
 | udp | [L4MatchAttributes](#istio.proxy.v1alpha.config.L4MatchAttributes) | optional |  |
-| http | [MatchCondition.HttpEntry](#istio.proxy.v1alpha.config.MatchCondition.HttpEntry) | repeated | Set of HTTP match conditions based on HTTP/1.1, HTTP/2, GRPC request metadata, such as "uri", "scheme", "authority". The header keys are case-insensitive. |
+| httpHeaders | [MatchCondition.HttpEntry](#istio.proxy.v1alpha.config.MatchCondition.HttpEntry) | repeated | Set of HTTP match conditions based on HTTP/1.1, HTTP/2, GRPC request metadata, such as "uri", "scheme", "authority". The header keys are case-insensitive. |
 
 
 <a name="istio.proxy.v1alpha.config.MatchCondition.HttpEntry"/>
@@ -213,7 +213,6 @@ DestinationPolicy declares policies that determine how to handle traffic for a
 | tags | [DestinationPolicy.TagsEntry](#istio.proxy.v1alpha.config.DestinationPolicy.TagsEntry) | repeated | Service version destination identifier for the destination service. The identifier is qualified by the destination service name, e.g. version "env=prod" in "my-service.default.svc.cluster.local".N.B. The map is used instead of pstruct due to lack of serialization supportin golang protobuf library (see https://github.com/golang/protobuf/pull/208) |
 | load_balancing | [LoadBalancing](#istio.proxy.v1alpha.config.LoadBalancing) | optional | Load balancing policy |
 | circuit_breaker | [CircuitBreaker](#istio.proxy.v1alpha.config.CircuitBreaker) | optional | Circuit breaker policy |
-| http_fault | [HTTPFaultInjection](#istio.proxy.v1alpha.config.HTTPFaultInjection) | optional | L7 fault injection policy applies to Http traffic |
 | custom | [Any](#google.protobuf.Any) | optional | Other custom policy implementations |
 
 

--- a/proxy/v1/config/cfg.proto
+++ b/proxy/v1/config/cfg.proto
@@ -283,6 +283,9 @@ message CircuitBreaker {
 
     /// Maximum number of requests per connection to a backend.
     int32 http_max_requests_per_connection = 7;
+
+    /// Maximum % of hosts in the destination service that can be ejected due to circuit breaking. Defaults to 10%.
+    int32 http_max_ejection_percent = 8;
   }
   oneof cb_policy {
     SimpleCircuitBreakerPolicy simple_cb = 1;

--- a/proxy/v1/config/cfg.proto
+++ b/proxy/v1/config/cfg.proto
@@ -84,14 +84,8 @@ message DestinationPolicy {
   /// Circuit breaker policy
   CircuitBreaker circuit_breaker = 4;
 
-  ///L7 fault injection policy applies to Http traffic
-  HTTPFaultInjection http_fault = 5;
-
-  ///@exclude L4 fault injection policy applies to Tcp/Udp (not Http) traffic
-  L4FaultInjection l4_fault = 6;
-
   /// Other custom policy implementations
-  google.protobuf.Any custom = 7;
+  google.protobuf.Any custom = 5;
 }
 
 /// Route rule provides a custom routing policy based on the source and
@@ -130,6 +124,12 @@ message RouteRule {
 
   /// Retry policy for HTTP requests.
   HTTPRetry http_req_retries = 6;
+
+  ///L7 fault injection policy applies to Http traffic
+  HTTPFaultInjection http_fault = 7;
+
+  ///@exclude L4 fault injection policy applies to Tcp/Udp (not Http) traffic
+  L4FaultInjection l4_fault = 8;
 }
 
 /// Match condition specifies a set of criterion to be met in order for the
@@ -158,7 +158,7 @@ message MatchCondition {
   /// Set of HTTP match conditions based on HTTP/1.1, HTTP/2, GRPC request metadata,
   /// such as "uri", "scheme", "authority".
   /// The header keys are case-insensitive.
-  map<string, StringMatch> http = 5;
+  map<string, StringMatch> httpHeaders = 5;
 }
 
 /// Each routing rule is associated with one or more service versions (see

--- a/proxy/v1/config/cfg.proto
+++ b/proxy/v1/config/cfg.proto
@@ -158,7 +158,7 @@ message MatchCondition {
   /// Set of HTTP match conditions based on HTTP/1.1, HTTP/2, GRPC request metadata,
   /// such as "uri", "scheme", "authority".
   /// The header keys are case-insensitive.
-  map<string, StringMatch> httpHeaders = 5;
+  map<string, StringMatch> http_headers = 5;
 }
 
 /// Each routing rule is associated with one or more service versions (see

--- a/proxy/v1/config/cfg.proto
+++ b/proxy/v1/config/cfg.proto
@@ -264,25 +264,25 @@ message HTTPRetry {
 message CircuitBreaker {
   message SimpleCircuitBreakerPolicy {
     /// Maximum number of connections to a backend.
-    int32 max_connections = 4;
+    int32 max_connections = 1;
 
     /// Maximum number of pending requests to a backend.
-    int32 http_max_pending_requests = 5;
+    int32 http_max_pending_requests = 2;
 
     /// Maximum number of requests to a backend.
-    int32 http_max_requests = 6;
+    int32 http_max_requests = 3;
 
     /// Minimum time the circuit will be closed. In floating point seconds format.
-    double sleep_window_seconds = 7;
+    double sleep_window_seconds = 4;
 
     /// Number of 5XX errors before circuit is opened.
-    int32 http_consecutive_errors = 8;
+    int32 http_consecutive_errors = 5;
 
     /// Interval for checking state of hystrix circuit.
-    int32 http_detection_interval = 9;
+    double http_detection_interval_seconds = 6;
 
     /// Maximum number of requests per connection to a backend.
-    int32 http_max_requests_per_connection = 10;
+    int32 http_max_requests_per_connection = 7;
   }
   oneof cb_policy {
     SimpleCircuitBreakerPolicy simple_cb = 1;

--- a/proxy/v1/config/cfg.proto
+++ b/proxy/v1/config/cfg.proto
@@ -313,37 +313,22 @@ message HTTPFaultInjection {
   /// were also delayed.
   Abort abort = 2;
 
-  /// Only requests with these Http headers will be subjected to fault
-  /// injection
-  map<string, StringMatch> headers = 3;
-
   /// MUST specify either a fixed delay or exponential delay. Exponential
   /// delay is unsupported at the moment.
   message Delay {
+    /// percentage of requests on which the delay will be injected
+    float percent = 1;
     oneof http_delay_type {
-      FixedDelay fixed_delay = 1;
-      ExponentialDelay exp_delay = 2;
+      /// Add a fixed delay before forwarding the request. Delay duration in seconds.nanoseconds
+      double fixed_delay_seconds = 2;
+      /// Add a delay (based on an exponential function) before forwarding
+      /// the request. mean delay needed to derive the exponential delay
+      /// values
+      double exponential_delay_seconds = 3;
     }
     // Specify delay duration as part of Http request.
     // TODO: The semantics and syntax of the headers is undefined.
-    string override_header_name = 3;
-  }
-
-  /// Add a fixed delay before forwarding the request
-  message FixedDelay {
-    /// percentage of requests on which the delay will be injected
-    float percent = 1;
-    /// delay duration in seconds.nanoseconds
-    double fixed_delay_seconds = 2;
-  }
-
-  /// Add a delay (based on an exponential function) before forwarding the
-  /// request
-  message ExponentialDelay {
-    /// percentage of requests on which the delay will be injected
-    float percent = 1;
-    /// mean delay needed to derive the exponential delay values
-    double mean_delay_seconds = 2;
+    string override_header_name = 4;
   }
 
   /// Abort Http request attempts and return error codes back to downstream

--- a/proxy/v1/config/cfg.proto
+++ b/proxy/v1/config/cfg.proto
@@ -272,8 +272,8 @@ message CircuitBreaker {
     /// Maximum number of requests to a backend.
     int32 http_max_requests = 6;
 
-    /// Minimum time the circuit will be closed.
-    string sleep_window = 7;
+    /// Minimum time the circuit will be closed. In floating point seconds format.
+    double sleep_window_seconds = 7;
 
     /// Number of 5XX errors before circuit is opened.
     int32 http_consecutive_errors = 8;


### PR DESCRIPTION
Just moving fault injection into route rule as discussed during the calls. Retained all docs, etc.