### PR TITLE
lyft->envoyproxy

### DIFF
--- a/proxy/v1/config/dest_policy.proto
+++ b/proxy/v1/config/dest_policy.proto
@@ -85,7 +85,7 @@ message DestinationPolicy {
 
 // Load balancing policy to use when forwarding traffic. These policies
 // directly correlate to [load balancer
-// types](https://lyft.github.io/envoy/docs/intro/arch_overview/load_balancing.html)
+// types](https://envoyproxy.github.io/envoy/intro/arch_overview/load_balancing.html)
 // supported by Envoy. Example,
 //
 //     metadata:
@@ -128,8 +128,8 @@ message LoadBalancing {
 // continually return errors for API calls are ejected from the pool for a
 // pre-defined period of time.
 // See Envoy's
-// [circuit breaker](https://lyft.github.io/envoy/docs/intro/arch_overview/circuit_breaking.html)
-// and [outlier detection](https://lyft.github.io/envoy/docs/intro/arch_overview/outlier.html)
+// [circuit breaker](https://envoyproxy.github.io/envoy/intro/arch_overview/circuit_breaking.html)
+// and [outlier detection](https://envoyproxy.github.io/envoy/intro/arch_overview/outlier.html)
 // for more details.
 message CircuitBreaker {
   // A simple circuit breaker can be set based on a number of criteria such as

--- a/proxy/v1/config/route_rule.proto
+++ b/proxy/v1/config/route_rule.proto
@@ -220,9 +220,8 @@ message MatchRequest {
   // to URI, protocol scheme (e.g., HTTP, HTTPS), HTTP method
   // (e.g., GET, POST), and the HTTP Host header respectively.
   //
-  // *Note 2:* _uri_ can be used to perform URL matches. For URL matches
-  // (_uri_), only prefix and exact matches are
-  // supported. For other HTTP headers, exact, prefix and ECMA style
+  // *Note 2:* _uri_ can be used to perform URL matches. 
+  // For all HTTP headers including _uri_, exact, prefix and ECMA style
   // regular expression matches are supported.
   map<string, StringMatch> headers = 1;
 }


### PR DESCRIPTION
Changing docs URL due to recent migration from lyft.github.io to envoyproxy.github.io