### PR TITLE
Introduce unary mixer APIs.

### DIFF
--- a/mixer/v1/attributes.proto
+++ b/mixer/v1/attributes.proto
@@ -24,102 +24,35 @@ option (gogoproto.goproto_getters_all) = false;
 option (gogoproto.equal_all) = false;
 option (gogoproto.gostring_all) = false;
 
-// An instance of this message is delivered to the mixer with every
+// An instance of this message is delivered to Mixer with many
 // API call.
 //
-// The general idea is to leverage the stateful gRPC streams from the
-// proxy to the mixer to keep to a minimum the 'attribute chatter'.
-// Only delta attributes are sent over, multiple concurrent attribute
-// contexts can be used to avoid thrashing, and attribute indices are used to
-// keep the wire protocol maximally efficient.
-//
-// Producing this message is the responsibility of the mixer's client
-// library which is linked into different proxy implementations.
-//
-// The processing order for this state in the mixer is:
-//
-//   * Any new dictionary is applied
-//
-//   * The requested attribute context is looked up. If no such context has been defined, a
-//     new context is automatically created and initialized to the empty state. When a gRPC
-//     stream is first created, there are no attribute contexts for the stream.
-//
-//   * If reset_context is true, then the attribute context is reset to the
-//     empty state.
-//
-//   * All attributes to deleted are removed from the attribute context.
-//
-//   * All attribute changes are applied to the attribute context.
-//
+// Within this message, strings are referenced using integer indices into
+// one of two string dictionaries. Positive integers index into the global
+// deployment-wide dictionary, whereas negative integers index into the message-level
+// dictionary instead. The message-level dictionary is carried by the
+// `words` field of this message, the deployment-wide dictionary is determined via
+// configuration.
 message Attributes {
-  // A dictionary that provides a mapping of shorthand index values to
-  // attribute names.
-  //
-  // This is intended to leverage the stateful gRPC stream from the
-  // proxy to the mixer. This dictionary is sent over only when a
-  // stream to the mixer is first established and when the proxy's
-  // configuration changes and different attributes may be produced.
-  //
-  // Once a dictionary has been sent over, it stays in effect until
-  // a new dictionary is sent to replace it. The first request sent on a
-  // stream must include a dictionary, otherwise the mixer can't process
-  // any attribute updates.
-  //
-  // Dictionaries are independent of the attribute context and are thus global
-  // to each gRPC stream.
-  map<int32, string> dictionary = 1;
+  // The message-level dictionary.
+  repeated string words = 1;
 
-  // The attribute context against which to operate.
-  //
-  // The mixer keeps different contexts live for any proxy gRPC stream. This
-  // allows the proxy to maintain multiple concurrent 'bags of attributes'
-  // within the mixer.
-  //
-  // If the proxy doesn't want to leverage multiple contexts, it just passes
-  // 0 here for every request.
-  //
-  // The proxy is configured to use a maximum number of attribute contexts in order
-  // to prevent an explosion of contexts in the mixer's memory space.
-  //
-  // TODO: Consider removing support for this feature. The proxy can achieve
-  // the same effect using multiple gRPC streams. The benefit of using streams
-  // would be that the mixer would be in control of the maximum number of streams
-  // it allows, whereas with the current model the proxy could overwhelm the
-  // mixer by creating too many contexts.
-  int32 attribute_context = 2;
-
-  // When true, resets the current attribute context to the empty state before
-  // applying any incoming attributes.
-  //
-  // Resetting contexts is useful to constrain the amount of resources used by
-  // the mixer. The proxy needs to intelligently manage a pool of contexts.
-  // It may be useful to reset a context when certain big events happen, such
-  // as when an HTTP2 connection into the proxy terminates.
-  bool reset_context = 3;
-
-  // Attributes being updated within the specified attribute context. These maps
-  // add and/or overwrite the context's current set of attributes.
-  map<int32, string> string_attributes = 4;
-  map<int32, int64> int64_attributes = 5;
-  map<int32, double> double_attributes = 6;
-  map<int32, bool> bool_attributes = 7;
-  map<int32, google.protobuf.Timestamp> timestamp_attributes = 8 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
-  map<int32, google.protobuf.Duration> duration_attributes = 9 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-  map<int32, bytes> bytes_attributes = 10;
-  map<int32, StringMap> stringMap_attributes = 11 [(gogoproto.nullable) = false];
-
-  // Attributes that should be removed from the specified attribute context. Deleting
-  // attributes which aren't currently in the attribute context is not considered an error.
-  repeated int32 deleted_attributes = 12;
-
-  // TODO: temporary workaround for gogoprotobuf code gen error (https://github.com/gogo/protobuf/issues/273). Remove
-  // when issue is fixed.
-  map<int32, google.protobuf.Timestamp> timestamp_attributes_HACK = 13 [(gogoproto.nullable) = false, (gogoproto.stdtime) = false];
-  map<int32, google.protobuf.Duration> duration_attributes_HACK = 14 [(gogoproto.nullable) = false, (gogoproto.stdduration) = false];
+  // Attribute payload. All `sint32` values represent indices into
+  // one of the word dictionaries. Positive values are indices into the
+  // global deployment-wide dictionary, negative values are indices into
+  // the message-level dictionary.
+  map<sint32, sint32> strings = 2;
+  map<sint32, int64> int64s = 3;
+  map<sint32, double> doubles = 4;
+  map<sint32, bool> bools = 5;
+  map<sint32, google.protobuf.Timestamp> timestamps = 6 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  map<sint32, google.protobuf.Duration> durations = 7 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+  map<sint32, bytes> bytes = 8;
+  map<sint32, StringMap> string_maps = 9 [(gogoproto.nullable) = false];
 }
 
