### PR TITLE
proxy config: per retry timeout

### DIFF
--- a/proxy/v1/config/cfg.md
+++ b/proxy/v1/config/cfg.md
@@ -172,6 +172,7 @@ Retry policy to use when a request fails.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | attempts | [int32](#int32) | optional | Number of retries for a given request. The interval between retries will be determined automatically (25ms+). Actual number of retries attempted depends on the http_timeout |
+| per_try_timeout_seconds | [double](#double) | optional | Timeout per retry attempt for a given request. Specified in seconds.nanoseconds format. |
 | override_header_name | [string](#string) | optional | Downstream Service could specify retry attempts via Http header to the proxy, if the proxy supports such a feature. |
 
 

--- a/proxy/v1/config/cfg.proto
+++ b/proxy/v1/config/cfg.proto
@@ -303,9 +303,12 @@ message HTTPRetry {
     /// will be determined automatically (25ms+). Actual number of retries
     /// attempted depends on the http_timeout
     int32 attempts = 1;
+    /// Timeout per retry attempt for a given request. 
+    /// Specified in seconds.nanoseconds format.
+    double per_try_timeout_seconds = 2;
     /// Downstream Service could specify retry attempts via Http header to
     /// the proxy, if the proxy supports such a feature.
-    string override_header_name = 2;
+    string override_header_name = 3;
   }
   oneof retry_policy {
     SimpleRetryPolicy simple_retry = 1;


### PR DESCRIPTION
This PR adds support for specifying timeout per retry in our route rule specification (corresponding support has been added in Envoy lyft/envoy#756). Together, we now have global timeout budget, per retry timeout with jitter between retries, max retries, and policies that govern when a retry should be attempted.