### PR TITLE
Add source.service to global dictionary

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -218,3 +218,4 @@
 - destination.labels
 - destination.user
 
+- source.service


### PR DESCRIPTION
Without this change, we get flooded with
```
0923 02:31:03.459056       1 protoBag.go:68] Attribute 'source.service' not in either global or message dictionaries
``` 
in Mixer logs.