### PR TITLE
Adding placeholder binary to get go dep in istio.io/istio...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@
 genbin/
 
 /vendor
+
+# placeholder binary
+/istioapi

--- a/istioapi.go
+++ b/istioapi.go
@@ -1,0 +1,7 @@
+// Placeholder file for go dep in istio.io/isio to pull the whole directory tree
+
+package main
+
+func main() {
+	//TODO maybe do something useful like print version etc
+}


### PR DESCRIPTION
To not complain
Solving failure: No versions of istio.io/api met constraints:
24209c4d7c9713900ac7571dfc38dd2eeea3f167: Could not introduce
istio.io/api@24209c4d7c9713900ac7571dfc38dd2eeea3f167, as its
subpackage istio.io/api does not contain usable Go code
(*build.NoGoError).. (Package is required by (root).)