### PR TITLE
Update Makefile to use local builds of deps for protoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@
 
 # protoc
 /protoc-tmp
-protoc-gen-*
-protoc-min-version-*
+bin/protoc-gen-*
+bin/protoc-min-version-*
 
 /vendor

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,7 @@
 
 # protoc
 /protoc-tmp
+protoc-gen-*
+protoc-min-version-*
 
 /vendor

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ PROTOC_MIN_VERSION_VERSION := bin/$(PROTOC_MIN_VERSION)-$(GOGO_VERSION)
 
 PROTOC := $(PROTOC_MIN_VERSION_VERSION) -version=3.5.0
 
-GOGOSLICK_PLUGIN_PREFIX := --plugin=bin/$(GOGOSLICK)-$(GOGO_VERSION) --gogoslick_out=plugins=grpc,
-GOGO_PLUGIN_PREFIX := --plugin=bin/$(GOGO)-$(GOGO_VERSION) --gogo_out=plugins=grpc,
+GOGOSLICK_PLUGIN_PREFIX := --plugin=bin/$(GOGOSLICK)-$(GOGO_VERSION) --gogoslick-$(GOGO_VERSION)_out=plugins=grpc,
+GOGO_PLUGIN_PREFIX := --plugin=bin/$(GOGO)-$(GOGO_VERSION) --gogo-$(GOGO_VERSION)_out=plugins=grpc,
 PLUGIN_SUFFIX = :.
 
 # BASIC STANDARD MAPPINGS

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ MIN_VERSION_PATH := $(GOGOPROTO_PATH)/$(PROTOC_MIN_VERSION)
 
 PROTOC := ./$(PROTOC_MIN_VERSION)-$(GOGO_VERSION) -version=3.5.0
 
-GOGOSLICK_PLUGIN_PREFIX := --plugin=$(GOGOSLICK)-$(GOGO_VERSION) --gogoslick_out=plugins=grpc,
-GOGO_PLUGIN_PREFIX := --plugin=$(GOGO)-$(GOGO_VERSION) --gogo_out=plugins=grpc,
+GOGOSLICK_PLUGIN_PREFIX := --plugin=./$(GOGOSLICK)-$(GOGO_VERSION) --gogoslick_out=plugins=grpc,
+GOGO_PLUGIN_PREFIX := --plugin=./$(GOGO)-$(GOGO_VERSION) --gogo_out=plugins=grpc,
 PLUGIN_SUFFIX = :.
 
 # BASIC STANDARD MAPPINGS

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ mixer/v1/config/fixed_cfg.pb.go : mixer/v1/config/cfg.proto | $(PROTOC_BIN)
 
 # TODO: kill all generated files too ?
 clean:
-	rm -rf protoc-gen-*
-	rm -rf protoc-min-version-*
+	rm -rf bin/protoc-gen-*
+	rm -rf bin/protoc-min-version-*
 	rm -rf protoc-tmp
 	rm -rf vendor

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ STATUS_PROTO := protoc-tmp/$(RPC_PATH)/status.proto
 CODE_PROTO := protoc-tmp/$(RPC_PATH)/code.proto
 ERR_PROTO := protoc-tmp/$(RPC_PATH)/error_details.proto
 
-# TODO: pull from Gopkg.lock somehow
-GOGO_VERSION := v0.5
+GOGO_VERSION := $(shell bin/getVersion.sh)
 
 GOGOPROTO_PATH := vendor/github.com/gogo/protobuf
 GOGO := protoc-gen-gogo
@@ -20,11 +19,14 @@ GOGOSLICK := protoc-gen-gogoslick
 GOGOSLICK_PATH := $(GOGOPROTO_PATH)/$(GOGOSLICK)
 PROTOC_MIN_VERSION := protoc-min-version
 MIN_VERSION_PATH := $(GOGOPROTO_PATH)/$(PROTOC_MIN_VERSION)
+PROTOC_GEN_GOGO := bin/$(GOGO)-$(GOGO_VERSION)
+PROTOC_GEN_GOGOSLICK := bin/$(GOGOSLICK)-$(GOGO_VERSION)
+PROTOC_MIN_VERSION_VERSION := bin/$(PROTOC_MIN_VERSION)-$(GOGO_VERSION)
 
-PROTOC := ./$(PROTOC_MIN_VERSION)-$(GOGO_VERSION) -version=3.5.0
+PROTOC := $(PROTOC_MIN_VERSION_VERSION) -version=3.5.0
 
-GOGOSLICK_PLUGIN_PREFIX := --plugin=./$(GOGOSLICK)-$(GOGO_VERSION) --gogoslick_out=plugins=grpc,
-GOGO_PLUGIN_PREFIX := --plugin=./$(GOGO)-$(GOGO_VERSION) --gogo_out=plugins=grpc,
+GOGOSLICK_PLUGIN_PREFIX := --plugin=bin/$(GOGOSLICK)-$(GOGO_VERSION) --gogoslick_out=plugins=grpc,
+GOGO_PLUGIN_PREFIX := --plugin=bin/$(GOGO)-$(GOGO_VERSION) --gogo_out=plugins=grpc,
 PLUGIN_SUFFIX = :.
 
 # BASIC STANDARD MAPPINGS
@@ -149,9 +151,6 @@ ifeq ($(UNAME), Linux)
 	rm -rf protoc3
 endif
 
-PROTOC_GEN_GOGO := $(GOGO)-$(GOGO_VERSION)
-PROTOC_GEN_GOGOSLICK := $(GOGOSLICK)-$(GOGO_VERSION)
-PROTOC_MIN_VERSION_VERSION := $(PROTOC_MIN_VERSION)-$(GOGO_VERSION)
 
 #####################
 # Generation Rule

--- a/bin/getVersion.sh
+++ b/bin/getVersion.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+ROOT=$GOPATH/src/istio.io/api
+
+sed -n '/gogo\/protobuf/,/\[\[projects/p' $ROOT/Gopkg.lock | grep "version = " | sed -e 's/^[^\"]*\"//g' -e 's/\"//g'


### PR DESCRIPTION
This PR removes the install into GOPATH of the go tools need for proto-compile. Instead, the tools are installed into a new `bin` directory (which also houses a script to extract tooling version from the lock file).