### PR TITLE
Add descriptors to the mixer's global config

### DIFF
--- a/mixer/v1/config/cfg.proto
+++ b/mixer/v1/config/cfg.proto
@@ -129,9 +129,9 @@ message GlobalConfig {
   // TODO: remove these in https://github.com/istio/api/pull/45
   repeated istio.mixer.v1.config.descriptor.LogEntryDescriptor logs = 3;
   repeated istio.mixer.v1.config.descriptor.MetricDescriptor metrics = 4;
-  repeated istio.mixer.v1.config.descriptor.QuotaDescriptor quotas = 5;
-  repeated istio.mixer.v1.config.descriptor.MonitoredResourceDescriptor monitored_resources = 6;
-  repeated istio.mixer.v1.config.descriptor.PrincipalDescriptor principals = 7;
+  repeated istio.mixer.v1.config.descriptor.MonitoredResourceDescriptor monitored_resources = 5;
+  repeated istio.mixer.v1.config.descriptor.PrincipalDescriptor principals = 6;
+  repeated istio.mixer.v1.config.descriptor.QuotaDescriptor quotas = 7;
 }
 
 // ClientConfig defines configuration from a client perspective.

--- a/mixer/v1/config/cfg.proto
+++ b/mixer/v1/config/cfg.proto
@@ -16,6 +16,12 @@ syntax = "proto3";
 
 import "google/protobuf/struct.proto";
 
+import "mixer/v1/config/descriptor/log_entry_descriptor.proto";
+import "mixer/v1/config/descriptor/metric_descriptor.proto";
+import "mixer/v1/config/descriptor/monitored_resource_descriptor.proto";
+import "mixer/v1/config/descriptor/principal_descriptor.proto";
+import "mixer/v1/config/descriptor/quota_descriptor.proto";
+
 
 package istio.mixer.v1.config;
 
@@ -119,6 +125,13 @@ message Adapter {
 message GlobalConfig {
   string revision = 1;
   repeated Adapter adapters = 2;
+
+  // TODO: remove these in https://github.com/istio/api/pull/45
+  repeated istio.mixer.v1.config.descriptor.LogEntryDescriptor logs = 3;
+  repeated istio.mixer.v1.config.descriptor.MetricDescriptor metrics = 4;
+  repeated istio.mixer.v1.config.descriptor.QuotaDescriptor quotas = 5;
+  repeated istio.mixer.v1.config.descriptor.MonitoredResourceDescriptor monitored_resources = 6;
+  repeated istio.mixer.v1.config.descriptor.PrincipalDescriptor principals = 7;
 }
 
 // ClientConfig defines configuration from a client perspective.

--- a/mixer/v1/config/descriptor/monitored_resource_descriptor.proto
+++ b/mixer/v1/config/descriptor/monitored_resource_descriptor.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package istio.mixer.v1.config.descriptor;
 
+import "mixer/v1/config/descriptor/label_descriptor.proto";
+
 // An object that describes the schema of a `MonitoredResource`. A
 // `MonitoredResource` is used to define a type of resources for
 // monitoring purpose. For example, the monitored resource "VM" refers
@@ -32,6 +34,8 @@ message MonitoredResourceDescriptor {
   // be used in documentation.
   string description = 2;
 
-  // The set of attributes that are necessary to describe a specific instance of a monitored resource.
-  repeated string attributes = 3;
+  // Labels represent the dimensions that uniquely identify this monitored resource.
+  // At runtime expressions will be evaluated to provide values for each label. Label
+  // names are mapped to expressions in the service config.
+  repeated LabelDescriptor labels = 3;
 }

--- a/mixer/v1/config/descriptor/principal_descriptor.proto
+++ b/mixer/v1/config/descriptor/principal_descriptor.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package istio.mixer.v1.config.descriptor;
 
+import "mixer/v1/config/descriptor/label_descriptor.proto";
+
 // Defines a a security principal.
 //
 // A principal is described by a set of attributes.
@@ -23,6 +25,8 @@ message PrincipalDescriptor {
   // The name of this descriptor.
   string name = 1;
 
-  // The set of attributes which are used to describe a specific security principal.
-  repeated string attributes = 2;
+  // Labels represent the dimensions that uniquely identify this security principal.
+  // At runtime expressions will be evaluated to provide values for each label. Label
+  // names are mapped to expressions in the service config.
+  repeated LabelDescriptor labels = 2;
 }


### PR DESCRIPTION
As a stopgap so we can make progress independent of @mandarjog's https://github.com/istio/api/pull/45, we add `repeated` descriptor fields to the global config. We also change the `MonitoredResourceDescriptor` and `PrincipalDescriptor` protos to use `LabelDescriptors` rather than `repeated string attributes`. This should let us close https://github.com/istio/api/issues/49.