### PR TITLE
Revert "port spec (#235)"

### DIFF
--- a/proxy/v1/config/egress_rule.proto
+++ b/proxy/v1/config/egress_rule.proto
@@ -43,6 +43,15 @@ package istio.proxy.v1.config;
 //           protocol: https
 //
 message EgressRule {
+  // Port describes the properties of a specific TCP port of an external service.
+  message Port {
+    // A valid non-negative integer port number.
+    int32 port = 1;
+    // The protocol to communicate with the external services.
+    // MUST BE one of HTTP|HTTPS|GRPC|HTTP2.
+    string protocol = 2;
+  }
+
   // REQUIRED: Hostname or a wildcard domain name associated with the external service.
   // ONLY the "service" field of destination will be taken into consideration. Name,
   // namespace, domain and labels are ignored. Routing rules and destination policies that

--- a/proxy/v1/config/route_rule.proto
+++ b/proxy/v1/config/route_rule.proto
@@ -493,15 +493,3 @@ message CorsPolicy {
   // Access-Control-Allow-Credentials header.
   google.protobuf.BoolValue allow_credentials = 6;
 }
-
-// Port describes the properties of a specific port of a service.
-message Port {
-  // A valid non-negative integer port number.
-  int32 number = 1;
-  // The protocol to communicate with the external services.
-  // MUST BE one of HTTP|HTTPS|GRPC|HTTP2|MONGO|REDIS|TCP.
-  string protocol = 2;
-
-  // Name assigned to the port.
-  string name = 3;
-}


### PR DESCRIPTION
This reverts commit 84f7ea18d778de7c448582071f59f192451e1d8d.

This is causing istio/istio to break when updating to latest version of istio/api
errors: 
```
ERROR: /Users/guptasu/go/src/istio.io/istio/pilot/model/BUILD:3:1: GoCompile pilot/model/~normal~go_default_library~/istio.io/istio/pilot/model.a failed (Exit 1).
pilot/model/validation.go:868:29: port.Port undefined (type *istio_proxy_v1_config.Port has no field or method Port)
pilot/model/validation.go:869:72: port.Port undefined (type *istio_proxy_v1_config.Port has no field or method Port)
pilot/model/validation.go:871:13: port.Port undefined (type *istio_proxy_v1_config.Port has no field or method Port)
pilot/model/validation.go:941:35: undefined: istio_proxy_v1_config.EgressRule_Port
2017/11/20 11:11:31 error running compiler: exit status 1
INFO: Elapsed time: 101.675s, Critical Path: 17.48s

```