### PR TITLE
Destination Rules: ports, (no)inheritance, and more

### DIFF
--- a/routing/v1alpha2/destination_rule.proto
+++ b/routing/v1alpha2/destination_rule.proto
@@ -91,7 +91,7 @@ package istio.routing.v1alpha2;
 //         trafficPolicy:
 //           loadBalancer:
 //             simple: LEAST_CONN
-//       - port: 7777
+//       - port: http-monitoring #can use names or numbers
 //         trafficPolicy:
 //           loadBalancer:
 //             simple: ROUND_ROBIN

--- a/routing/v1alpha2/destination_rule.proto
+++ b/routing/v1alpha2/destination_rule.proto
@@ -34,7 +34,7 @@ package istio.routing.v1alpha2;
 //         loadBalancer:
 //           simple: LEAST_CONN
 //
-// Version specific DestinationRule can be specified by defining a named
+// Version specific destination rule can be specified by defining a named
 // subset and overriding the settings specified at the service level. The
 // following rule uses a round robin load balancing policy for all traffic
 // going to a subset named testversion that is composed of endpoints (e.g.,
@@ -57,8 +57,92 @@ package istio.routing.v1alpha2;
 //           loadBalancer:
 //             simple: ROUND_ROBIN
 //
-// Note that policies specified for subsets will not take effect until
+// Note that rules specified for subsets will not take effect until
 // a route rule explicitly sends traffic to this subset.