-// A map of string to string. The keys in these maps are from the current
-// dictionary.
+// A map of string to string. The keys and values in this map are dictionary
+// indices (see the [Attributes][istio.mixer.v1.Attributes] message for an explanation)
 message StringMap {
-  map<int32, string> map = 1;
+  map<sint32, sint32> entries = 1;
 }

--- a/mixer/v1/check.proto
+++ b/mixer/v1/check.proto
@@ -18,7 +18,6 @@ package istio.mixer.v1;
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
-import "google/rpc/status.proto";
 import "mixer/v1/attributes.proto";
 
 option (gogoproto.goproto_getters_all) = false;
@@ -27,23 +26,24 @@ option (gogoproto.gostring_all) = false;
 
 // Used to verify preconditions before performing an action.
 message CheckRequest {
-  // Index within the stream for this request, used to match to responses
-  int64 request_index = 1;
-
   // The attributes to use for this request
-  Attributes attribute_update = 2 [(gogoproto.nullable) = false];
+  Attributes attributes = 1 [(gogoproto.nullable) = false];
 }
 
 message CheckResponse {
-  // Index of the request this response is associated with
-  int64 request_index = 1;
-
   // The attributes to use for this response
-  Attributes attribute_update = 2;
-
-  // Indicates whether or not the preconditions succeeded
-  google.rpc.Status result = 3 [(gogoproto.nullable) = false];
+  Attributes attributes = 1 [(gogoproto.nullable) = false];
 
   // The amount of time for which this result can be considered valid, given the same inputs
-  google.protobuf.Duration expiration = 4 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+  //
+  // Caching of results is based on the set of supplied attributes.
+  // Given the exact same set of attributes, the result of a previous
+  // Check call can be used for the given interval.
+  //
+  // A more sophisticated caching approach is to only consider the set of
+  // attributes which can impact the Check result. Only changes in those attributes
+  // can lead to changes in the result of Check. Determining this precise subset
+  // of attributes is handled by the Istio configuration system, and made available
+  // out-of-band to clients.
+  google.protobuf.Duration expiration = 2 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 }

--- a/mixer/v1/quota.proto
+++ b/mixer/v1/quota.proto
@@ -18,7 +18,6 @@ package istio.mixer.v1;
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
-import "google/rpc/status.proto";
 import "mixer/v1/attributes.proto";
 
 option (gogoproto.goproto_getters_all) = false;
@@ -26,42 +25,30 @@ option (gogoproto.equal_all) = false;
 option (gogoproto.gostring_all) = false;
 
 message QuotaRequest {
-  // Index within the stream for this request, used to match to responses
-  int64 request_index = 1;
-
   // The attributes to use for this request
-  Attributes attribute_update = 2 [(gogoproto.nullable) = false];
+  Attributes attributes = 1 [(gogoproto.nullable) = false];
 
   // Used for deduplicating quota allocation/free calls in the case of
   // failed RPCs and retries. This should be a UUID per call, where the same
   // UUID is used for retries of the same quota allocation call.
-  string deduplication_id = 3;
+  string deduplication_id = 2;
 
   // The quota to allocate from.
-  string quota = 4;
+  string quota = 3;
 
   // The amount of quota to allocate.
-  int64 amount = 5;
+  int64 amount = 4;
 
   // If true, allows a response to return less quota than requested. When
   // false, the exact requested amount is returned or 0 if not enough quota
   // was available.
-  bool best_effort = 6;
+  bool best_effort = 5;
 }
 
 message QuotaResponse {
-  // Index of the request this response is associated with.
-  int64 request_index = 1;
-
-  // The attributes to use for this response
-  Attributes attribute_update = 2;
-
-  // Indicates whether the quota request was successfully processed.
-  google.rpc.Status result = 3 [(gogoproto.nullable) = false];
-
-  // The amount of time the returned quota can be considered valid, this is 0 for non-expiring quotas.
-  google.protobuf.Duration expiration = 4 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+  // The amount of time the returned quota can be considered valid, this is null or 0 for non-expiring quotas.
+  google.protobuf.Duration expiration = 1 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
   // The total amount of quota returned, may be less than requested.
-  int64 amount = 5;
+  int64 amount = 2;
 }

