### PR TITLE
Change proto Attributes to use map.

### DIFF
--- a/mixer/v1/attributes.proto
+++ b/mixer/v1/attributes.proto
@@ -54,7 +54,7 @@ option (gogoproto.gostring_all) = false;
 // Each type of value is encoded into one of the so-called transport types present
 // in this message.
 //
-// Defines a list of attributes in uncompressed format.
+// Defines a map of attributes in uncompressed format.
 // Following places may use this message:
 // 1) Configure Istio/Proxy with static per-proxy attributes, such as source.uid.
 // 2) Service IDL definition to extract api attributes for active requests.

--- a/mixer/v1/attributes.proto
+++ b/mixer/v1/attributes.proto
@@ -60,14 +60,11 @@ option (gogoproto.gostring_all) = false;
 // 2) Service IDL definition to extract api attributes for active requests.
 // 3) Forward attributes from client proxy to server proxy for HTTP requests.
 message Attributes {
-  // A list of attributes.
-  repeated Attribute attributes = 1;
+  // A map of attribute name to its value.
+  map<string, AttributeValue> attributes = 1;
 
-  // Specifies one attribute with name and value.
-  message Attribute {
-    // The attribute name.
-    string name = 1;
-
+  // Specifies one attribute value with different type.
+  message AttributeValue {
     // The attribute value.
     oneof value {
       string string_value = 2;
@@ -79,11 +76,11 @@ message Attributes {
       google.protobuf.Duration duration_value = 8;
       StringMap string_map_value = 9;
     }
+  }
 
-    // Defines a strig map.
-    message StringMap {
-      map<string, string> entries = 1;
-    }
+  // Defines a strig map.
+  message StringMap {
+    map<string, string> entries = 1;
   }
 }
 


### PR DESCRIPTION
To support attribute update.  Update may replace or erase an attribute. 
Mixerclient plans to use this message to replace its Attributes class.