### PR TITLE
Use proper destination field type in DestinationWeight

### DIFF
--- a/proxy/v1/config/route_rule.proto
+++ b/proxy/v1/config/route_rule.proto
@@ -251,7 +251,7 @@ message MatchRequest {
 message DestinationWeight {
   // Optional destination uniquely identifies the destination service. If not
   // specified, the value is inherited from the parent route rule.
-  string destination = 1;
+  IstioService destination = 1;
 
   // Service version identifier for the destination service.
   // (-- N.B. The map is used instead of pstruct due to lack of serialization support


### PR DESCRIPTION
From `string destination` to `IstioService destination`