### PR TITLE
Update global_dictionary.yaml with TCP attributes

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -173,3 +173,16 @@
 - x-b3-traceid
 - x-b3-sampled
 - x-b3-spanid
+- tcp
+
+# connection attributes
+- connection.id
+- connection.received.bytes
+- connection.received.bytes_total
+- connection.sent.bytes
+- connection.sent.bytes_total
+- connection.duration
+
+# context attributes
+- context.protocol
+- context.timestamp


### PR DESCRIPTION
To support TCP policy and telemetry, we are adding the following attributes to the global list:

- `connection.id` (unique ID for a connection)
- `connection.received.bytes` (bytes received since last Report())
- `connection.received.bytes_total` (total bytes received during lifetime of connection)
- `connection.sent.bytes` (bytes sent since last Report())
- `connection.sent.bytes_total` (total bytes sent during lifetime of connection)
- `connection.duration` (total duration of the connection)
- `context.protocol` (used to distinguish mode of Check()/Report(), for example: `tcp`, `http`)
- `context.timestamp` (timestamp of Check() or Report())