+//
+// Destination rules can also be restricted to either HTTP or TCP as
+// shown below:
+//
+//     apiVersion: config.istio.io/v1alpha2
+//     kind: DestinationRule
+//     metadata:
+//       name: bookinfo-ratings
+//     spec:
+//       name: ratings
+//       http: # applies to all ports using HTTP1/HTTP2/gRPC
+//         trafficPolicy:
+//           loadBalancer:
+//             simple: LEAST_CONN
+//       tcp: # applies to all ports using TCP including HTTPS
+//         trafficPolicy:
+//           loadBalancer:
+//             simple: ROUND_ROBIN
+//
+// Further customization can be done for a specific port
+//
+//     apiVersion: config.istio.io/v1alpha2
+//     kind: DestinationRule
+//     metadata:
+//       name: bookinfo-ratings
+//     spec:
+//       name: ratings
+//       http:
+//       - port: 8080
+//         trafficPolicy:
+//           loadBalancer:
+//             simple: LEAST_CONN
+//       - port: 7777
+//         trafficPolicy:
+//           loadBalancer:
+//             simple: ROUND_ROBIN
+//
+// DNS prefixes with wildcards can be used to define rules for a group of
+// services. For example, the following destination rule defines the round
+// robin load balancing policy for all services under *.dev.bookinfo.com
+// domain, using HTTP-based protocols, and sets a maximum of 100 pending
+// requests per connection.
+//
+//     apiVersion: config.istio.io/v1alpha2
+//     kind: DestinationRule
+//     metadata:
+//       name: dev-settings
+//     spec:
+//       name: *.dev.bookinfo.com
+//       http:
+//         trafficPolicy:
+//           loadBalancer:
+//             simple: ROUND_ROBIN
+//           connectionPool:
+//             http:
+//               http1MaxPendingRequests: 100
+//
+// Services can override the global setting by using an exact name or a
+// more specific prefix match. For example, the following rule overrides
+// the default load balancing policy defined above, for the
+// ratings.dev.bookinfo.com service.
+//
+//     apiVersion: config.istio.io/v1alpha2
+//     kind: DestinationRule
+//     metadata:
+//       name: ratings-dev-settings
+//     spec:
+//       name: ratings.dev.bookinfo.com
+//       http:
+//         trafficPolicy:
+//           loadBalancer:
+//             simple: LEAST_CONN
+//           # no connection pool settings. Use default value of 1024 pending req.
+//
+// Destination rules do not support inheritance. When attempting to locate
+// a destination rule for an upstream service, Istio would search for a
+// rule using the most specific name first, followed by less specific rules
+// using wildcard prefixes. In the example above, when attempting to
+// configure load balancing settings for traffic bound to ratings service,
+// Istio would look for a rule under ratings.dev.bookinfo.com, followed by
+// *.dev.bookinfo.com, *.bookinfo.com, *.com, and finally *. All settings
+// found under the chosen rule will be applied. Any omitted setting (e.g.,
+// http1MaxPendingRequests) will assume the default value.
+//
 message DestinationRule {
   // REQUIRED. The destination address for traffic captured by this 
   // rule.  Could be a DNS name with wildcard prefix or a CIDR


### PR DESCRIPTION
cc @louiscryan / @ZackButcher / @kyessenov / @frankbu 

The PR currently has docs that describe how the destination rules would look. Once we converge on this, I can update the protos.

Some pending issues
================

TLS upgrade clunkiness
------------------------

Contrary to what I thought earlier, this does not solve the clunky declaration in Foreign services where the user has to indicate that traffic arriving on google.com:80 on the sidecar has to be sent to upstream google.com:443 over HTTPS, i.e. the current proposed foreign services syntax is

```yaml
hosts:
- *.google.com
portMaps: # this is the proposal
- inPort: 80
   outPort: 443
   tlsUpgrade: true
   discovery: none #indicates pass through
```

It is possible to achieve the behavior above using the following set of rules (for non wildcard services) using a simple foreign services declaration of the form

```yaml
kind: ForeignService
hosts:
- simpleapi.google.com #can't do wildcards if we want port remapping
ports:
- number: 80
   protocol: http
- number: 443
   protocol: https
```

and a route rule to reroute traffic from 80 to 443

```yaml
kind: RouteRule
hosts:
- simpleapi.google.com
http:
- match:
   - port:
         number: 80
   route:
   - destination:
          name: simpleapi.google.com
          port: 443
```

followed by a destination rule:

```yaml
kind: DestinationRule
name: simpleapi.google.com
http:
- port: 443
   tls:
      mode: simple
```

Ignoring some implementation issues for the moment, this experience seems awfully bad. 50% of folks are going to use HTTPS directly. 50% of folks will want to use HTTP, to get metrics and want us to originate TLS. The second half will have to create 3 rules for every external service that they access. Now, if this number was like 10% of people, we can live with this added verbosity as they fall in the minority. But given that this upgrade scenario is pretty common, I feel that the API should accommodate for this common use case and provide a simpler configuration.

This issue is present even internally, when we want to do incremental migration from port X to TLS enabled port Y. I would have to setup a route rule and a destination rule to handle this. Given that the migration is likely to happen over a long time (weeks), a route rule seems like a risky place, because I could be doing other app development stuff in the meantime. Such development would likely result in more route rules (new versions, etc.). It is easy for an end user to mess up the migration, if they create a new route rule that misses the from xxx to yyy transition that we ask users to do.

Egress gateway usage
----------------------

IF someone wants to use a dedicated Egress gateway, we have to augment the foreign service spec to specify the gateway where the service should be made visible. Imagine something like this:

```yaml
kind: ForeignService
hosts:
- someapi.google.com #wildcards wont work for now. Different discussion
gateways:
- foogateway # Like route rules, "mesh" is default gateway
discovery: dns
port:
- number: 80 # from sidecar to gateway, traffic arrives over TLS using istio-auth
   protocol: http
- number: 443 # what will this do? this is where I think the inPort/outPort helps
   protocol: https
```

And then a gateway spec:

```yaml
kind: Gateway
name: foogateway
services:
- port:
       number: 80
   hosts:
   - someapi.google.com
```

and a route rule to reroute traffic to the gateway as well as for gateway to send outside mesh

```yaml
kind: RouteRule
hosts:
- someapi.google.com
gateways:
- mesh
- foogateway
http:
- match: # from mesh to foogateway
   - port:
          number: 80
   - gateways:
      - mesh
   route:
   - destination:
          gateway: foogateway # this is new
 - match: # from foogateway to external world
    - port:
           number: 80
     - gateways:
        - foogateway
    route:
    - destination:
            name: someapi.google.com
            port:
                 number: 443
```

and finally a destination rule that does the TLS upgrade

```yaml
kind: DestinationRule
name: someapi.google.com
http:
- port: 443
   tls:
      mode: simple
```

I feel like there is something missing from this flow, and its not immediately intuitive from an end user perspective.