### PR TITLE
add context.time

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -186,3 +186,4 @@
 # context attributes
 - context.protocol
 - context.timestamp
+- context.time


### PR DESCRIPTION
To be consistent with request.time and response.time.  It should be context.time not context.timestamp.