### PR TITLE
Rename bytes_total -> total_bytes

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -181,9 +181,9 @@
 # connection attributes
 - connection.id
 - connection.received.bytes
-- connection.received.bytes_total
+- connection.received.total_bytes
 - connection.sent.bytes
-- connection.sent.bytes_total
+- connection.sent.total_bytes
 - connection.duration
 
 # context attributes


### PR DESCRIPTION
cc: @wora 

Prefer readability of "total bytes" to "bytes total", per api style guide
> Field names should also avoid using postpositive adjectives (modifiers placed after the noun)