### PR TITLE
Define per-service mixerclient runtime configuration

### DIFF
--- a/mixer/v1/config/client/mixer_filter_config.proto
+++ b/mixer/v1/config/client/mixer_filter_config.proto
@@ -62,15 +62,20 @@ message MixerFilterConfig {
 
   // Map of control configuration indexed by destination.service. This
   // is used to support per-service configuration for cases where a
-  // mixerclient serves multiple services.
+  // mixerclient serves multiple services. Takes precedence over 
+  // default_control_configs if destination.service match is found.
   map<string, MixerControlConfig> control_configs = 5;
+  
+  // Default control configuration when no destination.service match is 
+  // found.
+  MixerControlConfig default_control_configs = 6;
 
   // Default attributes to send to Mixer in both Check and
   // Report. This typically includes "destination.ip" and
   // "destination.uid" attributes.
-  Attributes mixer_attributes = 6;
+  Attributes mixer_attributes = 7;
 
   // Default attributes to forward to upstream. This typically
   // includes the "source.ip" and "source.uid" attributes.
-  Attributes forward_attributes = 7;
+  Attributes forward_attributes = 8;
 }

--- a/mixer/v1/config/client/mixer_filter_config.proto
+++ b/mixer/v1/config/client/mixer_filter_config.proto
@@ -20,8 +20,7 @@ import "mixer/v1/config/client/quota.proto";
 
 package istio.mixer.v1.config.client;
 
-// Defines mixer control config.
-// It is per-route for upstream if it is from Envoy route opaque config.
+// Defines the per-service mixerclient control configuration.
 message MixerControlConfig {
   // If true, call Mixer Check.
   bool enable_mixer_check = 1;
@@ -29,23 +28,19 @@ message MixerControlConfig {
   // If true, call Mixer Report.
   bool enable_mixer_Report = 2;
 
-  // If true, disable forwarding any attributes to upstream.
-  bool disable_forward_attributes = 3;
-
-  // Send these attributes to Mixer in both Check and Report.
-  Attributes mixer_attributes = 4;
-
-  // Forward these attributes to upstream.
-  Attributes forward_attributes = 5;
+  // Send these attributes to Mixer in both Check and Report. This
+  // typically includes the "destination.service" attribute.
+  Attributes mixer_attributes = 3;
 
   // HTTP API specifications to generate API attributes.
-  repeated HTTPAPISpec http_api_spec = 6;
+  repeated HTTPAPISpec http_api_spec = 4;
 
   // Quota specifications to generate quota requirements.
-  repeated QuotaSpec quota_spec = 7;
+  repeated QuotaSpec quota_spec = 5;
 }
 
-// Specifies config for Envoy Mixer HTTP filter and TCP filter.
+// Defines the Mixerclient's envoy HTTP filter and TCP filter
+// configuration.
 message MixerFilterConfig {
   // The flag to disable check cache.
   bool disable_check_cache = 1;
@@ -65,8 +60,17 @@ message MixerFilterConfig {
   // Specifies the policy when failed to connect to Mixer server.
   NetworkFailPolicy network_fail_policy = 4;
 
-  // Specifies the default Mixer control config.
-  // If one is defined in upstream route table, per-route mixer control config
-  // takes precedence over the default mixer control config.
-  MixerControlConfig control_config = 5;
+  // Map of control configuration indexed by destination.service. This
+  // is used to support per-service configuration for cases where a
+  // mixerclient serves multiple services.
+  map<string, MixerControlConfig> control_configs = 5;
+
+  // Default attributes to send to Mixer in both Check and
+  // Report. This typically includes "destination.ip" and
+  // "destination.uid" attributes.
+  Attributes mixer_attributes = 6;
+
+  // Default attributes to forward to upstream. This typically
+  // includes the "source.ip" and "source.uid" attributes.
+  Attributes forward_attributes = 7;
 }

--- a/mixer/v1/config/client/mixer_filter_config.proto
+++ b/mixer/v1/config/client/mixer_filter_config.proto
@@ -62,13 +62,12 @@ message MixerFilterConfig {
 
   // Map of control configuration indexed by destination.service. This
   // is used to support per-service configuration for cases where a
-  // mixerclient serves multiple services. Takes precedence over 
-  // default_control_configs if destination.service match is found.
+  // mixerclient serves multiple services. 
   map<string, MixerControlConfig> control_configs = 5;
   
-  // Default control configuration when no destination.service match is 
-  // found.
-  MixerControlConfig default_control_configs = 6;
+  // Default destination service name if none was specified in the 
+  // client request.
+  string default_destination_service = 6;
 
   // Default attributes to send to Mixer in both Check and
   // Report. This typically includes "destination.ip" and


### PR DESCRIPTION
A single mixerclient may serve multiple destination services. Aspects
of runtime configuration must therefore be defined per-service,
e.g. Quota, APISpec. Express this per-service configuration as a map
of config elements indexed by the fully qualified destination service,
e.g. destination.service.

As an implementation note, the mixerclient could derive
destination.service using the `host` header. Alternatively, Pilot can
populate inbound route's opaque_config with the canonical destination
service name. The mixerclient can use the destination service
name as key into the runtime configuration to determine the
approptiate quota, apispec, etc. This has the nice property of
automatically handling all domain name variations, e.g. my-service,
my-service.my-namespace, my-service.my-namespace.svc.local.