### PR TITLE
Update comment for TCP filter report interval config.

### DIFF
--- a/mixer/v1/config/client/client_config.pb.go
+++ b/mixer/v1/config/client/client_config.pb.go
@@ -125,7 +125,8 @@ type TcpClientConfig struct {
 	// It applies on the new TCP connections.
 	ConnectionQuotaSpec *QuotaSpec `protobuf:"bytes,5,opt,name=connection_quota_spec,json=connectionQuotaSpec" json:"connection_quota_spec,omitempty"`
 	// Specify report interval to send periodical reports for long TCP
-	// connections. If not specified, the interval is 10 seconds.
+	// connections. If not specified, the interval is 10 seconds. This interval
+	// should not be less than 1 second, otherwise it will be reset to 1 second.
 	ReportInterval *google_protobuf1.Duration `protobuf:"bytes,6,opt,name=report_interval,json=reportInterval" json:"report_interval,omitempty"`
 }
 

--- a/mixer/v1/config/client/client_config.proto
+++ b/mixer/v1/config/client/client_config.proto
@@ -126,6 +126,7 @@ message TcpClientConfig {
   QuotaSpec connection_quota_spec = 5;
 
   // Specify report interval to send periodical reports for long TCP
-  // connections. If not specified, the interval is 10 seconds.
+  // connections. If not specified, the interval is 10 seconds. This interval
+  // should not be less than 1 second, otherwise it will be reset to 1 second.
   google.protobuf.Duration report_interval = 6;
 }

--- a/mixer/v1/config/client/istio.mixer.v1.config.client.pb.html
+++ b/mixer/v1/config/client/istio.mixer.v1.config.client.pb.html
@@ -1030,7 +1030,8 @@ It applies on the new TCP connections.</p>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">google.protobuf.Duration</a></code></td>
 <td>
 <p>Specify report interval to send periodical reports for long TCP
-connections. If not specified, the interval is 10 seconds.</p>
+connections. If not specified, the interval is 10 seconds. This interval
+should not be less than 1 second, otherwise it will be reset to 1 second.</p>
 
 </td>
 </tr>


### PR DESCRIPTION
Add config description that the TCP filter report interval should be at least one second.