### PR TITLE
C++ bazel rules for API

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,8 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-load("@io_bazel_rules_go//go:def.bzl", "gazelle", "go_prefix")
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
 
 go_prefix("istio.io/api")
 
-gazelle(name = "gazelle")

--- a/BUILD
+++ b/BUILD
@@ -5,4 +5,3 @@ licenses(["notice"])
 load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
 
 go_prefix("istio.io/api")
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,13 +13,3 @@ go_repositories()
 load("//:api.bzl", "go_istio_api_dependencies")
 
 go_istio_api_dependencies()
-
-bind(
-    name = "protoc",
-    actual = "@com_github_google_protobuf//:protoc",
-)
-
-bind(
-    name = "protocol_compiler",
-    actual = "@com_github_google_protobuf//:protoc",
-)

--- a/api.bzl
+++ b/api.bzl
@@ -1,16 +1,70 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_repository")
 
+def protobuf_repositories(bind=True):
+    # PROTOBUF_SHA = "52ab3b07ac9a6889ed0ac9bf21afd8dab8ef0014" # Oct 4, 2016 (match pubref dep)
+    PROTOBUF_SHA = "c4083bb3d1231f8a94f2f000434e38528bdff64a" # 
+
+    native.http_archive(
+        name = "com_google_protobuf",
+        strip_prefix = "protobuf-" + PROTOBUF_SHA,
+        urls = ["https://github.com/google/protobuf/archive/" + PROTOBUF_SHA + ".tar.gz"],
+    )
+
+    native.http_archive(
+        name = "com_google_protobuf_cc",
+        strip_prefix = "protobuf-" + PROTOBUF_SHA,
+        urls = ["https://github.com/google/protobuf/archive/" + PROTOBUF_SHA + ".tar.gz"],
+    )
+
+    native.http_archive(
+        name = "com_github_google_protobuf",
+        strip_prefix = "protobuf-" + PROTOBUF_SHA,
+        urls = ["https://github.com/google/protobuf/archive/" + PROTOBUF_SHA + ".tar.gz"],
+    )
+
+    if bind:
+        native.bind(
+            name = "protoc",
+            actual = "@com_google_protobuf//:protoc",
+        )
+
+        native.bind(
+            name = "protocol_compiler",
+            actual = "@com_google_protobuf//:protoc",
+        )
+
+        native.bind(
+            name = "protobuf",
+            actual = "@com_google_protobuf//:protobuf",
+        )
+
+        native.bind(
+            name = "cc_wkt_protos",
+            actual = "@com_google_protobuf//:cc_wkt_protos",
+        )
+
+        native.bind(
+            name = "cc_wkt_protos_genproto",
+            actual = "@com_google_protobuf//:cc_wkt_protos_genproto",
+        )
+
+        native.bind(
+            name = "protobuf_compiler",
+            actual = "@com_google_protobuf//:protoc_lib",
+        )
+
+        native.bind(
+            name = "protobuf_clib",
+            actual = "@com_google_protobuf//:protoc_lib",
+        )
+
 def go_istio_api_dependencies():
+    protobuf_repositories()
+
     native.git_repository(
         name = "org_pubref_rules_protobuf",
         commit = "eafd42ce6471ce3ea265729c85e18e6180dea620",  # Sept 22, 2017 (genfiles path calculation fix)
         remote = "https://github.com/pubref/rules_protobuf",
-    )
-
-    native.git_repository(
-        name = "com_github_google_protobuf",
-        commit = "52ab3b07ac9a6889ed0ac9bf21afd8dab8ef0014",  # Oct 4, 2016 (match pubref dep)
-        remote = "https://github.com/google/protobuf.git",
     )
 
     go_repository(
@@ -113,7 +167,7 @@ cc_proto_library(
         "google/rpc/status.proto",
     ],
     imports = [
-        "../../external/com_github_google_protobuf/src",
+        "../../external/com_google_protobuf/src",
     ],
     verbose = 0,
 )

--- a/api.bzl
+++ b/api.bzl
@@ -1,8 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_repository")
 
 def protobuf_repositories(bind=True):
-    # PROTOBUF_SHA = "52ab3b07ac9a6889ed0ac9bf21afd8dab8ef0014" # Oct 4, 2016 (match pubref dep)
-    PROTOBUF_SHA = "c4083bb3d1231f8a94f2f000434e38528bdff64a" # 
+    PROTOBUF_SHA = "c4083bb3d1231f8a94f2f000434e38528bdff64a" # Oct 10, 2017
 
     native.http_archive(
         name = "com_google_protobuf",
@@ -33,33 +32,8 @@ def protobuf_repositories(bind=True):
             actual = "@com_google_protobuf//:protoc",
         )
 
-        native.bind(
-            name = "protobuf",
-            actual = "@com_google_protobuf//:protobuf",
-        )
-
-        native.bind(
-            name = "cc_wkt_protos",
-            actual = "@com_google_protobuf//:cc_wkt_protos",
-        )
-
-        native.bind(
-            name = "cc_wkt_protos_genproto",
-            actual = "@com_google_protobuf//:cc_wkt_protos_genproto",
-        )
-
-        native.bind(
-            name = "protobuf_compiler",
-            actual = "@com_google_protobuf//:protoc_lib",
-        )
-
-        native.bind(
-            name = "protobuf_clib",
-            actual = "@com_google_protobuf//:protoc_lib",
-        )
-
-def go_istio_api_dependencies():
-    protobuf_repositories()
+def go_istio_api_dependencies(bind=True):
+    protobuf_repositories(bind)
 
     native.git_repository(
         name = "org_pubref_rules_protobuf",

--- a/gogoproto/BUILD
+++ b/gogoproto/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "gogoproto_protos",
+    srcs = [":gogo.proto"],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:descriptor_proto",
+    ],
+)
+
+genrule(
+    name = "status_proto",
+    srcs = ["@com_github_gogo_protobuf//gogoproto:go_default_library_protos"],
+    outs = ["gogo.proto"],
+    cmd = "cat $(location @com_github_gogo_protobuf//gogoproto:go_default_library_protos) > $@",
+)

