### PR TITLE
Add INHERIT to AuthenticationPolicy enum.

### DIFF
--- a/proxy/v1/config/proxy_mesh.proto
+++ b/proxy/v1/config/proxy_mesh.proto
@@ -18,7 +18,15 @@ import "google/protobuf/duration.proto";
 
 package istio.proxy.v1.config;
 
+// AuthenticationPolicy defines authentication policy. It can be set for
+// different scopes (mesh, service …), and the most narrow scope with
+// non-”DEFAULT” value will be used.
+// Mess policy cannot be “DEFAULT”.
 enum AuthenticationPolicy {
+  // Use the policy defined by the parent scope. Should not be used for mesh’s
+  // policy.
+  DEFAULT = -1;
+
   // Do not encrypt Envoy to Envoy traffic.
   NONE = 0;
 
@@ -76,7 +84,7 @@ message ProxyConfig {
 
   // Port on which Envoy should listen for administrative commands.
   int32 proxy_admin_port = 11;
-  
+
   // The availability zone where this Envoy instance is running. When running
   // Envoy as a sidecar in Kubernetes, this flag must be one of the availability
   // zones assigned to a node using failure-domain.beta.kubernetes.io/zone annotation.
@@ -85,7 +93,7 @@ message ProxyConfig {
   // Authentication policy defines the global switch to control authentication
   // for Envoy-to-Envoy communication for istio components Mixer and Pilot.
   AuthenticationPolicy control_plane_auth_policy = 13;
-  
+
   // File path of custom proxy configuration, currently used by proxies
   // in front of Mixer and Pilot.
   string custom_config_file = 14;
@@ -154,7 +162,7 @@ message MeshConfig {
   // Defines whether to use Istio ingress controller for annotated or all ingress resources.
   IngressControllerMode ingress_controller_mode = 9;
 
-  // TODO AuthPolicy needs to be removed and merged with AuthPolicy defined above  
+  // TODO AuthPolicy needs to be removed and merged with AuthPolicy defined above
   enum AuthPolicy {
     // Do not encrypt Envoy to Envoy traffic.
     NONE = 0;

--- a/proxy/v1/config/proxy_mesh.proto
+++ b/proxy/v1/config/proxy_mesh.proto
@@ -21,9 +21,9 @@ package istio.proxy.v1.config;
 // AuthenticationPolicy defines authentication policy. It can be set for
 // different scopes (mesh, service …), and the most narrow scope with
 // non-INHERIT value will be used.
-// Mess policy cannot be INHERIT.
+// Mesh policy cannot be INHERIT.
 enum AuthenticationPolicy {
-  // Use the policy defined by the parent scope. Should not be used for mesh’s
+  // Use the policy defined by the parent scope. Should not be used for mesh
   // policy.
   INHERIT = 1000;
 

--- a/proxy/v1/config/proxy_mesh.proto
+++ b/proxy/v1/config/proxy_mesh.proto
@@ -25,7 +25,7 @@ package istio.proxy.v1.config;
 enum AuthenticationPolicy {
   // Use the policy defined by the parent scope. Should not be used for mesh’s
   // policy.
-  INHERIT = -1;
+  INHERIT = 1000;
 
   // Do not encrypt Envoy to Envoy traffic.
   NONE = 0;

--- a/proxy/v1/config/proxy_mesh.proto
+++ b/proxy/v1/config/proxy_mesh.proto
@@ -20,12 +20,12 @@ package istio.proxy.v1.config;
 
 // AuthenticationPolicy defines authentication policy. It can be set for
 // different scopes (mesh, service …), and the most narrow scope with
-// non-”DEFAULT” value will be used.
-// Mess policy cannot be “DEFAULT”.
+// non-INHERIT value will be used.
+// Mess policy cannot be INHERIT.
 enum AuthenticationPolicy {
   // Use the policy defined by the parent scope. Should not be used for mesh’s
   // policy.
-  DEFAULT = -1;
+  INHERIT = -1;
 
   // Do not encrypt Envoy to Envoy traffic.
   NONE = 0;

--- a/proxy/v1/config/proxy_mesh.proto
+++ b/proxy/v1/config/proxy_mesh.proto
@@ -84,7 +84,6 @@ message ProxyConfig {
 
   // Port on which Envoy should listen for administrative commands.
   int32 proxy_admin_port = 11;
-
   // The availability zone where this Envoy instance is running. When running
   // Envoy as a sidecar in Kubernetes, this flag must be one of the availability
   // zones assigned to a node using failure-domain.beta.kubernetes.io/zone annotation.
@@ -93,7 +92,6 @@ message ProxyConfig {
   // Authentication policy defines the global switch to control authentication
   // for Envoy-to-Envoy communication for istio components Mixer and Pilot.
   AuthenticationPolicy control_plane_auth_policy = 13;
-
   // File path of custom proxy configuration, currently used by proxies
   // in front of Mixer and Pilot.
   string custom_config_file = 14;


### PR DESCRIPTION
This change is in order to reuse AuthenticationPolicy enum for per-service enablement.

Issue: https://github.com/istio/auth/issues/267

Design doc:
https://docs.google.com/document/d/1D7wZCQjVB72Wlwr5ZxP5WUmn3FUDr-XzfX8OodPXe8Y/edit#heading=h.eg4nr9f3mo7h