### PR TITLE
Introduce ingress rule

### DIFF
--- a/proxy/v1/config/ingress_rule.proto
+++ b/proxy/v1/config/ingress_rule.proto
@@ -1,0 +1,66 @@
+// Copyright 2017 Istio Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+syntax = "proto3";
+
+import "proxy/v1/config/route_rule.proto";
+
+package istio.proxy.v1.config;
+
+// Ingress rules are routing rules applied to the mediating middle proxy. This
+// proxy serves as an ingress proxy for the entire mesh, but can also be
+// addressed from inside the mesh.  Each ingress rule defines a destination
+// service and port. Rules that do not resolve to a service or a port in the
+// mesh are ignored.
+//
+// The routing rules for the destination service are applied at the ingress
+// proxy. That means the routing rule match conditions are composed and its
+// actions are enforced. The traffic splitting for the destination service is
+// also effective.
+message IngressRule {
+  // REQUIRED: Ingress rules have unique names to allow multiple rules, e.g.
+  // "my-rule".
+  string name = 1;
+
+  // REQUIRED: Port on which the ingress proxy listens and applies the rule.
+  int32 port = 2;
+
+  // Optional TLS secret path to apply server-side TLS context on the port.
+  string tls_secret = 3;
+
+  // RECOMMENDED. Precedence is used to disambiguate the order of application
+  // of rules. A higher number takes priority. If not specified, the value is
+  // assumed to be 0.  The order of application for rules with the same
+  // precedence is unspecified.
+  int32 precedence = 4;
+
+  // Match condtions to be satisfied for the ingress rule to be
+  // activated.
+  MatchCondition match = 5;
+
+  // REQUIRED: Destination uniquely identifies the destination service. Value
+  // must be in fully qualified domain name format (e.g.,
+  // "my-service.default.svc.cluster.local").
+  string destination = 6;
+
+  // REQUIRED: Destination port identifies a port on the destination service for routing.
+  oneof destination_service_port {
+    // Identifies the destination service port by value
+    int32 destination_port = 7;
+
+    // Identifies the destination service port by name
+    string destination_port_name = 8;
+  }
+}
+

--- a/proxy/v1/config/ingress_rule.proto
+++ b/proxy/v1/config/ingress_rule.proto
@@ -18,16 +18,18 @@ import "proxy/v1/config/route_rule.proto";
 
 package istio.proxy.v1.config;
 
-// Ingress rules are routing rules applied to the mediating middle proxy. This
-// proxy serves as an ingress proxy for the entire mesh, but can also be
-// addressed from inside the mesh.  Each ingress rule defines a destination
-// service and port. Rules that do not resolve to a service or a port in the
-// mesh should be ignored.
+// Ingress rules are routing rules applied to the ingress proxy pool. The
+// ingress proxes serve as the receiving edge proxy for the entire mesh, but
+// can also be addressed from inside the mesh.  Each ingress rule defines a
+// destination service and port. Rules that do not resolve to a service or a
+// port in the mesh should be ignored.
 //
 // The routing rules for the destination service are applied at the ingress
 // proxy. That means the routing rule match conditions are composed and its
 // actions are enforced. The traffic splitting for the destination service is
 // also effective.
+//
+// WARNING: This API is experimental and under active development
 message IngressRule {
   // REQUIRED: Ingress rules have unique names to allow multiple rules, e.g.
   // "my-rule".

--- a/proxy/v1/config/ingress_rule.proto
+++ b/proxy/v1/config/ingress_rule.proto
@@ -22,7 +22,7 @@ package istio.proxy.v1.config;
 // proxy serves as an ingress proxy for the entire mesh, but can also be
 // addressed from inside the mesh.  Each ingress rule defines a destination
 // service and port. Rules that do not resolve to a service or a port in the
-// mesh are ignored.
+// mesh should be ignored.
 //
 // The routing rules for the destination service are applied at the ingress
 // proxy. That means the routing rule match conditions are composed and its
@@ -37,6 +37,7 @@ message IngressRule {
   int32 port = 2;
 
   // Optional TLS secret path to apply server-side TLS context on the port.
+  // It is up to the underlying secret store to interpret the path to the secret.
   string tls_secret = 3;
 
   // RECOMMENDED. Precedence is used to disambiguate the order of application
@@ -45,7 +46,7 @@ message IngressRule {
   // precedence is unspecified.
   int32 precedence = 4;
 
-  // Match condtions to be satisfied for the ingress rule to be
+  // Match conditions to be satisfied for the ingress rule to be
   // activated.
   MatchCondition match = 5;
 


### PR DESCRIPTION
This definition captures the effective use of the route rules in the ingress controller in Pilot. The route rules fields that are missing are simply ignored by the implementation. Hoping to get this merged so we can transition to one-proto-per-type in the config system.