### PR TITLE
Introduce unary mixer APIs.

### DIFF
--- a/mixer/v1/config/descriptor/quota_descriptor.proto
+++ b/mixer/v1/config/descriptor/quota_descriptor.proto
@@ -16,7 +16,6 @@ syntax = "proto3";
 
 package istio.mixer.v1.config.descriptor;
 
-import "google/protobuf/duration.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 
 // Configuration state for a particular quota.
@@ -43,11 +42,6 @@ message QuotaDescriptor {
   // for a quota of this type.
   map<string, ValueType> labels = 4;
 
-  // The default imposed maximum amount for values of this quota.
-  int64 max_amount = 5;
-
-  // The amount of time allocated quota remains valid before it is
-  // automatically released. If this is 0, then allocated quota is
-  // not automatically released.
-  google.protobuf.Duration expiration = 6;
+  // Indicates whether the quota represents a rate limit or represents a resource quota.
+  bool rate_limit = 5;
 }


### PR DESCRIPTION
For now, all unary methods have a 2
suffix to allow implementation work to proceed side-by-side with
the existing API. Once work is complete in the mixer and mixer
client, then we can get rid of the streaming API definitions and
drop the 2 suffix on the unary definitions.

This API updates the attribute protocol to use both a global connection-level dictionary and a
per-message dictionary, add supports for using the dictionary for attribute values in addition to
using it for attribute names. Finally, the new protocol doesn't provide delta
semantics, it's always all-or-nothing.