### PR TITLE
fix the comment of sleep window of circuit breaker

### DIFF
--- a/routing/v1alpha1/dest_policy.pb.go
+++ b/routing/v1alpha1/dest_policy.pb.go
@@ -493,7 +493,7 @@ type CircuitBreaker_SimpleCircuitBreakerPolicy struct {
 	HttpMaxPendingRequests int32 `protobuf:"varint,2,opt,name=http_max_pending_requests,json=httpMaxPendingRequests" json:"http_max_pending_requests,omitempty"`
 	// Maximum number of requests to a backend. Default 1024
 	HttpMaxRequests int32 `protobuf:"varint,3,opt,name=http_max_requests,json=httpMaxRequests" json:"http_max_requests,omitempty"`
-	// Minimum time the circuit will be closed. format: 1h/1m/1s/1ms. MUST
+	// Minimum time the circuit will be open. format: 1h/1m/1s/1ms. MUST
 	// BE >=1ms. Default is 30s.
 	SleepWindow *google_protobuf1.Duration `protobuf:"bytes,4,opt,name=sleep_window,json=sleepWindow" json:"sleep_window,omitempty"`
 	// Number of 5XX errors before circuit is opened. Defaults to 5.

--- a/routing/v1alpha1/dest_policy.proto
+++ b/routing/v1alpha1/dest_policy.proto
@@ -135,7 +135,7 @@ message CircuitBreaker {
   // A simple circuit breaker can be set based on a number of criteria such as
   // connection and request limits. For example, the following destination
   // policy sets a limit of 100 connections to "reviews" service version
-  // "v1" backends. 
+  // "v1" backends.
   //
   //     metadata:
   //       name: reviews-cb-policy
@@ -171,7 +171,7 @@ message CircuitBreaker {
   //           httpConsecutiveErrors: 7
   //           sleepWindow: 15m
   //           httpDetectionInterval: 5m
-  //           
+  //
   message SimpleCircuitBreakerPolicy {
     // Maximum number of connections to a backend.
     int32 max_connections = 1;
@@ -182,7 +182,7 @@ message CircuitBreaker {
     // Maximum number of requests to a backend. Default 1024
     int32 http_max_requests = 3;
 
-    // Minimum time the circuit will be closed. format: 1h/1m/1s/1ms. MUST
+    // Minimum time the circuit will be open. format: 1h/1m/1s/1ms. MUST
     // BE >=1ms. Default is 30s.
     google.protobuf.Duration sleep_window = 4;
 


### PR DESCRIPTION
minimum time the circuit will be **open** instead of **closed** as it was previously.
The circuit is _open_ = "no traffic".