### PR TITLE
Rename fields (tags->labels, source->src, destination|target->dst)

### DIFF
--- a/mixer/v1/config/cfg.proto
+++ b/mixer/v1/config/cfg.proto
@@ -34,7 +34,7 @@ package istio.mixer.v1.config;
 // subject: "namespace:ns1"
 // revision: "1011"
 // rules:
-// - selector: target.service == "*"
+// - selector: dst.service == "*"
 //   aspects:
 //   - kind: metrics
 //     params:
@@ -45,7 +45,7 @@ package istio.mixer.v1.config;
 //           statusCode: response.code
 //
 // actionRules:
-// - selector: target.service == "*"
+// - selector: dst.service == "*"
 //   actions:
 //   - handler: prometheus-handler
 //     instances:
@@ -62,8 +62,8 @@ package istio.mixer.v1.config;
 //   params:
 //     value: 1
 //     dimensions:
-//       source: origin.service
-//       target_ip: destination.ip
+//       src: origin.service
+//       dst_ip: destination.ip
 // ```
 //
 // (== deprecation_description ServiceConfig is deprecated, see the Config API's
@@ -100,7 +100,7 @@ message AspectRule {
   //
   // * an empty selector evaluates to `true`
   // * `true`, a boolean literal; a rule with this selector will always be executed
-  // * `target.service == ratings*` selects any request targeting a service whose
+  // * `dst.service == ratings*` selects any request targeting a service whose
   // name starts with "ratings"
   // * `attr1 == "20" && attr2 == "30"` logical AND, OR, and NOT are also available
   string selector = 1;
@@ -117,8 +117,8 @@ message AspectRule {
 // aspect: each kind of aspect defines its own `params` proto.
 //
 // The following example instructs Mixer to populate a metric named "response_time"
-// that was declared to have three labels: src_consumer_id, target_response_status_code,
-// and target_service_name. For each label and the metric's `value` we provide
+// that was declared to have three labels: src_consumer_id, dst_response_status_code,
+// and dst_service_name. For each label and the metric's `value` we provide
 // an expression over Istio's attributes. Mixer evaluates these expressions for
 // each request.
 //
@@ -129,9 +129,9 @@ message AspectRule {
 //   - descriptorName: response_time # tie this metric to a descriptor of the same name
 //     value: response.time  # from the set of canonical attributes
 //     labels:
-//       src_consumer_id: source.user | source.uid
-//       target_response_status_code: response.code
-//       target_service_name: target.service
+//       src_consumer_id: src.user | src.uid
+//       dst_response_status_code: response.code
+//       dst_service_name: dst.service
 // ```
 message Aspect {
   // Required. The kind of aspect this intent is targeting.
@@ -305,7 +305,7 @@ message EmailAddress {
 //
 // ```yaml
 // actionRules:
-// - selector: target.service == "*"
+// - selector: dst.service == "*"
 //   actions:
 //   - handler: prometheus-handler
 //     instances:
@@ -320,7 +320,7 @@ message Rule {
   //
   // * an empty selector evaluates to `true`
   // * `true`, a boolean literal; a rule with this selector will always be executed
-  // * `target.service == ratings*` selects any request targeting a service whose
+  // * `dst.service == ratings*` selects any request targeting a service whose
   // name starts with "ratings"
   // * `attr1 == "20" && attr2 == "30"` logical AND, OR, and NOT are also available
   string selector = 1;
@@ -371,8 +371,8 @@ message Action {
 //   params:
 //     value: 1
 //     dimensions:
-//       source: origin.service
-//       target_ip: destination.ip
+//       src: origin.service
+//       dst_ip: destination.ip
 // ```
 message Instance {
   // Required. The name of this instance

--- a/proxy/v1/config/dest_policy.proto
+++ b/proxy/v1/config/dest_policy.proto
@@ -18,37 +18,37 @@ import "google/protobuf/duration.proto";
 
 package istio.proxy.v1.config;
 
-// DestinationPolicy defines client/caller-side policies that determine how
+// DstPolicy defines client/caller-side policies that determine how
 // to handle traffic bound to a particular destination service. The policy
 // specifies configuration for load balancing and circuit breakers.  For
 // example, a simple load balancing policy for the reviews service would
 // look as follows:
 //
-//     destination: reviews.default.svc.cluster.local
+//     dst: reviews.default.svc.cluster.local
 //     policy:
 //     - loadBalancing: 
 //         name: RANDOM
 //
 // Policies are applicable per individual service versions. ONLY
 // ONE policy can be defined per service version. Policy CANNOT be empty.
-message DestinationPolicy {
+message DstPolicy {
   // REQUIRED. Service name for which the service version is defined. The
   // value MUST BE a fully-qualified domain name,
   // e.g. _my-service.default.svc.cluster.local_.
-  string destination = 1;
+  string dst = 1;
 
   // REQUIRED. List of policies, one per service version.
-  repeated DestinationVersionPolicy policy = 2;
+  repeated DstVersionPolicy policy = 2;
 }
 
 // A destination policy can be restricted to a particular version of a
 // service or applied to all versions. The labels field in the
-// DestinationVersionPolicy allow restricting the scope of a
-// DestinationPolicy. For example, the following load balancing policy
+// DstVersionPolicy allow restricting the scope of a
+// DstPolicy. For example, the following load balancing policy
 // applies to version v1 of the reviews service running in the prod
 // environment:
 //
-//     destination: reviews.default.svc.cluster.local
+//     dst: reviews.default.svc.cluster.local
 //     policy:
 //     - labels:
 //         env: prod
@@ -62,7 +62,7 @@ message DestinationPolicy {
 // labelged instances are explicity routed to. In other words, for every
 // destination policy defined, atleast one route rule must refer to the
 // service version indicated in the destination policy.
-message DestinationVersionPolicy {
+message DstVersionPolicy {
   // Optional set of labels that identify a particular version of the
   // destination service. If omitted, the policy will apply to all versions
   // of the service. (-- N.B. The map is used instead of
@@ -85,7 +85,7 @@ message DestinationVersionPolicy {
 // types](https://lyft.github.io/envoy/docs/intro/arch_overview/load_balancing.html)
 // supported by Envoy. Example,
 //
-//     destination: reviews.default.svc.cluster.local
+//     dst: reviews.default.svc.cluster.local
 //     policy:
 //     - loadBalancing: 
 //         name: RANDOM
@@ -130,7 +130,7 @@ message CircuitBreaker {
   // policy sets a limit of 100 connections to "reviews" service version
   // "v1" backends. 
   //
-  //     destination: reviews.default.svc.cluster.local
+  //     dst: reviews.default.svc.cluster.local
   //     policy:
   //     - labels:
   //         version: v1
@@ -144,7 +144,7 @@ message CircuitBreaker {
   // hosts to be scanned every 5 mins, such that any host that fails 7
   // consecutive times with 5XX error code will be ejected for 15 minutes.
   //
-  //     destination: reviews.default.svc.cluster.local
+  //     dst: reviews.default.svc.cluster.local
   //     policy:
   //     - labels:
   //         version: v1

--- a/proxy/v1/config/dest_policy.proto
+++ b/proxy/v1/config/dest_policy.proto
@@ -42,7 +42,7 @@ message DestinationPolicy {
 }
 
 // A destination policy can be restricted to a particular version of a
-// service or applied to all versions. The tags field in the
+// service or applied to all versions. The labels field in the
 // DestinationVersionPolicy allow restricting the scope of a
 // DestinationPolicy. For example, the following load balancing policy
 // applies to version v1 of the reviews service running in the prod
@@ -50,25 +50,25 @@ message DestinationPolicy {
 //
 //     destination: reviews.default.svc.cluster.local
 //     policy:
-//     - tags:
+//     - labels:
 //         env: prod
 //         version: v1
 //       loadBalancing: 
 //         name: RANDOM
 //
-// If tags are omitted, the policy applies for all versions of the
+// If labels are omitted, the policy applies for all versions of the
 // service. Policy CANNOT BE empty.
 // *Note:* Destination policies will be applied only if the corresponding
-// tagged instances are explicity routed to. In other words, for every
+// labelged instances are explicity routed to. In other words, for every
 // destination policy defined, atleast one route rule must refer to the
 // service version indicated in the destination policy.
 message DestinationVersionPolicy {
-  // Optional set of tags that identify a particular version of the
+  // Optional set of labels that identify a particular version of the
   // destination service. If omitted, the policy will apply to all versions
   // of the service. (-- N.B. The map is used instead of
   // pstruct due to lack of serialization support in golang protobuf
   // library (see https://github.com/golang/protobuf/pull/208) --)
-  map<string, string> tags = 1;
+  map<string, string> labels = 1;
 
   // Load balancing policy.
   LoadBalancing load_balancing = 2;
@@ -132,7 +132,7 @@ message CircuitBreaker {
   //
   //     destination: reviews.default.svc.cluster.local
   //     policy:
-  //     - tags:
+  //     - labels:
   //         version: v1
   //       circuitBreaker:
   //         simpleCb:
@@ -146,7 +146,7 @@ message CircuitBreaker {
   //
   //     destination: reviews.default.svc.cluster.local
   //     policy:
-  //     - tags:
+  //     - labels:
   //         version: v1
   //       circuitBreaker:
   //         simpleCb:

--- a/proxy/v1/config/http_fault.proto
+++ b/proxy/v1/config/http_fault.proto
@@ -44,7 +44,7 @@ message HTTPFaultInjection {
   //
   //     destination: reviews.default.svc.cluster.local
   //     route:
-  //     - tags:
+  //     - labels:
   //         version: v1
   //     httpFault:
   //       delay:
@@ -77,7 +77,7 @@ message HTTPFaultInjection {
   //
   //     destination: ratings.default.svc.cluster.local
   //     route:
-  //     - tags:
+  //     - labels:
   //         version: v1
   //     httpFault:
   //       abort:

--- a/proxy/v1/config/http_fault.proto
+++ b/proxy/v1/config/http_fault.proto
@@ -42,7 +42,7 @@ message HTTPFaultInjection {
   // in 10% of the requests to the "v1" version of the "reviews"
   // service.
   //
-  //     destination: reviews.default.svc.cluster.local
+  //     dst: reviews.default.svc.cluster.local
   //     route:
   //     - labels:
   //         version: v1
@@ -75,7 +75,7 @@ message HTTPFaultInjection {
   // pre-specified error code. The following example will return an HTTP
   // 400 error code for 10% of the requests to the "ratings" service "v1".
   //
-  //     destination: ratings.default.svc.cluster.local
+  //     dst: ratings.default.svc.cluster.local
   //     route:
   //     - labels:
   //         version: v1

--- a/proxy/v1/config/ingress_rule.proto
+++ b/proxy/v1/config/ingress_rule.proto
@@ -55,15 +55,15 @@ message IngressRule {
   // REQUIRED: Destination uniquely identifies the destination service. Value
   // must be in fully qualified domain name format (e.g.,
   // "my-service.default.svc.cluster.local").
-  string destination = 6;
+  string dst = 6;
 
   // REQUIRED: Destination port identifies a port on the destination service for routing.
-  oneof destination_service_port {
+  oneof dst_service_port {
     // Identifies the destination service port by value
-    int32 destination_port = 7;
+    int32 dst_port = 7;
 
     // Identifies the destination service port by name
-    string destination_port_name = 8;
+    string dst_port_name = 8;
   }
 }
 

--- a/proxy/v1/config/route_rule.proto
+++ b/proxy/v1/config/route_rule.proto
@@ -65,7 +65,7 @@ package istio.proxy.v1.config;
 // For example, a simple rule to send 100% of incoming traffic for a
 // "reviews" service to version "v1" can be specified as follows:
 //
-//     destination: reviews.default.svc.cluster.local
+//     dst: reviews.default.svc.cluster.local
 //     name: my-rule
 //     route:
 //     - labels:
@@ -82,7 +82,7 @@ message RouteRule {
   // resolution for HTTP traffic as well as IP-based resolution for
   // TCP/UDP traffic. The value MUST BE a fully-qualified domain name,
   // e.g. "my-service.default.svc.cluster.local".
-  string destination = 1;
+  string dst = 1;
 
   // RECOMMENDED. Precedence is used to disambiguate the order of
   // application of rules for the same destination service. A higher number
@@ -101,7 +101,7 @@ message RouteRule {
   // of a service (see glossary in beginning of document). Weights
   // associated with the service version determine the proportion of
   // traffic it receives.
-  repeated DestinationWeight route = 4;
+  repeated DstWeight route = 4;
 
   // REQUIRED (route|redirect). A routing rule can either redirect traffic or
   // forward traffic. The redirect primitive can be used to send a HTTP 302
@@ -134,11 +134,11 @@ message RouteRule {
 // service where the URL path starts with /ratings/v2/ and the request
 // contains a "cookie" with value "user=jason",
 //
-//     destination: ratings.default.svc.cluster.local
+//     dst: ratings.default.svc.cluster.local
 //     name: my-rule
 //     match:
-//       source: reviews.default.svc.cluster.local
-//       sourceLabels:
+//       src: reviews.default.svc.cluster.local
+//       srcLabels:
 //         version: v2
 //       httpHeaders:
 //         cookie:
@@ -146,17 +146,17 @@ message RouteRule {
 //         uri:
 //           prefix: "/ratings/v2/"
 //
-// MatchCondition CANNOT BE empty. Atleast one of source, source_labels or
+// MatchCondition CANNOT BE empty. Atleast one of source, src_labels or
 // http_headers must be specified.
 message MatchCondition {
   // Identifies the service initiating a connection or a request by its
   // name. If specified, name MUST BE a fully qualified domain name such
   // as foo.bar.com
-  string source = 1;
+  string src = 1;
 
   // One or more labels that uniquely identify the source service version. In
   // Kubernetes, labels correspond to the labels associated with pods.
-  map<string, string> source_labels = 2;
+  map<string, string> src_labels = 2;
 
   // (-- Set of layer 4 match conditions based on the IP ranges --)
   L4MatchAttributes tcp = 3 ;
@@ -186,7 +186,7 @@ message MatchCondition {
 // instances with the "v2" label and the remaining traffic (i.e., 75%) to
 // "v1".
 //
-//     destination: reviews.default.svc.cluster.local
+//     dst: reviews.default.svc.cluster.local
 //     name: my-rule
 //     route:
 //     - labels:
@@ -196,12 +196,12 @@ message MatchCondition {
 //         version: v1
 //       weight: 75
 //
-message DestinationWeight {
+message DstWeight {
   // Destination uniquely identifies the destination service. If not
   // specified, the value is inherited from the parent route rule. Value
   // must be in fully qualified domain name format (e.g.,
   // "my-service.default.svc.cluster.local").
-  string destination = 1;
+  string dst = 1;
 
   // Service version identifier for the destination service.
   // (-- N.B. The map is used instead of pstruct due to lack of serialization support
@@ -220,12 +220,12 @@ message DestinationWeight {
 message L4MatchAttributes {
   // IPv4 or IPv6 ip address with optional subnet. E.g., a.b.c.d/xx form or
   // just a.b.c.d
-  repeated string source_subnet = 1;
+  repeated string src_subnet = 1;
 
   // IPv4 or IPv6 ip address of destination with optional subnet.
   // E.g., a.b.c.d/xx form or just a.b.c.d. This is only valid when the destination
   // service has several IPs and the application explicitly specifies a particular IP.
-  repeated string destination_subnet = 2;
+  repeated string dst_subnet = 2;
 }
 
 // HTTPRedirect can be used to send a 302 redirect response to the caller,
@@ -234,7 +234,7 @@ message L4MatchAttributes {
 // requests for /v1/getProductRatings API on the ratings service to
 // /v1/bookRatings provided by the bookratings service.
 //
-//     destination: ratings.default.svc.cluster.local
+//     dst: ratings.default.svc.cluster.local
 //     name: my-rule
 //     match:
 //       httpHeaders:
@@ -257,11 +257,11 @@ message HTTPRedirect {
  
 // HTTPRewrite can be used to rewrite specific parts of a HTTP request
 // before forwarding the request to the destination. Rewrite primitive can
-// be used only with the DestinationWeights. The following example
+// be used only with the DstWeights. The following example
 // demonstrates how to rewrite the URL prefix for api call (/ratings) to
 // ratings service before making the actual API call.
 //
-//     destination: ratings.default.svc.cluster.local
+//     dst: ratings.default.svc.cluster.local
 //     name: my-rule
 //     match:
 //       httpHeaders:
@@ -298,7 +298,7 @@ message StringMatch {
 // Describes HTTP request timeout. For example, the following rule sets a
 // 10 second timeout for calls to the ratings:v1 service
 //
-//     destination: ratings.default.svc.cluster.local
+//     dst: ratings.default.svc.cluster.local
 //     name: my-rule
 //     route:
 //     - labels:
@@ -329,7 +329,7 @@ message HTTPTimeout {
 // example, the following rule sets the maximum number of retries to 3 when
 // calling ratings:v1 service, with a 2s timeout per retry attempt.
 //
-//     destination: ratings.default.svc.cluster.local
+//     dst: ratings.default.svc.cluster.local
 //     name: my-rule
 //     route:
 //     - labels:

--- a/proxy/v1/config/route_rule.proto
+++ b/proxy/v1/config/route_rule.proto
@@ -68,7 +68,7 @@ package istio.proxy.v1.config;
 //     destination: reviews.default.svc.cluster.local
 //     name: my-rule
 //     route:
-//     - tags:
+//     - labels:
 //         version: v1
 //       weight: 100
 //
@@ -138,7 +138,7 @@ message RouteRule {
 //     name: my-rule
 //     match:
 //       source: reviews.default.svc.cluster.local
-//       sourceTags:
+//       sourceLabels:
 //         version: v2
 //       httpHeaders:
 //         cookie:
@@ -146,7 +146,7 @@ message RouteRule {
 //         uri:
 //           prefix: "/ratings/v2/"
 //
-// MatchCondition CANNOT BE empty. Atleast one of source, source_tags or
+// MatchCondition CANNOT BE empty. Atleast one of source, source_labels or
 // http_headers must be specified.
 message MatchCondition {
   // Identifies the service initiating a connection or a request by its
@@ -154,9 +154,9 @@ message MatchCondition {
   // as foo.bar.com
   string source = 1;
 
-  // One or more tags that uniquely identify the source service version. In
-  // Kubernetes, tags correspond to the labels associated with pods.
-  map<string, string> source_tags = 2;
+  // One or more labels that uniquely identify the source service version. In
+  // Kubernetes, labels correspond to the labels associated with pods.
+  map<string, string> source_labels = 2;
 
   // (-- Set of layer 4 match conditions based on the IP ranges --)
   L4MatchAttributes tcp = 3 ;
@@ -183,16 +183,16 @@ message MatchCondition {
 // glossary in beginning of document). Weights associated with the version
 // determine the proportion of traffic it receives. For example, the
 // following rule will route 25% of traffic for the "reviews" service to
-// instances with the "v2" tag and the remaining traffic (i.e., 75%) to
+// instances with the "v2" label and the remaining traffic (i.e., 75%) to
 // "v1".
 //
 //     destination: reviews.default.svc.cluster.local
 //     name: my-rule
 //     route:
-//     - tags:
+//     - labels:
 //         version: v2
 //       weight: 25
-//     - tags:
+//     - labels:
 //         version: v1
 //       weight: 75
 //
@@ -206,7 +206,7 @@ message DestinationWeight {
   // Service version identifier for the destination service.
   // (-- N.B. The map is used instead of pstruct due to lack of serialization support
   // in golang protobuf library (see https://github.com/golang/protobuf/pull/208) --)
-  map<string, string> tags = 2;
+  map<string, string> labels = 2;
 
   // REQUIRED. The proportion of traffic to be forwarded to the service
   // version. (0-100). Sum of weights across destinations SHOULD BE ==
@@ -270,7 +270,7 @@ message HTTPRedirect {
 //     rewrite:
 //       uri: /v1/bookRatings
 //     route:
-//     - tags:
+//     - labels:
 //         version: v1
 //
 message HTTPRewrite {
@@ -301,7 +301,7 @@ message StringMatch {
 //     destination: ratings.default.svc.cluster.local
 //     name: my-rule
 //     route:
-//     - tags:
+//     - labels:
 //         version: v1
 //     httpReqTimeout:
 //       simpleTimeout:
@@ -332,7 +332,7 @@ message HTTPTimeout {
 //     destination: ratings.default.svc.cluster.local
 //     name: my-rule
 //     route:
-//     - tags:
+//     - labels:
 //         version: v1
 //     httpReqRetries:
 //       simpleRetry:


### PR DESCRIPTION
Renaming all fields and references to fields in the doc comments.
Order of update in dependent repos could be (to maintain e2e green build)
1. Proxy adds src and dst fields in addition to source/target (as it doesn't depend on this repo)
2. Pilot adds src and dst fields to mixer config in addition to existing source/target (without updating proto)
3. Mixer switches to src/dst while updating the SHA for istio/api (also update istio/istio and e2e test)
4. Pilot removes source/target from mixer config, switches to new proto (also update istio/istio, e2e test)
5. Proxy removes source/target from the attributes it sends
6. Update docs in istio.github.io
