### PR TITLE
Egress rule updated after design review

### DIFF
--- a/proxy/v1/config/egress_rule.proto
+++ b/proxy/v1/config/egress_rule.proto
@@ -17,10 +17,7 @@ syntax = "proto3";
 package istio.proxy.v1.config;
 
 // Egress rules specify which domains outside of the mesh are allowed to be accessed by
-// the microservices of the mesh. Currently, only two protocols are supported:
-// HTTP and HTTPS. For HTTPS, the applications in the mesh will send HTTP requests to the
-// appropriate port, e.g. GET http:/gmail.com:443. The Egress or the sidecar proxy will 
-// perform TLS origination.
+// the microservices of the mesh. Currently, only HTTP is supported.
 //
 // An example rule - allow traffic to *cnn.com and *cnn.it domains that are not part of the mesh.
 //
@@ -33,8 +30,6 @@ package istio.proxy.v1.config;
 //   ports:
 //     - port: 80
 //       protocol: http
-//     - port: 443
-//       protocol: https
 //   use_egress_proxy: true
 //
 message EgressRule {
@@ -45,7 +40,7 @@ message EgressRule {
         // The number of the port on which the external services are available.
 	int32 port = 1;
 	// The protocol to communicate with the external services.
-	// Currently supported HTTP and HTTPS
+	// Currently only HTTP is supported.
 	string protocol = 2;
   }
 

--- a/proxy/v1/config/egress_rule.proto
+++ b/proxy/v1/config/egress_rule.proto
@@ -27,6 +27,8 @@ package istio.proxy.v1.config;
 //   ports:
 //     - port: 80
 //       protocol: http
+//     - port: 8080
+//       protocol: http
 //   use_egress_proxy: true
 //
 message EgressRule {

--- a/proxy/v1/config/egress_rule.proto
+++ b/proxy/v1/config/egress_rule.proto
@@ -19,14 +19,11 @@ package istio.proxy.v1.config;
 // Egress rules specify which domains outside of the mesh are allowed to be accessed by
 // the microservices of the mesh. Currently, only HTTP is supported.
 //
-// An example rule - allow traffic to *cnn.com and *cnn.it domains that are not part of the mesh.
+// An example rule - allow traffic to *cnn.com hosts that are not part of the mesh.
 //
 // type: egress-rule
 // spec:
-//   name: cnn
-//   domains:
-//     - "*cnn.com"
-//     - "*cnn.it"
+//   domain: "*cnn.com"
 //   ports:
 //     - port: 80
 //       protocol: http
@@ -44,23 +41,22 @@ message EgressRule {
 	string protocol = 2;
   }
 
-  // REQUIRED: Egress rules have unique names, e.g. "my-egress-rule".
-  string name = 1;
-
-  // REQUIRED: list of domains to redirect outside of the mesh.
-  // The domains are according to the definion of Envoy's domain of virtual hosts:
+  // REQUIRED: the domain (with or without a wildcard) to redirect outside of the mesh.
+  // The domain is according to the definion of Envoy's domain of virtual hosts:
   // Wildcard hosts are supported in the form of “*.foo.com” or “*-bar.foo.com”.
   // Note that the wildcard will not match the empty string. e.g. “*-bar.foo.com” will match “baz-bar.foo.com” 
   // but not “-bar.foo.com”.  Additionally, a special entry “*” is allowed which will match any host/authority header.
-  repeated string domains = 2;
+  // The exact domain string (with or without a wildcard) must be unique among all the egress rules.
+  // bar.foo.com and *.foo.com are considered different domains. The most specific domain will win when applying a rule.
+  string domain = 1;
 
   // REQUIRED: list of ports on which the external services are available.
-  repeated Port ports = 3;
+  repeated Port ports = 2;
 
   // Forward all the external traffic through a dedicated egress proxy. It is used in some scenarios
   // where there is a requirement that all the external traffic goes through special dedicated nodes/pods.
   // These dedicated egress nodes could then be more closely monitored for security vulnerabilities.
   //
   // The default is false, i.e. the sidecar forwards external traffic directly to the external service.
-  bool use_egress_proxy = 4;
+  bool use_egress_proxy = 3;
 }


### PR DESCRIPTION
1. Remove HTTPS for now. Let HTTPS be handled by iptables.
2. Change `domains` to `domain` and remove `name`. `domain` will be the key of the rule, ensuring there will be no overlapping of domains between the rules, according to Envoy's semantics.

Issue https://github.com/istio/istio/issues/552.
Pilot model, including validation is here - https://github.com/vadimeisenbergibm/pilot/tree/egress_rule, to be merged after this merge.