### PR TITLE
Revert "Add gogoproto option to generate compare method"

### DIFF
--- a/proxy/v1/config/cfg.proto
+++ b/proxy/v1/config/cfg.proto
@@ -47,14 +47,11 @@
 
 syntax = "proto3";
 
-package istio.proxy.v1alpha.config;
-
 import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
-import "gogoproto/gogo.proto";
 
+package istio.proxy.v1alpha.config;
 option go_package = "config";
-option (gogoproto.compare_all) = true;
 
 ///@exclude Proxy level global configurations go here
 message ProxyMeshConfig {


### PR DESCRIPTION
Reverts istio/api#62
gogoproto doesn't support compare on `oneof` fields and generates invalid go sources.