### PR TITLE
Provide TTL values for Check and Quota responses.

### DIFF
--- a/mixer/v1/check.proto
+++ b/mixer/v1/check.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package istio.mixer.v1;
 
+import "google/protobuf/duration.proto";
 import "google/rpc/status.proto";
 import "mixer/v1/attributes.proto";
 
@@ -34,4 +35,7 @@ message CheckResponse {
 
   // Indicates whether or not the preconditions succeeded
   google.rpc.Status result = 2;
+
+  // The amount of time for which this result can be considered valid, given the same inputs
+  google.protobuf.Duration expiration = 3;
 }

--- a/mixer/v1/quota.proto
+++ b/mixer/v1/quota.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package istio.mixer.v1;
 
-import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 import "google/rpc/status.proto";
 import "mixer/v1/attributes.proto";
 
@@ -51,8 +51,8 @@ message QuotaResponse {
   // Indicates whether the quota request was successfully processed.
   google.rpc.Status result = 2;
 
-  // The time at which the returned quota expires, this is 0 for non-expiring quotas.
-  google.protobuf.Timestamp expiration = 3;
+  // The amount of time the returned quota can be considered valid, this is 0 for non-expiring quotas.
+  google.protobuf.Duration expiration = 3;
 
   // The total amount of quota returned, may be less than requested.
   int64 amount = 4;


### PR DESCRIPTION
Quota had a TTL value expressed in terms of absolute time.
This unfortunately is useless in a distributed system.

Now both QuotaResponse and CheckResponse carry a Duration value
represent how long the response is valid for.