### PR TITLE
add service-zone flag to proxy config

### DIFF
--- a/proxy/v1/config/proxy_mesh.proto
+++ b/proxy/v1/config/proxy_mesh.proto
@@ -68,6 +68,9 @@ message ProxyConfig {
 
   // Port on which Envoy should listen for administrative commands.
   int32 proxy_admin_port = 11;
+  
+  // The availability zone where this Envoy instance is running
+  string availability_zone = 12;
 }
 
 

--- a/proxy/v1/config/proxy_mesh.proto
+++ b/proxy/v1/config/proxy_mesh.proto
@@ -72,7 +72,7 @@ message ProxyConfig {
   // The availability zone where this Envoy instance is running. When running
   // Envoy as a sidecar in Kubernetes, this flag must be one of the availability
   // zones assigned to a node using failure-domain.beta.kubernetes.io/zone annotation.
-  string service_zone = 12;
+  string availability_zone = 12;
 }
 
 

--- a/proxy/v1/config/proxy_mesh.proto
+++ b/proxy/v1/config/proxy_mesh.proto
@@ -69,7 +69,9 @@ message ProxyConfig {
   // Port on which Envoy should listen for administrative commands.
   int32 proxy_admin_port = 11;
   
-  // The availability zone where this Envoy instance is running
+  // The availability zone where this Envoy instance is running. When running
+  // Envoy as a sidecar in Kubernetes, this flag must be one of the availability
+  // zones assigned to a node using failure-domain.beta.kubernetes.io/zone annotation.
   string service_zone = 12;
 }
 

--- a/proxy/v1/config/proxy_mesh.proto
+++ b/proxy/v1/config/proxy_mesh.proto
@@ -70,7 +70,7 @@ message ProxyConfig {
   int32 proxy_admin_port = 11;
   
   // The availability zone where this Envoy instance is running
-  string availability_zone = 12;
+  string service_zone = 12;
 }
 
 


### PR DESCRIPTION
This flag specifies the availability zone associated with an envoy instance. Part of the solution for https://github.com/istio/pilot/issues/1212