### PR TITLE
Add distribution kind to metric_descriptor.

### DIFF
--- a/mixer/v1/config/descriptor/metric_descriptor.proto
+++ b/mixer/v1/config/descriptor/metric_descriptor.proto
@@ -48,7 +48,7 @@ import "mixer/v1/config/descriptor/value_type.proto";
 //        api_method: $apiMethod | "unknown"
 //        # either the attribute named 'responseCode' or the literal int64 500; must eval to an int64
 //        response_code: $responseCode | 500
-//      
+//
 message MetricDescriptor {
   // The name of this descriptor. This is used to refer to this descriptor in other contexts.
   string name = 1;
@@ -94,24 +94,14 @@ message MetricDescriptor {
   map<string, ValueType> labels = 6;
 
   message BucketsDefinition {
-    // Exactly one of these three fields must be set.
-    oneof options {
-      // The linear bucket.
-      Linear linear_buckets = 1;
-
-      // The exponential buckets.
-      Exponential exponential_buckets = 2;
-
-      // The explicit buckets.
-      Explicit explicit_buckets = 3;
-    }
-
     // Specifies a linear sequence of buckets that all have the same width
     // (except overflow and underflow). Each bucket represents a constant
     // absolute uncertainty on the specific value in the bucket.
     //
-    // There are `num_finite_buckets + 2` (= N) buckets. Bucket `i` has the
-    // following boundaries:
+    // There are `num_finite_buckets + 2` (= N) buckets. The two additional
+    // buckets are the underflow and overflow buckets.
+    //
+    // Bucket `i` has the following boundaries:
     //
     //    Upper bound (0 <= i < N-1):     offset + (width * i).
     //    Lower bound (1 <= i < N):       offset + (width * (i - 1)).
@@ -130,8 +120,10 @@ message MetricDescriptor {
     // proportional to the value of the lower bound. Each bucket represents a
     // constant relative uncertainty on a specific value in the bucket.
     //
-    // There are `num_finite_buckets + 2` (= N) buckets. Bucket `i` has the
-    // following boundaries:
+    // There are `num_finite_buckets + 2` (= N) buckets. The two additional
+    // buckets are the underflow and overflow buckets.
+    //
+    // Bucket `i` has the following boundaries:
     //
     //    Upper bound (0 <= i < N-1):     scale * (growth_factor ^ i).
     //    Lower bound (1 <= i < N):       scale * (growth_factor ^ (i - 1)).
@@ -160,6 +152,19 @@ message MetricDescriptor {
     message Explicit {
       // The values must be monotonically increasing.
       repeated double bounds = 1;
+    }
+
+
+    // Exactly one of these three fields must be set.
+    oneof definition {
+      // The linear buckets.
+      Linear linear_buckets = 1;
+
+      // The exponential buckets.
+      Exponential exponential_buckets = 2;
+
+      // The explicit buckets.
+      Explicit explicit_buckets = 3;
     }
   }
 

--- a/mixer/v1/config/descriptor/metric_descriptor.proto
+++ b/mixer/v1/config/descriptor/metric_descriptor.proto
@@ -154,7 +154,6 @@ message MetricDescriptor {
       repeated double bounds = 1;
     }
 
-
     // Exactly one of these three fields must be set.
     oneof definition {
       // The linear buckets.

--- a/mixer/v1/config/descriptor/metric_descriptor.proto
+++ b/mixer/v1/config/descriptor/metric_descriptor.proto
@@ -71,7 +71,17 @@ message MetricDescriptor {
     // A count of occurrences over an interval, always a positive integer.
     // For example, the number of API requests.
     COUNTER = 2;
+
+    // Summary statistics for a population of values. At the moment, only histograms
+    // representing the distribution of those values across a set of buckets are
+    // supported (configured via the buckets field).
+    //
+    // Values for DISTRIBUTIONs will be reported in singular form. It will be up to the
+    // mixer adapters and backend systems to transform single reported values into the
+    // distribution form as needed (and as supported).
+    DISTRIBUTION = 3;
   }
+
   // Whether the metric records instantaneous values, changes to a value, etc.
   MetricKind kind = 4;
 
@@ -82,4 +92,80 @@ message MetricDescriptor {
   // map attribute expressions to actual values for these labels at run time; the result of the evaluation
   // must be of the type described by the kind for each label.
   map<string, ValueType> labels = 6;
+
+  message BucketsDefinition {
+    // Exactly one of these three fields must be set.
+    oneof options {
+      // The linear bucket.
+      Linear linear_buckets = 1;
+
+      // The exponential buckets.
+      Exponential exponential_buckets = 2;
+
+      // The explicit buckets.
+      Explicit explicit_buckets = 3;
+    }
+
+    // Specifies a linear sequence of buckets that all have the same width
+    // (except overflow and underflow). Each bucket represents a constant
+    // absolute uncertainty on the specific value in the bucket.
+    //
+    // There are `num_finite_buckets + 2` (= N) buckets. Bucket `i` has the
+    // following boundaries:
+    //
+    //    Upper bound (0 <= i < N-1):     offset + (width * i).
+    //    Lower bound (1 <= i < N):       offset + (width * (i - 1)).
+    message Linear {
+      // Must be greater than 0.
+      int32 num_finite_buckets = 1;
+
+      // Must be greater than 0.
+      double width = 2;
+
+      // Lower bound of the first bucket.
+      double offset = 3;
+    }
+
+    // Specifies an exponential sequence of buckets that have a width that is
+    // proportional to the value of the lower bound. Each bucket represents a
+    // constant relative uncertainty on a specific value in the bucket.
+    //
+    // There are `num_finite_buckets + 2` (= N) buckets. Bucket `i` has the
+    // following boundaries:
+    //
+    //    Upper bound (0 <= i < N-1):     scale * (growth_factor ^ i).
+    //    Lower bound (1 <= i < N):       scale * (growth_factor ^ (i - 1)).
+    message Exponential {
+      // Must be greater than 0.
+      int32 num_finite_buckets = 1;
+
+      // Must be greater than 1.
+      double growth_factor = 2;
+
+      // Must be greater than 0.
+      double scale = 3;
+    }
+
+    // Specifies a set of buckets with arbitrary widths.
+    //
+    // There are `size(bounds) + 1` (= N) buckets. Bucket `i` has the following
+    // boundaries:
+    //
+    //    Upper bound (0 <= i < N-1):     bounds[i]
+    //    Lower bound (1 <= i < N);       bounds[i - 1]
+    //
+    // The `bounds` field must contain at least one element. If `bounds` has
+    // only one element, then there are no finite buckets, and that single
+    // element is the common boundary of the overflow and underflow buckets.
+    message Explicit {
+      // The values must be monotonically increasing.
+      repeated double bounds = 1;
+    }
+  }
+
+  // For metrics with a metric kind of DISTRIBUTION, this provides a mechanism for configuring
+  // the buckets that will be used to store the aggregated values. This field must be provided
+  // for metrics declared to be of type DISTRIBUTION. This field will be ignored for
+  // non-distribution metric kinds.
+  BucketsDefinition buckets = 7;
 }


### PR DESCRIPTION
This is needed to provide instruction to backends and adapters to treat
values as observations within a histogram. This will enable
adapters/backends to more readily monitor values that are distributions
when they have native support for distribution values.

Example uses:
- prometheus (histograms:
https://prometheus.io/docs/concepts/metric_types/#histogram)
- statds (timings:
https://github.com/etsy/statsd/blob/master/docs/metric_types.md#timing)
- stackdriver (distributions:
https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TypedValue#Distribution)

The documentation for the bucket definitions (and actual proto messages)
are taken from existing stackdriver custom metrics protos for
distributions.

NOTE: individual reports can still be single-valued. Adapters that
support distributions will be responsible for appropriately
summarizing/transforming single reports. Adapters that do not support
distributions can treat them as counters or gauges (depending). At the
moment, we do not have any adapters that cannot support distributions.