### PR TITLE
fix mixerclient build with gogoslick_proto_library

### DIFF
--- a/mixer/v1/config/client/api_spec.proto
+++ b/mixer/v1/config/client/api_spec.proto
@@ -16,8 +16,14 @@ syntax = "proto3";
 
 package istio.mixer.v1.config.client;
 
+import "gogoproto/gogo.proto";
+
 import "mixer/v1/attributes.proto";
-import "proxy/v1/config/route_rule.proto";
+import "mixer/v1/config/client/service.proto";
+
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
 
 // HTTPAPISpec defines the canonical configuration for generating
 // API-related attributes from HTTP requests based on the method and
@@ -154,7 +160,7 @@ message HTTPAPISpecReference {
 //
 message HTTPAPISpecBinding {
   // REQUIRED. One or more services to map the listed HTTPAPISpec onto.
-  repeated istio.proxy.v1.config.IstioService services = 1;
+  repeated IstioService services = 1;
 
   // REQUIRED. One or more HTTPAPISpec references that should be mapped to
   // the specified service(s). The aggregate collection of match

--- a/mixer/v1/config/client/mixer_filter_config.proto
+++ b/mixer/v1/config/client/mixer_filter_config.proto
@@ -14,11 +14,17 @@
 
 syntax = "proto3";
 
+import "gogoproto/gogo.proto";
+
 import "mixer/v1/attributes.proto";
 import "mixer/v1/config/client/api_spec.proto";
 import "mixer/v1/config/client/quota.proto";
 
 package istio.mixer.v1.config.client;
+
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
 
 // Defines the per-service mixerclient control configuration.
 message MixerControlConfig {
@@ -62,10 +68,10 @@ message MixerFilterConfig {
 
   // Map of control configuration indexed by destination.service. This
   // is used to support per-service configuration for cases where a
-  // mixerclient serves multiple services. 
+  // mixerclient serves multiple services.
   map<string, MixerControlConfig> control_configs = 5;
-  
-  // Default destination service name if none was specified in the 
+
+  // Default destination service name if none was specified in the
   // client request.
   string default_destination_service = 6;
 
@@ -77,4 +83,7 @@ message MixerFilterConfig {
   // Default attributes to forward to upstream. This typically
   // includes the "source.ip" and "source.uid" attributes.
   Attributes forward_attributes = 8;
+
+  // If set to true, disables mixer check calls for TCP connections
+  bool DisableTCPCheckCalls = 9;
 }

--- a/mixer/v1/config/client/quota.proto
+++ b/mixer/v1/config/client/quota.proto
@@ -16,7 +16,12 @@ syntax = "proto3";
 
 package istio.mixer.v1.config.client;
 
-import "proxy/v1/config/route_rule.proto";
+import "gogoproto/gogo.proto";
+import "mixer/v1/config/client/service.proto";
+
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
 
 // Specifies runtime quota rules.
 //  * Uses Istio attributes to match individual requests
@@ -73,6 +78,19 @@ message QuotaRule {
   repeated Quota quotas = 2;
 }
 
+// Describes how to match a given string in HTTP headers. Match is
+// case-sensitive.
+message StringMatch {
+  oneof match_type {
+    // exact string match
+    string exact = 1;
+    // prefix-based match
+    string prefix = 2;
+    // ECMAscript style regex-based match
+    string regex = 3;
+  }
+}
+
 // Specifies a match clause to match Istio attributes
 message AttributeMatch {
   // Map of attribute names to StringMatch type.
@@ -85,7 +103,7 @@ message AttributeMatch {
   //       exact: SOURCE_UID
   //     request.http_method:
   //       exact: POST
-  map<string, istio.proxy.v1.config.StringMatch> clause = 1;
+  map<string, StringMatch> clause = 1;
 }
 
 // Specifies a quota to use with quota name and amount.
@@ -101,7 +119,7 @@ message Quota {
 // IstioService.
 message QuotaSpecBinding {
   // REQUIRED. One or more services to map the listed QuotaSpec onto.
-  repeated istio.proxy.v1.config.IstioService services = 1;
+  repeated IstioService services = 1;
 
   message QuotaSpecReference {
     // REQUIRED. The short name of the QuotaSpec. This is the resource

--- a/mixer/v1/config/client/service.proto
+++ b/mixer/v1/config/client/service.proto
@@ -1,0 +1,55 @@
+// Copyright 2017 Istio Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+syntax = "proto3";
+
+package istio.mixer.v1.config.client;
+
+import "gogoproto/gogo.proto";
+
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
+
+// NOTE: this is a duplicate of proxy.v1.config.IstioService from
+// proxy/v1/config/route_rules.proto.
+//
+// Mixer protobufs have gogoproto specific options which are not
+// compatiable with the proxy's vanilla protobufs. Ideally, these
+// protobuf options be reconciled so fundamental istio concepts and
+// types can be shared by components. Until then, make a copy of
+// IstioService for mixerclient to use.
+
+// IstioService identifies a service and optionally service version.
+// The FQDN of the service is composed from the name, namespace, and implementation-specific domain suffix
+// (e.g. on Kubernetes, "reviews" + "default" + "svc.cluster.local" -> "reviews.default.svc.cluster.local").
+message IstioService {
+  // The short name of the service such as "foo".
+  string name = 1;
+
+  // Optional namespace of the service. Defaults to value of metadata namespace field.
+  string namespace = 2;
+
+  // Domain suffix used to construct the service FQDN in implementations that support such specification.
+  string domain = 3;
+
+  // The service FQDN.
+  string service = 4;
+
+  // Optional one or more labels that uniquely identify the service version.
+  //
+  // *Note:* When used for a RouteRule destination, labels MUST be empty.
+  //
+  map<string, string> labels = 5;
+}


### PR DESCRIPTION
NOTE: posted for early review. I'll rebase+merge after repo consolidation is finished.

gogoproto options seem to be infectious on dependent protobufs. Make
the following changes to enable mixerclient protobufs to be built with
gogoslick_proto_library.

1) Mirror attributes.go options into mixerclient protobufs to avoid
 errors about undefined methods, e.g.

    `this.Attributes.Equal undefined (type *istio_mixer_v1.Attributes has no field or method Equal)`

2) duplicate proxy.v1.config.IstioService and
 proxy.v1.config.StringMatch into mixer.v1.config.client to avoid
 polluting proxy protobufs with gogoproto options. Resulting jsonpb
 encoding is the same for c++ mixerclient.

