### PR TITLE
rename field to disable_tcp_check_calls.

### DIFF
--- a/mixer/v1/config/client/mixer_filter_config.proto
+++ b/mixer/v1/config/client/mixer_filter_config.proto
@@ -85,5 +85,5 @@ message MixerFilterConfig {
   Attributes forward_attributes = 8;
 
   // If set to true, disables mixer check calls for TCP connections
-  bool DisableTCPCheckCalls = 9;
+  bool disable_tcp_check_calls = 9;
 }


### PR DESCRIPTION
Protobuf field names should be hyphen with lower case instead of camel case.  to be consistent with other field names.