### PR TITLE
Update metric descriptor code comments so they'll be rendered correctly

### DIFF
--- a/mixer/v1/config/descriptor/metric_descriptor.proto
+++ b/mixer/v1/config/descriptor/metric_descriptor.proto
@@ -51,7 +51,8 @@ import "mixer/v1/config/descriptor/value_type.proto";
 //     apiMethod: api.method | "unknown"
 //     # either the attribute named 'response.code' or the literal int64 500; must eval to an int64
 //     responseCode: response.code | 500
-//```
+// ```
+//
 message MetricDescriptor {
   // Required. The name of this descriptor. This is used to refer to this
   // descriptor in other contexts.

--- a/mixer/v1/config/descriptor/monitored_resource_descriptor.proto
+++ b/mixer/v1/config/descriptor/monitored_resource_descriptor.proto
@@ -33,7 +33,7 @@ message MonitoredResourceDescriptor {
   // Optional. A detailed description of the monitored resource descriptor that
   // might be used in documentation.
   string description = 2;
-  
+
   // Labels represent the dimensions that uniquely identify this monitored
   // resource. At runtime expressions will be evaluated to provide values for
   // each label. Label names are mapped to expressions as part of aspect


### PR DESCRIPTION
Apparently you need a space or it breaks. Clean up some whitespace I noticed while checking the other files.