--- a/google/rpc/BUILD
+++ b/google/rpc/BUILD
@@ -10,16 +10,30 @@ gogoslick_proto_library(
         "google/protobuf/duration.proto": "github.com/gogo/protobuf/types",
     },
     imports = [
-        "external/com_github_google_protobuf/src",
-        "../../external/com_github_google_protobuf/src",
+        "external/com_google_protobuf/src",
+        "../../external/com_google_protobuf/src",
     ],
     inputs = [
-        "@com_github_google_protobuf//:well_known_protos",
+        "@com_google_protobuf//:well_known_protos",
     ],
     deps = [
         "@com_github_gogo_protobuf//types:go_default_library",
     ],
     verbose = 0,
+)
+
+cc_proto_library(
+    name = "cc_protos",
+    deps = [":rpc_protos"],
+)
+
+proto_library(
+    name = "rpc_protos",
+    srcs = [":protos"],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+    ],
 )
 
 filegroup(

--- a/mixer/v1/BUILD
+++ b/mixer/v1/BUILD
@@ -10,14 +10,14 @@ gogoslick_proto_library(
     },
     imports = [
         "external/com_github_gogo_protobuf",
-        "external/com_github_google_protobuf/src",
+        "external/com_google_protobuf/src",
         "external/com_github_googleapis_googleapis",
         "../../external/com_github_gogo_protobuf",
-        "../../external/com_github_google_protobuf/src",
+        "../../external/com_google_protobuf/src",
         "../../external/com_github_googleapis_googleapis",
     ],
     inputs = [
-        "@com_github_google_protobuf//:well_known_protos",
+        "@com_google_protobuf//:well_known_protos",
         "@com_github_googleapis_googleapis//:status_proto",
         "@com_github_gogo_protobuf//gogoproto:go_default_library_protos",
     ],
@@ -31,6 +31,24 @@ gogoslick_proto_library(
         "@com_github_gogo_protobuf//types:go_default_library",
         "//google/rpc:go_default_library",
     ],
+)
+
+cc_proto_library(
+    name = "cc_protos",
+    deps = [":mixer_protos"],
+)
+
+proto_library(
+    name = "mixer_protos",
+    srcs = [":protos"],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "//gogoproto:gogoproto_protos",
+        "//google/rpc:rpc_protos",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/mixer/v1/BUILD
+++ b/mixer/v1/BUILD
@@ -36,6 +36,7 @@ gogoslick_proto_library(
 cc_proto_library(
     name = "cc_protos",
     deps = [":mixer_protos"],
+    visibility = ["//visibility:public"],
 )
 
 proto_library(

--- a/mixer/v1/config/BUILD
+++ b/mixer/v1/config/BUILD
@@ -16,12 +16,12 @@ gogo_proto_compile(
         "mixer/v1/config/descriptor/value_type.proto": "istio.io/api/mixer/v1/config/descriptor",
     },
     imports = [
-        "external/com_github_google_protobuf/src",
-        "../../external/com_github_google_protobuf/src",
+        "external/com_google_protobuf/src",
+        "../../external/com_google_protobuf/src",
     ],
     inputs = [
         "//mixer/v1/config/descriptor:protos",
-        "@com_github_google_protobuf//:well_known_protos",
+        "@com_google_protobuf//:well_known_protos",
     ],
     protos = [
         "cfg.proto",

--- a/mixer/v1/config/descriptor/BUILD
+++ b/mixer/v1/config/descriptor/BUILD
@@ -6,11 +6,11 @@ gogoslick_proto_library(
         "google/protobuf/duration.proto": "github.com/gogo/protobuf/types",
     },
     imports = [
-        "external/com_github_google_protobuf/src",
-        "../../external/com_github_google_protobuf/src",
+        "external/com_google_protobuf/src",
+        "../../external/com_google_protobuf/src",
     ],
     inputs = [
-        "@com_github_google_protobuf//:well_known_protos",
+        "@com_google_protobuf//:well_known_protos",
     ],
     protos = [
         ":protos",

--- a/mixer/v1/template/BUILD
+++ b/mixer/v1/template/BUILD
@@ -6,11 +6,11 @@ gogoslick_proto_library(
         "google/protobuf/descriptor.proto": "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     },
     imports = [
-        "external/com_github_google_protobuf/src",
-        "../../external/com_github_google_protobuf/src",
+        "external/com_google_protobuf/src",
+        "../../external/com_google_protobuf/src",
     ],
     inputs = [
-        "@com_github_google_protobuf//:well_known_protos",
+        "@com_google_protobuf//:well_known_protos",
     ],
     protos = [":protos"],
     verbose = 0,

--- a/prow/api-presubmit.sh
+++ b/prow/api-presubmit.sh
@@ -27,5 +27,6 @@ set -u
 set -x
 
 echo "=== Bazel Build ==="
+bazel version
 bazel build //...
 


### PR DESCRIPTION
Unfortunately, the fix to expose WKT for C++ was merged on Sep 5 and has missed protobuf 3.4.1.
Pointing to master as a temporary workaround.

I checked that both mixerclient and mixer build fine against this PR.