### PR TITLE
Add common integer strings.

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -187,3 +187,21 @@
 - context.protocol
 - context.timestamp
 - context.time
+
+# common integer strings
+- 0
+- 1
+- 200
+- 302
+- 400
+- 401
+- 403
+- 404
+- 409
+- 429
+- 499
+- 500
+- 501
+- 502
+- 503
+- 504


### PR DESCRIPTION
Integer strings, such as 200, 0, and 1, were added with single quote, such as '200', '1' and '0'.  These have to be added without single quote.

Also add some popular http response codes