### PR TITLE
New config model (renames and restructuring)

### DIFF
--- a/mixer/v1/config/cfg.proto
+++ b/mixer/v1/config/cfg.proto
@@ -33,7 +33,7 @@ package istio.mixer.v1.config;
 // ```yaml
 // subject: "namespace:ns1"
 // revision: "1011"
-// action_rules:
+// actionRules:
 // - selector: target.service == "*"
 //   actions:
 //   - handler: prometheus-handler
@@ -75,12 +75,14 @@ message ServiceConfig {
 
   // This is about to get deprecated. The configuration will move to
   // [action_rules][istio.mixer.v1.config.ServiceConfig.action_rules].
-  repeated AspectRule rules = 3;
+  // (== deprecation_description Please use action_rules to express the intention associated with this ServiceConfig ==)
+  repeated AspectRule rules = 3 [deprecated = true];
 
   // Optional. List of constructors that can be referenced from [actions][istio.mixer.v1.config.Action.instances]
   repeated Constructor constructors = 4;
 
-  // Optional. List of actions that apply for this service.
+  // Optional. List of actions that apply for this service
+  // TODO: Rename this to rules once we delete the AspectRule field.
   repeated ActionRule action_rules = 5;
 }
 
@@ -154,7 +156,7 @@ message Aspect {
 // params:
 // ```
 message Adapter {
-  // Required, must be unique per `kind`. Used by [Aspect][istio.mixer.v1.config.Aspect]
+  // Required. must be unique per `kind`. Used by [Aspect][istio.mixer.v1.config.Aspect]
   // to refer to this adapter. The name "default" is special: when an Aspect does not
   // specify a name, the Adapter named "default" of the same `kind` is used to execute
   // the intention described by the [AspectRule][istio.mixer.v1.config.AspectRule]s.
@@ -166,7 +168,7 @@ message Adapter {
   // Required. The name of a specific adapter implementation. An adapter's
   // implementation name is typically a constant in its code.
   string impl = 3;
-  // Optional, depends on adapter implementation. Struct representation of a
+  // Optional. Depends on adapter implementation. Struct representation of a
   // proto defined by the implementation; this varies depending on `impl`.
   google.protobuf.Struct params = 4;
 }
@@ -196,7 +198,7 @@ message GlobalConfig {
   // Optional. List of handlers that can be referenced from [actions][istio.mixer.v1.config.Action.handler]
   repeated Handler handlers = 9;
 
-  // Optional. List of types that can be referenced from [Constructors][istio.mixer.v1.config.Constructor.type]
+  // Optional. List of types that can be referenced from [constructors][istio.mixer.v1.config.Constructor.type]
   repeated Type types = 10;
 }
 
@@ -295,11 +297,11 @@ message EmailAddress {
 }
 
 
-// An ActionRule is a selector and a set of intentions to be executed when the
-// selector is `true`.
+// An Rule is a selector and a set of intentions to be executed when the
+// selector is `true`
 //
 // The following example instructs Mixer to invoke 'prometheus-handler' handler for all services and pass it the object
-// constructed using the constructor 'RequestCountByService'
+// constructed using the 'RequestCountByService' constructor.
 //
 // ```yaml
 // action_rules:
@@ -309,9 +311,9 @@ message EmailAddress {
 //     instances:
 //     - RequestCountByService
 // ```
-message ActionRule {
+message Rule {
   // Required. Selector is an attribute based predicate. When Mixer receives a
-  // request it evaluates all selectors in scope and executes the ActionRule for all
+  // request it evaluates all selectors in scope and executes the `actions` for all
   // selectors that evaluated to true.
   //
   // A few example selectors:
@@ -328,7 +330,8 @@ message ActionRule {
 
   // Optional. Nested action rules; their selectors are evaluated if this selector
   // predicate evaluates to `true`.
-  repeated ActionRule action_rules = 3;
+  // TODO: Rename this to rules once we delete the AspectRule field.
+  repeated Rule action_rules = 3;
 }
 
 // Action describes which [Handler][istio.mixer.v1.config.Handler] to invoke and what data to pass to it for processing.
@@ -342,22 +345,24 @@ message ActionRule {
 //   - RequestCountByService
 // ```
 message Action {
-  // Required: The handler to invoke.
+  // Required: The handler to invoke. Must match the `name` of a [Handler][istio.mixer.v1.config.Handler.name] in scope.
   string handler = 2;
 
-  // Required: List of constructor names that will be evaluated during request execution, and the constructed object
-  // will be passed to the handler for processing.
+  // Required: The name must match the `name` of the [Constructor][istio.mixer.v1.config.Constructor.name]s in scope.
+  // Referenced constructors are evaluated by resolving the attributes/literals for all the fields.
+  // The constructed objects are then passed to the `handler` referenced within this action.
   repeated string instances = 3;
 }
 
-// Constructor tell Mixer how to create instances of particular types.
+// Constructor tell Mixer how to create instances of particular [Type][istio.mixer.v1.config.Type].
 //
 // Constructor is defined by the operator. Constructor is defined relative to a known
-// [Type][istio.mixer.v1.config.Type]. Their purpose is to tell Mixer how to use attributes or literals to produce
-// instances of the specified type.
+// `Type`. Their purpose is to tell Mixer how to use attributes or literals to produce
+// instances of the specified `Type` at runtime.
 //
-// The following example instructs Mixer to construct an object named 'RequestCountByService' for type 'RequestCounter'
-// and it also provides mapping between fields of the type and attributes/literals.
+// The following example instructs Mixer to construct an object for type 'RequestCounter'
+// and it also provides mapping between fields of the type and attributes/literals. This construtor
+// can be referenced by [Actions][istio.mixer.v1.config.Action] using name 'RequestCountByService'.
 //
 // ```yaml
 // - name: RequestCountByService
@@ -369,16 +374,18 @@ message Action {
 //       target_ip: destination.ip
 // ```
 message Constructor {
-  // Require. Name of the constructor
+  // Required. Name of the constructor
   //
   // Must be unique in the entire mixer configuration. Used by [Action][istio.mixer.v1.config.Action] to refer
   // to this constructor.
   string name = 1;
 
-  // Require. The name of the type this constructor intend to construct.
+  // Required. The value must match the `name` of one of the [Types][istio.mixer.v1.config.Type.name] in scope.
+  // It points to the `Type` this constructor intend to construct.
   string type = 2;
 
-  // Required. Struct representation of a proto associated with the 'type'.
+  // Required. Depends on referenced `Type`. Struct representation of a
+  // proto defined by the [Type][istio.mixer.v1.config.Type]; this varies depending on the value of field `type`.
   google.protobuf.Struct params = 3;
 }
 
@@ -394,25 +401,27 @@ message Constructor {
 // params:
 // ```
 message Handler {
-  // Required, Must be unique in the entire mixer configuration. Used by [Actions][istio.mixer.v1.config.Action.handler]
+  // Required. Must be unique in the entire mixer configuration. Used by [Actions][istio.mixer.v1.config.Action.handler]
   // to refer to this handler.
   string name = 1;
   // Required. The name of a specific adapter implementation. An adapter's
   // implementation name is typically a constant in its code.
   string adapter = 2;
-  // Optional, depends on adapter implementation. Struct representation of a
-  // proto defined by the implementation; this varies depending on `adapter`.
+  // Optional. Depends on adapter implementation. Struct representation of a
+  // proto defined by the adapter implementation; this varies depending on the value of field `adapter`.
   google.protobuf.Struct params = 3;
 }
 
-// Type describes the shape of the object that can be constructed using the
+// A `Type` describes the shape of an object that can be constructed using a
 // [Constructor][istio.mixer.v1.config.Constructor].
 //
-// In the following example we define a `RequestCounter` type. The type is based on 'MetricTemplate' template.
-// Template is a proto message that describes a general category of data that mixer can
-// pass to various adapters for processing. Template dictates how types associated with it should configure the
-// shape of the object that can be constructed. In this case, MetricTemplate requires all types associated with it to
-// declare a 'value' field with its required ValueType and dimensions field with their name and required ValueType.
+// A `Type` is based on a specific `Template`. A `Template` describes a category of `Type`s. Each of the types
+// conforming to the `Template` describes the shape of an object that can be constructed at runtime.
+//
+// In the following example we define a 'MetricTemplate' template, which requires that any `Type` associated with it to
+// declare ValueType associated with 'value' and 'dimensions' field. The example also declares a 'RequestCounter'
+// `Type` which is based on `Template` 'MetricTemplate'. 'RequestCounter' expresses that 'value' field be of type
+// 'INT64' and 'source' dimension be of type STRING.
 //
 // ```yaml
 // - name: RequestCounter
@@ -433,13 +442,14 @@ message Handler {
 // }
 // ```
 message Type {
-  // Required, Name of the type. Must be unique in the entire mixer configuration. Used by
+  // Required. Name of the type. Must be unique in the entire mixer configuration. Used by
   // [Constructor][istio.mixer.v1.config.Constructor.type] which tells the mixer how to construct this type.
   string name = 1;
-  // Required. The name of a specific template this type belongs to.
+  // Required. The name of a specific template this type belongs to. The value must match the name of the available
+  // template in scope.
   string template = 2;
 
-  // Required, depends on template referenced by this type. Struct representation of a
-  // proto defined for the template; this varies depending on `template`.
+  // Optional. Depends on referenced `template`. Struct representation of a
+  // proto defined by the Template; this varies depending on the value of field `template`.
   google.protobuf.Struct params = 3;
 }

--- a/mixer/v1/config/cfg.proto
+++ b/mixer/v1/config/cfg.proto
@@ -197,7 +197,7 @@ message GlobalConfig {
   repeated Handler handlers = 9;
 
   // Optional. List of types that can be referenced from [Constructors][istio.mixer.v1.config.Constructor.type]
-  repeated Types types = 10;
+  repeated Type types = 10;
 }
 
 // AttributeManifest describes a set of Attributes produced by some component
@@ -439,7 +439,7 @@ message Type {
   // Required. The name of a specific template this type belongs to.
   string template = 2;
 
-  // Optional, depends on template referenced by this type. Struct representation of a
+  // Required, depends on template referenced by this type. Struct representation of a
   // proto defined for the template; this varies depending on `template`.
   google.protobuf.Struct params = 3;
 }

--- a/mixer/v1/config/cfg.proto
+++ b/mixer/v1/config/cfg.proto
@@ -33,17 +33,34 @@ package istio.mixer.v1.config;
 // ```yaml
 // subject: "namespace:ns1"
 // revision: "1011"
-// rules:
+// action_rules:
 // - selector: target.service == "*"
-//   aspects:
-//   - kind: metrics
-//     params:
-//       metrics: # defines metric collection across the board.
-//       - descriptorName: response_time_by_status_code
-//         value: response.time
-//         labels:
-//           statusCode: response.code
-// ```
+//   actions:
+//   - handler: prometheus-handler
+//     instances:
+//     - RequestCountByService
+//
+// handlers:
+// - name: prometheus-handler
+//   adapter: prometheus
+//   params:
+//
+// constructors:
+// - name: RequestCountByService
+//   type: RequestCounter
+//   params:
+//     value: 1
+//     dimensions:
+//       source: origin.service
+//       target_ip: destination.ip
+//
+// types:
+// - name: RequestCounter
+//   template: MetricTemplate
+//   params:
+//     value: INT64
+//     dimensions:
+//       source: STRING
 //
 // (== deprecation_description ServiceConfig is deprecated, see the Config API's
 // swagger spec. ==)
@@ -55,7 +72,16 @@ message ServiceConfig {
   string subject = 1;
   // Optional. revision of this config. This is assigned by the server
   string revision = 2;
+
+  // This is about to get deprecated. The configuration will move to
+  // [action_rules][istio.mixer.v1.config.ServiceConfig.action_rules].
   repeated AspectRule rules = 3;
+
+  // Optional. List of constructors that can be referenced from [actions][istio.mixer.v1.config.Action.instances]
+  repeated Constructor constructors = 4;
+
+  // Optional. List of actions that apply for this service.
+  repeated ActionRule action_rules = 5;
 }
 
 // An AspectRule is a selector and a set of intentions to be executed when the
@@ -76,6 +102,7 @@ message AspectRule {
   string selector = 1;
   // The aspects that apply when selector evaluates to `true`.
   repeated Aspect aspects = 2;
+
   // Nested aspect rules; their selectors are evaluated if this selector
   // predicate evaluates to `true`.
   repeated AspectRule rules = 3;
@@ -165,6 +192,12 @@ message GlobalConfig {
   repeated istio.mixer.v1.config.descriptor.MonitoredResourceDescriptor monitored_resources = 6;
   repeated istio.mixer.v1.config.descriptor.PrincipalDescriptor principals = 7;
   repeated istio.mixer.v1.config.descriptor.QuotaDescriptor quotas = 8;
+
+  // Optional. List of handlers that can be referenced from [actions][istio.mixer.v1.config.Action.handler]
+  repeated Handler handlers = 9;
+
+  // Optional. List of types that can be referenced from [Constructors][istio.mixer.v1.config.Constructor.type]
+  repeated Types types = 10;
 }
 
 // AttributeManifest describes a set of Attributes produced by some component
@@ -259,4 +292,154 @@ message DnsName {
 // EmailAddress holds a properly formatted email address.
 message EmailAddress {
   string value = 1;
+}
+
+
+// An ActionRule is a selector and a set of intentions to be executed when the
+// selector is `true`.
+//
+// The following example instructs Mixer to invoke 'prometheus-handler' handler for all services and pass it the object
+// constructed using the constructor 'RequestCountByService'
+//
+// ```yaml
+// action_rules:
+// - selector: target.service == "*"
+//   actions:
+//   - handler: prometheus-handler
+//     instances:
+//     - RequestCountByService
+// ```
+message ActionRule {
+  // Required. Selector is an attribute based predicate. When Mixer receives a
+  // request it evaluates all selectors in scope and executes the ActionRule for all
+  // selectors that evaluated to true.
+  //
+  // A few example selectors:
+  //
+  // * an empty selector evaluates to `true`
+  // * `true`, a boolean literal; a rule with this selector will always be executed
+  // * `target.service == ratings*` selects any request targeting a service whose
+  // name starts with "ratings"
+  // * `attr1 == "20" && attr2 == "30"` logical AND, OR, and NOT are also available
+  string selector = 1;
+
+  // Optional. The actions that will be executed when selector evaluates to `true`.
+  repeated Action actions = 2;
+
+  // Optional. Nested action rules; their selectors are evaluated if this selector
+  // predicate evaluates to `true`.
+  repeated ActionRule action_rules = 3;
+}
+
+// Action describes which [Handler][istio.mixer.v1.config.Handler] to invoke and what data to pass to it for processing.
+//
+// The following example instructs Mixer to invoke 'prometheus-handler' handler and pass it the object
+// constructed using the constructor 'RequestCountByService'
+//
+// ```yaml
+// - handler: prometheus-handler
+//   instances:
+//   - RequestCountByService
+// ```
+message Action {
+  // Required: The handler to invoke.
+  string handler = 2;
+
+  // Required: List of constructor names that will be evaluated during request execution, and the constructed object
+  // will be passed to the handler for processing.
+  repeated string instances = 3;
+}
+
+// Constructor tell Mixer how to create instances of particular types.
+//
+// Constructor is defined by the operator. Constructor is defined relative to a known
+// [Type][istio.mixer.v1.config.Type]. Their purpose is to tell Mixer how to use attributes or literals to produce
+// instances of the specified type.
+//
+// The following example instructs Mixer to construct an object named 'RequestCountByService' for type 'RequestCounter'
+// and it also provides mapping between fields of the type and attributes/literals.
+//
+// ```yaml
+// - name: RequestCountByService
+//   type: RequestCounter
+//   params:
+//     value: 1
+//     dimensions:
+//       source: origin.service
+//       target_ip: destination.ip
+// ```
+message Constructor {
+  // Require. Name of the constructor
+  //
+  // Must be unique in the entire mixer configuration. Used by [Action][istio.mixer.v1.config.Action] to refer
+  // to this constructor.
+  string name = 1;
+
+  // Require. The name of the type this constructor intend to construct.
+  string type = 2;
+
+  // Required. Struct representation of a proto associated with the 'type'.
+  google.protobuf.Struct params = 3;
+}
+
+// Handler allows the operator to configure a specific adapter implementation.
+// Each adapter implementation defines its own `params` proto.
+//
+// In the following example we define a `metrics` adapter using the Mixer's prepackaged
+// prometheus adapter. This adapter doesn't require any parameters.
+//
+// ```yaml
+// name: prometheus-handler
+// adapter: prometheus
+// params:
+// ```
+message Handler {
+  // Required, Must be unique in the entire mixer configuration. Used by [Actions][istio.mixer.v1.config.Action.handler]
+  // to refer to this handler.
+  string name = 1;
+  // Required. The name of a specific adapter implementation. An adapter's
+  // implementation name is typically a constant in its code.
+  string adapter = 2;
+  // Optional, depends on adapter implementation. Struct representation of a
+  // proto defined by the implementation; this varies depending on `adapter`.
+  google.protobuf.Struct params = 3;
+}
+
+// Type describes the shape of the object that can be constructed using the
+// [Constructor][istio.mixer.v1.config.Constructor].
+//
+// In the following example we define a `RequestCounter` type. The type is based on 'MetricTemplate' template.
+// Template is a proto message that describes a general category of data that mixer can
+// pass to various adapters for processing. Template dictates how types associated with it should configure the
+// shape of the object that can be constructed. In this case, MetricTemplate requires all types associated with it to
+// declare a 'value' field with its required ValueType and dimensions field with their name and required ValueType.
+//
+// ```yaml
+// - name: RequestCounter
+//   template: MetricTemplate
+//   params:
+//     value: INT64
+//     dimensions:
+//       source: STRING
+// ```
+//
+// Sample MetricTemplate
+//
+// ```proto
+// message MetricTemplate {
+//   string name;
+//   ValueType value;
+//   map<string, ValueType> dimensions;
+// }
+// ```
+message Type {
+  // Required, Name of the type. Must be unique in the entire mixer configuration. Used by
+  // [Constructor][istio.mixer.v1.config.Constructor.type] which tells the mixer how to construct this type.
+  string name = 1;
+  // Required. The name of a specific template this type belongs to.
+  string template = 2;
+
+  // Optional, depends on template referenced by this type. Struct representation of a
+  // proto defined for the template; this varies depending on `template`.
+  google.protobuf.Struct params = 3;
 }

--- a/mixer/v1/config/cfg.proto
+++ b/mixer/v1/config/cfg.proto
@@ -83,7 +83,7 @@ message ServiceConfig {
 
   // Optional. List of actions that apply for this service
   // TODO: Rename this to rules once we delete the AspectRule field.
-  repeated ActionRule action_rules = 5;
+  repeated Rule action_rules = 5;
 }
 
 // An AspectRule is a selector and a set of intentions to be executed when the


### PR DESCRIPTION
Proto changes reflecting the new revised mixer configuration object model (https://docs.google.com/document/d/1elqeOTDCGSaKP7GI0mrNkZDtt0dq8TbarEt0jUNTk-M/edit).

