### PR TITLE
Use one domain per egress rule

### DIFF
--- a/proxy/v1/config/egress_rule.proto
+++ b/proxy/v1/config/egress_rule.proto
@@ -14,6 +14,8 @@
 
 syntax = "proto3";
 
+import "proxy/v1/config/route_rule.proto";
+
 package istio.proxy.v1.config;
 
 // Egress rules describe the properties of a service outside Istio. When transparent proxying
@@ -32,7 +34,8 @@ package istio.proxy.v1.config;
 //     metadata:
 //       name: foo-egress-rule
 //     spec:
-//       destination: *.foo.com
+//       destination:
+//         service: *.foo.com
 //       ports:
 //         - port: 80
 //           protocol: http
@@ -50,11 +53,14 @@ message EgressRule {
   }
 
   // REQUIRED: Hostname or a wildcard domain name associated with the external service.
-  // Wildcard domain specifications must conform to format allowed by Envoy's Virtual Host
-  // specification, such as “*.foo.com” or “*-bar.foo.com”. The character '*' indicates a
-  // non-empty string. So, a wildcard domain of form “*-bar.foo.com” will match “baz-bar.foo.com”
-  // but not “-bar.foo.com”.
-  string destination = 2;
+  // ONLY the "service" field of destination will be taken into consideration. Name,
+  // namespace and domain are ignored. Routing rules and destination policies that
+  // refer to these external services must have identical specification for the destination
+  // as the corresponding egress rule. Wildcard domain specifications must conform to format
+  // allowed by Envoy's Virtual Host specification, such as “*.foo.com” or “*-bar.foo.com”.
+  // The character '*' in a domain specification indicates a non-empty string. Hence, a wildcard
+  // domain of form “*-bar.foo.com” will match “baz-bar.foo.com” but not “-bar.foo.com”.
+  IstioService destination = 2;
 
   // REQUIRED: list of ports on which the external service is available.
   repeated Port ports = 3;

--- a/proxy/v1/config/egress_rule.proto
+++ b/proxy/v1/config/egress_rule.proto
@@ -14,53 +14,56 @@
 
 syntax = "proto3";
 
+import "proxy/v1/config/route_rule.proto";
+
 package istio.proxy.v1.config;
 
-// Egress rules specify which domains outside of the mesh are allowed to be accessed by
-// the microservices of the mesh. Currently, only two protocols are supported:
-// HTTP and HTTPS. For HTTPS, the applications in the mesh will send HTTP requests to the
-// appropriate port, e.g. GET http:/gmail.com:443. The Egress or the sidecar proxy will 
-// perform TLS origination.
+// Egress rules describe the properties of a service outside Istio. When transparent proxying
+// is used, egress rules signify a white listed set of domains that microserves in the mesh
+// are allowed to access. A subset of routing rules and all destination policies can be applied
+// on the service targeted by an egress rule. The destination of an egress rule is allowed to
+// contain wildcards (e.g., *.foo.com). Currently, only HTTP-based services can be expressed
+// through the egress rule. If TLS origination from the sidecar is desired, the protocol
+// associated with the service port must be marked as HTTPS, and the service is expected to
+// be accessed over HTTP (e.g., http://gmail.com:443). The sidecar will automatically upgrade
+// the connection to TLS when initiating a connection with the external service.
 //
-// An example rule - allow traffic to *cnn.com and *cnn.it domains that are not part of the mesh.
+// For example, the following egress rule describes set of services hosted in the *.foo.com domain
 //
 //     kind: EgressRule
 //     metadata:
-//       name: cnn-egress-rule
+//       name: foo-egress-rule
 //     spec:
-//       domains:
-//         - "*cnn.com"
-//         - "*cnn.it"
+//       destination:
+//         name: "*.foo.com"
 //       ports:
 //         - port: 80
 //           protocol: http
 //         - port: 443
 //           protocol: https
