### PR TITLE
Add Template Extension proto inside istio.io/api/mixer/v1/template

### DIFF
--- a/mixer/v1/template/extensions.proto
+++ b/mixer/v1/template/extensions.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package istio.mixer.v1.config.template;
+import "google/protobuf/descriptor.proto";
+
+enum TemplateVariety {
+    TEMPLATE_VARIETY_CHECK = 0;
+    TEMPLATE_VARIETY_REPORT = 1;
+    TEMPLATE_VARIETY_QUOTA = 2;
+}
+
+extend google.protobuf.FileOptions {
+    TemplateVariety template_variety = 72295727;
+}
+
+message Expr {
+    // This will be deleted in the next PR once the initial codegen implementation is fixed to not use it. Curren plan
+    // is to treate field of type ValueType as expressions.
+}

--- a/mixer/v1/template/extensions.proto
+++ b/mixer/v1/template/extensions.proto
@@ -3,17 +3,14 @@ syntax = "proto3";
 package istio.mixer.v1.template;
 import "google/protobuf/descriptor.proto";
 
+// Specifies the varity of the the Template.
 enum TemplateVariety {
     TEMPLATE_VARIETY_CHECK = 0;
     TEMPLATE_VARIETY_REPORT = 1;
     TEMPLATE_VARIETY_QUOTA = 2;
 }
 
+// File option for the TemplateVariety.
 extend google.protobuf.FileOptions {
     TemplateVariety template_variety = 72295727;
-}
-
-message Expr {
-    // This will be deleted in the next PR once the initial codegen implementation is fixed to not use it. Curren plan
-    // is to treate field of type ValueType as expressions.
 }

--- a/mixer/v1/template/extensions.proto
+++ b/mixer/v1/template/extensions.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package istio.mixer.v1.config.template;
+package istio.mixer.v1.template;
 import "google/protobuf/descriptor.proto";
 
 enum TemplateVariety {


### PR DESCRIPTION
In order to support templates to be defined outside Mixer repo, we need to move out the TemplateExtension.proto from https://github.com/istio/mixer/blob/master/pkg/adapter/template/TemplateExtensions.proto into istio.io/api/mixer/v1/template. If the TemplateExtensions.proto is in Mixer repo, it was causing cyclic includes when trying to compile a Template outside Mixer repo that depends on Mixer.

There will be one following PR in the Mixer repo that changes all of the the existing defined templates to use the one from this new location. It will also delete the old TemplateExtensions.proto inside the Mixer repo.