--- a/mixer/v1/report.proto
+++ b/mixer/v1/report.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 package istio.mixer.v1;
 
 import "gogoproto/gogo.proto";
-import "google/rpc/status.proto";
 import "mixer/v1/attributes.proto";
 
 option (gogoproto.goproto_getters_all) = false;
@@ -26,20 +25,25 @@ option (gogoproto.gostring_all) = false;
 
 // Used to report telemetry after performing an action.
 message ReportRequest {
-  // Index within the stream for this request, used to match to responses
-  int64 request_index = 1;
+  // The attributes to use for this request.
+  //
+  // These attributes are delta-encoded. In other words, each individual
+  // set of attributes is used to modify the previous set. This eliminates
+  // the need to redundantly send the same attributes multiple times over within
+  // a single request.
+  //
+  // If a client is not sophisticated and doesn't want to use delta-encoding,
+  // a degenerate case is to include all attributes in every individual message.
+  repeated Attributes attributes = 1 [(gogoproto.nullable) = false];
 
-  // The attributes to use for this request
-  Attributes attribute_update = 2 [(gogoproto.nullable) = false];
+  // The default message-level dictionary for all the attributes.
+  // Individual attribute messages can have their own dictionaries, but if they don't
+  // then this set of words, if it is provided, is used instead.
+  //
+  // This makes it possible to share the same dictionary for all attributes in this
+  // request, which can substantially reduce the overall request size.
+  repeated string default_words = 2;
 }
 
 message ReportResponse {
-  // Index of the request this response is associated with
-  int64 request_index = 1;
-
-  // The attributes to use for this response
-  Attributes attribute_update = 2;
-
-  // Indicates whether the report was processed or not
-  google.rpc.Status result = 3 [(gogoproto.nullable) = false];
 }

--- a/mixer/v1/service.proto
+++ b/mixer/v1/service.proto
@@ -27,25 +27,25 @@ import "mixer/v1/quota.proto";
 // Preconditions can include whether the service consumer is properly
 // authenticated, is on the service’s whitelist, passes ACL checks, and more.
 //
-// - *Telemetry Reporting*. Enables services to report logging and monitoring.
-// In the future, it will also enable tracing and billing streams intended for
-// both the service operator as well as for service consumers.
-//
 // - *Quota Management*. Enables services to allocate and free quota on a number
 // of dimensions, Quotas are used as a relatively simple resource management tool
 // to provide some fairness between service consumers when contending for limited
 // resources. Rate limits are examples of quotas.
+//
+// - *Telemetry Reporting*. Enables services to report logging and monitoring.
+// In the future, it will also enable tracing and billing streams intended for
+// both the service operator as well as for service consumers.
 service Mixer {
   // Checks preconditions before performing an operation.
   // The preconditions enforced depend on the set of supplied attributes and
   // the active configuration.
-  rpc Check(stream CheckRequest) returns (stream CheckResponse) {}
+  rpc Check(CheckRequest) returns (CheckResponse) {}
 
   // Reports telemetry, such as logs and metrics.
   // The reported information depends on the set of supplied attributes and the
   // active configuration.
-  rpc Report(stream ReportRequest) returns (stream ReportResponse) {}
+  rpc Report(ReportRequest) returns (ReportResponse) {}
 
   // Quota allocates and releases quota.
-  rpc Quota(stream QuotaRequest) returns (stream QuotaResponse) {}
+  rpc Quota(QuotaRequest) returns (QuotaResponse) {}
 }


### PR DESCRIPTION
For now, all unary methods have a 2
suffix to allow implementation work to proceed side-by-side with
the existing API. Once work is complete in the mixer and mixer
client, then we can get rid of the streaming API definitions and
drop the 2 suffix on the unary definitions.