-//       use_egress_proxy: true
 //
 message EgressRule {
-  // This message defines a port on which the external services are available.
-  // It is comprised of a port number and a protocol to communicate with the
-  // external services through that port number.
+  // Port describes the properties of a specific TCP port of an external service.
   message Port {
-        // The number of the port on which the external services are available.
+    // A valid non-negative integer port number.
 	int32 port = 1;
 	// The protocol to communicate with the external services.
-	// Currently supported HTTP and HTTPS
+	// MUST BE one of HTTP|HTTPS|GRPC|HTTP2.
 	string protocol = 2;
   }
 
-  // REQUIRED: list of domains to redirect outside of the mesh.
-  // The domains are according to the definion of Envoy's domain of virtual hosts:
-  // Wildcard hosts are supported in the form of “*.foo.com” or “*-bar.foo.com”.
-  // Note that the wildcard will not match the empty string. e.g. “*-bar.foo.com” will match “baz-bar.foo.com” 
-  // but not “-bar.foo.com”.  Additionally, a special entry “*” is allowed which will match any host/authority header.
-  repeated string domains = 2;
+  // REQUIRED: Hostname or a wildcard domain name associated with the external service.
+  // ONLY the name field is taken into consideration. Namespace and domain fields are ignored.
+  // Wildcard domain specifications must conform to format allowed by Envoy's Virtual Host specification,
+  // such as “*.foo.com” or “*-bar.foo.com”. The character '*' indicates a non-empty string.
+  // So, a wildcard domain of form “*-bar.foo.com” will match “baz-bar.foo.com” 
+  // but not “-bar.foo.com”.
+  IstioService destination = 2;
 
-  // REQUIRED: list of ports on which the external services are available.
+  // REQUIRED: list of ports on which the external service is available.
   repeated Port ports = 3;
 
-  // Forward all the external traffic through a dedicated egress proxy. It is used in some scenarios
+  // DEPRECATED. Forward all the external traffic through a dedicated egress proxy. It is used in some scenarios
   // where there is a requirement that all the external traffic goes through special dedicated nodes/pods.
   // These dedicated egress nodes could then be more closely monitored for security vulnerabilities.
   //

--- a/proxy/v1/config/egress_rule.proto
+++ b/proxy/v1/config/egress_rule.proto
@@ -14,8 +14,6 @@
 
 syntax = "proto3";
 
-import "proxy/v1/config/route_rule.proto";
-
 package istio.proxy.v1.config;
 
 // Egress rules describe the properties of a service outside Istio. When transparent proxying
@@ -53,12 +51,11 @@ message EgressRule {
   }
 
   // REQUIRED: Hostname or a wildcard domain name associated with the external service.
-  // ONLY the name field is taken into consideration. Namespace and domain fields are ignored.
-  // Wildcard domain specifications must conform to format allowed by Envoy's Virtual Host specification,
-  // such as “*.foo.com” or “*-bar.foo.com”. The character '*' indicates a non-empty string.
-  // So, a wildcard domain of form “*-bar.foo.com” will match “baz-bar.foo.com” 
+  // Wildcard domain specifications must conform to format allowed by Envoy's Virtual Host
+  // specification, such as “*.foo.com” or “*-bar.foo.com”. The character '*' indicates a
+  // non-empty string. So, a wildcard domain of form “*-bar.foo.com” will match “baz-bar.foo.com”
   // but not “-bar.foo.com”.
-  IstioService destination = 2;
+  string destination = 2;
 
   // REQUIRED: list of ports on which the external service is available.
   repeated Port ports = 3;

--- a/proxy/v1/config/egress_rule.proto
+++ b/proxy/v1/config/egress_rule.proto
@@ -54,7 +54,7 @@ message EgressRule {
 
   // REQUIRED: Hostname or a wildcard domain name associated with the external service.
   // ONLY the "service" field of destination will be taken into consideration. Name,
-  // namespace and domain are ignored. Routing rules and destination policies that
+  // namespace, domain and labels are ignored. Routing rules and destination policies that
   // refer to these external services must have identical specification for the destination
   // as the corresponding egress rule. Wildcard domain specifications must conform to format
   // allowed by Envoy's Virtual Host specification, such as “*.foo.com” or “*-bar.foo.com”.

--- a/proxy/v1/config/egress_rule.proto
+++ b/proxy/v1/config/egress_rule.proto
@@ -32,8 +32,7 @@ package istio.proxy.v1.config;
 //     metadata:
 //       name: foo-egress-rule
 //     spec:
-//       destination:
-//         name: "*.foo.com"
+//       destination: *.foo.com
 //       ports:
 //         - port: 80
 //           protocol: http

--- a/proxy/v1/config/egress_rule.proto
+++ b/proxy/v1/config/egress_rule.proto
@@ -28,7 +28,7 @@ package istio.proxy.v1.config;
 // be accessed over HTTP (e.g., http://gmail.com:443). The sidecar will automatically upgrade
 // the connection to TLS when initiating a connection with the external service.
 //
-// For example, the following egress rule describes set of services hosted in the *.foo.com domain
+// For example, the following egress rule describes the set of services hosted under the *.foo.com domain
 //
 //     kind: EgressRule
 //     metadata:


### PR DESCRIPTION
Convert from multiple domains per egress rule to a single domain per egress rule. Reuse the destination structure defined in route_rule and cleanup the description. 