### PR TITLE
Rename Attributes to CompressedAttributes.

### DIFF
--- a/mixer/v1/attributes.proto
+++ b/mixer/v1/attributes.proto
@@ -59,7 +59,7 @@ option (gogoproto.gostring_all) = false;
 // 1) Configure Istio/Proxy with static per-proxy attributes, such as source.uid.
 // 2) Service IDL definition to extract api attributes for active requests.
 // 3) Forward attributes from client proxy to server proxy for HTTP requests.
-message UncompressedAttributes {
+message Attributes {
   // A list of attributes.
   repeated Attribute attributes = 1;
 
@@ -94,7 +94,7 @@ message UncompressedAttributes {
 // dictionary instead. The message-level dictionary is carried by the
 // `words` field of this message, the deployment-wide dictionary is determined via
 // configuration.
-message Attributes {
+message CompressedAttributes {
   // The message-level dictionary.
   repeated string words = 1;
 

--- a/mixer/v1/check.proto
+++ b/mixer/v1/check.proto
@@ -40,7 +40,7 @@ message CheckRequest {
   //
   // Mixer's configuration determines how these attributes are used to
   // establish the result returned in the response.
-  Attributes attributes = 1 [(gogoproto.nullable) = false];
+  CompressedAttributes attributes = 1 [(gogoproto.nullable) = false];
 
   // The number of words in the global dictionary, used with to populate the attributes.
   // This value is used as a quick way to determine whether the client is using a dictionary that
@@ -73,7 +73,7 @@ message CheckResponse {
     // adapters Mixer is configured with. These attributes are used to
     // ferry new attributes that Mixer derived based on the input set of
     // attributes and its configuration.
-    Attributes attributes = 4 [(gogoproto.nullable) = false];
+    CompressedAttributes attributes = 4 [(gogoproto.nullable) = false];
 
     // The total set of attributes that were used in producing the result
     // along with matching conditions.
@@ -113,7 +113,7 @@ message ReferencedAttributes {
 
   message AttributeMatch {
     // The name of the attribute. This is a dictionary index encoded in a manner identical
-    // to all strings in the [Attributes][istio.mixer.v1.Attributes] message.
+    // to all strings in the [CompressedAttributes][istio.mixer.v1.CompressedAttributes] message.
     sint32 name = 1;
 
     // The kind of match against the attribute value.
@@ -123,7 +123,7 @@ message ReferencedAttributes {
     string regex = 3;
   }
 
-  // The message-level dictionary. Refer to [Attributes][istio.mixer.v1.Attributes] for information
+  // The message-level dictionary. Refer to [CompressedAttributes][istio.mixer.v1.CompressedAttributes] for information
   // on using dictionaries.
   repeated string words = 1;
 

--- a/mixer/v1/report.proto
+++ b/mixer/v1/report.proto
@@ -41,7 +41,7 @@ message ReportRequest {
   //
   // If a client is not sophisticated and doesn't want to use delta-encoding,
   // a degenerate case is to include all attributes in every individual message.
-  repeated Attributes attributes = 1 [(gogoproto.nullable) = false];
+  repeated CompressedAttributes attributes = 1 [(gogoproto.nullable) = false];
 
   // The default message-level dictionary for all the attributes.
   // Individual attribute messages can have their own dictionaries, but if they don't


### PR DESCRIPTION
So that UncompressedAttributes can be called Attributes. 

Now it is good time to name it properly.  It will be much harder to do it once they are used all over the places.