### PR TITLE
Use gogoprotobuf code gen options to improve the Go versions of our A…

### DIFF
--- a/mixer/v1/attributes.proto
+++ b/mixer/v1/attributes.proto
@@ -16,8 +16,13 @@ syntax = "proto3";
 
 package istio.mixer.v1;
 
+import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
+
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
 
 // An instance of this message is delivered to the mixer with every
 // API call.
@@ -98,14 +103,19 @@ message Attributes {
   map<int32, int64> int64_attributes = 5;
   map<int32, double> double_attributes = 6;
   map<int32, bool> bool_attributes = 7;
-  map<int32, google.protobuf.Timestamp> timestamp_attributes = 8;
-  map<int32, google.protobuf.Duration> duration_attributes = 9;
+  map<int32, google.protobuf.Timestamp> timestamp_attributes = 8 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  map<int32, google.protobuf.Duration> duration_attributes = 9 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
   map<int32, bytes> bytes_attributes = 10;
   map<int32, StringMap> stringMap_attributes = 11;
 
   // Attributes that should be removed from the specified attribute context. Deleting
   // attributes which aren't currently in the attribute context is not considered an error.
   repeated int32 deleted_attributes = 12;
+
+  // TODO: temporary workaround for gogoprotobuf code gen error (https://github.com/gogo/protobuf/issues/273). Remove
+  // when issue is fixed.
+  map<int32, google.protobuf.Timestamp> timestamp_attributes_HACK = 13 [(gogoproto.nullable) = false, (gogoproto.stdtime) = false];
+  map<int32, google.protobuf.Duration> duration_attributes_HACK = 14 [(gogoproto.nullable) = false, (gogoproto.stdduration) = false];
 }
 
 // A map of string to string. The keys in these maps are from the current

--- a/mixer/v1/check.proto
+++ b/mixer/v1/check.proto
@@ -16,9 +16,14 @@ syntax = "proto3";
 
 package istio.mixer.v1;
 
+import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
 import "google/rpc/status.proto";
 import "mixer/v1/attributes.proto";
+
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
 
 // Used to verify preconditions before performing an action.
 message CheckRequest {
@@ -26,7 +31,7 @@ message CheckRequest {
   int64 request_index = 1;
 
   // The attributes to use for this request
-  Attributes attribute_update = 2;
+  Attributes attribute_update = 2 [(gogoproto.nullable) = false];
 }
 
 message CheckResponse {
@@ -34,8 +39,8 @@ message CheckResponse {
   int64 request_index = 1;
 
   // Indicates whether or not the preconditions succeeded
-  google.rpc.Status result = 2;
+  google.rpc.Status result = 2 [(gogoproto.nullable) = false];
 
   // The amount of time for which this result can be considered valid, given the same inputs
-  google.protobuf.Duration expiration = 3;
+  google.protobuf.Duration expiration = 3 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 }

--- a/mixer/v1/quota.proto
+++ b/mixer/v1/quota.proto
@@ -16,16 +16,21 @@ syntax = "proto3";
 
 package istio.mixer.v1;
 
+import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
 import "google/rpc/status.proto";
 import "mixer/v1/attributes.proto";
+
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
 
 message QuotaRequest {
   // Index within the stream for this request, used to match to responses
   int64 request_index = 1;
 
   // The attributes to use for this request
-  Attributes attribute_update = 2;
+  Attributes attribute_update = 2 [(gogoproto.nullable) = false];
 
   // Used for deduplicating quota allocation/free calls in the case of
   // failed RPCs and retries. This should be a UUID per call, where the same
@@ -49,10 +54,10 @@ message QuotaResponse {
   int64 request_index = 1;
 
   // Indicates whether the quota request was successfully processed.
-  google.rpc.Status result = 2;
+  google.rpc.Status result = 2 [(gogoproto.nullable) = false];
 
   // The amount of time the returned quota can be considered valid, this is 0 for non-expiring quotas.
-  google.protobuf.Duration expiration = 3;
+  google.protobuf.Duration expiration = 3 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
   // The total amount of quota returned, may be less than requested.
   int64 amount = 4;

--- a/mixer/v1/report.proto
+++ b/mixer/v1/report.proto
@@ -16,8 +16,13 @@ syntax = "proto3";
 
 package istio.mixer.v1;
 
+import "gogoproto/gogo.proto";
 import "google/rpc/status.proto";
 import "mixer/v1/attributes.proto";
+
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
 
 // Used to report telemetry after performing an action.
 message ReportRequest {
@@ -25,7 +30,7 @@ message ReportRequest {
   int64 request_index = 1;
 
   // The attributes to use for this request
-  Attributes attribute_update = 2;
+  Attributes attribute_update = 2 [(gogoproto.nullable) = false];
 }
 
 message ReportResponse {
@@ -33,5 +38,5 @@ message ReportResponse {
   int64 request_index = 1;
 
   // Indicates whether the report was processed or not
-  google.rpc.Status result = 2;
+  google.rpc.Status result = 2 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
…PI protos.

This makes for smaller & nicer Go code that runs faster due to decreased
GC pressure.