### PR TITLE
Add attribute proto.

### DIFF
--- a/proxy/v1/config/attributes.proto
+++ b/proxy/v1/config/attributes.proto
@@ -1,0 +1,61 @@
+// Copyright 2017 Istio Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+package istio.proxy.v1.config;
+
+// Specifies Istio Mixer attributes for Envoy Mixer filter.
+// Following places will use this messages
+//  * Istio Pilot to set mesh attributes to Proxy.
+//  * Client Proxy to pass attributes to server Proxy.
+//
+
+// Specifies attributes to config Istio Proxy.
+// It represents the same data as ::istio:;mixer::v1::attributes defined in
+// mixer/v1/attributes.proto but in different formats.
+// ::istio:;mixer::v1::attributes was defined for transport optimizated.
+// It uses global dictionary and per-message dictionary to compress the data
+// for data transport.
+// This one is targeted for Proxy configuration, not need to compress data,
+// it should be easy to use.
+message Attributes {
+  // A list of attributes.
+  repeated Attribute attributes = 1;
+}
+
+// Specifies one attribute with name and value.
+message Attribute {
+  // The attribute name.
+  string name = 1;
+
+  oneof value {
+    string string_value = 2;
+    int64 int64_value = 3;
+    double double_value = 4;
+    bool bool_value = 5;
+    bytes bytes_value = 6;
+    google.protobuf.Timestamp timestamp_value = 7;
+    google.protobuf.Duration duration_value = 8;
+    StringMap string_map_value = 9;
+  }
+
+  // Defines a strig map.
+  message StringMap {
+    map<string, string> entries = 1;
+  }
+}

--- a/proxy/v1/config/attributes.proto
+++ b/proxy/v1/config/attributes.proto
@@ -25,14 +25,7 @@ package istio.proxy.v1.config;
 //  * Client Proxy to pass attributes to server Proxy.
 //
 
-// Specifies attributes to config Istio Proxy.
-// It represents the same data as ::istio:;mixer::v1::attributes defined in
-// mixer/v1/attributes.proto but in different formats.
-// ::istio:;mixer::v1::attributes was defined for transport optimizated.
-// It uses global dictionary and per-message dictionary to compress the data
-// for data transport.
-// This one is targeted for Proxy configuration, not need to compress data,
-// it should be easy to use.
+// Defines attributes for use in proxy configuration.
 message Attributes {
   // A list of attributes.
   repeated Attribute attributes = 1;
@@ -43,6 +36,7 @@ message Attribute {
   // The attribute name.
   string name = 1;
 
+  // The attribute value.
   oneof value {
     string string_value = 2;
     int64 int64_value = 3;


### PR DESCRIPTION
This one is for Proxy config.  Pilot will use it to set mesh attributes to Istio Proxy.