### PR TITLE
adding correct kind name to v1alpha2 protos so users are not confused

### DIFF
--- a/routing/v1alpha2/gateway.pb.go
+++ b/routing/v1alpha2/gateway.pb.go
@@ -110,7 +110,7 @@ func (Server_TLSOptions_TLSmode) EnumDescriptor() ([]byte, []int) {
 // (i.e. 80 redirects to 443).
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: bookinfo-rule
 //     spec:
@@ -150,7 +150,7 @@ func (Server_TLSOptions_TLSmode) EnumDescriptor() ([]byte, []int) {
 // the reserved name "mesh".
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: bookinfo-Mongo
 //     spec:

--- a/routing/v1alpha2/gateway.proto
+++ b/routing/v1alpha2/gateway.proto
@@ -84,7 +84,7 @@ option go_package = "istio.io/api/routing/v1alpha2";
 // (i.e. 80 redirects to 443).
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: bookinfo-rule
 //     spec:
@@ -124,7 +124,7 @@ option go_package = "istio.io/api/routing/v1alpha2";
 // the reserved name "mesh".
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: bookinfo-Mongo
 //     spec:

--- a/routing/v1alpha2/istio.routing.v1alpha2.pb.html
+++ b/routing/v1alpha2/istio.routing.v1alpha2.pb.html
@@ -180,7 +180,7 @@ Access-Control-Allow-Credentials header to false. In addition, it only
 exposes X-Foo-bar header and sets an expiry period of 1 day.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-rule
 spec:
@@ -304,7 +304,7 @@ reviews service with label &ldquo;version: v1&rdquo; on a subset named v1, and s
 to subset v2, in a kubernetes environment.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-rule
 spec:
@@ -352,7 +352,7 @@ from the service registry and populate the sidecar&rsquo;s load balancing
 pool.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-productpage-rule
 spec:
@@ -369,7 +369,7 @@ spec:
 service wikipedia.org, as there is no internal service of that name.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-wiki-rule
 spec:
@@ -558,7 +558,7 @@ instances with the &ldquo;v2&rdquo; tag and the remaining traffic (i.e., 75%) to
 &ldquo;v1&rdquo;.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-rule
 spec:
@@ -989,7 +989,7 @@ http://uk.bookinfo.com gets redirected to https://uk.bookinfo.com
 (i.e. 80 redirects to 443).</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: bookinfo-rule
 spec:
@@ -1030,7 +1030,7 @@ rule is not applicable internally in the mesh as the gateway list omits
 the reserved name &ldquo;mesh&rdquo;.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: bookinfo-Mongo
 spec:
@@ -1127,7 +1127,7 @@ pre-specified error code. The following example will return an HTTP
 400 error code for 10% of the requests to the &ldquo;ratings&rdquo; service &ldquo;v1&rdquo;.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-rule
 spec:
@@ -1201,7 +1201,7 @@ in 10% of the requests to the &ldquo;v1&rdquo; version of the &ldquo;reviews&rdq
 service from all pods with label env: prod</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-rule
 spec:
@@ -1274,7 +1274,7 @@ starts with /ratings/v2/ and the request contains a &ldquo;cookie&rdquo; with va
 &ldquo;user=jason&rdquo;.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-rule
 spec:
@@ -1430,7 +1430,7 @@ requests for /v1/getProductRatings API on the ratings service to
 /v1/bookRatings provided by the bookratings service.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-rule
 spec:
@@ -1484,7 +1484,7 @@ example, the following rule sets the maximum number of retries to 3 when
 calling ratings:v1 service, with a 2s timeout per retry attempt.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-rule
 spec:
@@ -1539,7 +1539,7 @@ demonstrates how to rewrite the URL prefix for api call (/ratings) to
 ratings service before making the actual API call.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-rule
 spec:
@@ -2151,7 +2151,7 @@ the sidecars in the mesh (indicated by the reserved gateway name
 &ldquo;mesh&rdquo;).</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: my-rule
 spec:
@@ -2603,7 +2603,7 @@ following routing rule forwards traffic arriving at port 2379 named
 Mongo from 172.17.16.* subnet to another Mongo server on port 5555.</p>
 
 <pre><code>apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+kind: V1alpha2RouteRule
 metadata:
   name: bookinfo-Mongo
 spec:

--- a/routing/v1alpha2/route_rule.pb.go
+++ b/routing/v1alpha2/route_rule.pb.go
@@ -33,7 +33,7 @@ var _ = math.Inf
 // "mesh").
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -180,7 +180,7 @@ func (m *RouteRule) GetTcp() []*TCPRoute {
 // to subset v2, in a kubernetes environment.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -226,7 +226,7 @@ func (m *RouteRule) GetTcp() []*TCPRoute {
 // pool.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-productpage-rule
 //     spec:
@@ -242,7 +242,7 @@ func (m *RouteRule) GetTcp() []*TCPRoute {
 // service wikipedia.org, as there is no internal service of that name.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-wiki-rule
 //     spec:
@@ -452,7 +452,7 @@ func (m *HTTPRoute) GetAppendHeaders() map[string]string {
 // Mongo from 172.17.16.* subnet to another Mongo server on port 5555.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: bookinfo-Mongo
 //     spec:
@@ -506,7 +506,7 @@ func (m *TCPRoute) GetRoute() []*DestinationWeight {
 // "user=jason".
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -667,7 +667,7 @@ func (m *HTTPMatchRequest) GetGateways() []string {
 // "v1".
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -808,7 +808,7 @@ func (m *L4MatchAttributes) GetGateways() []string {
 // /v1/bookRatings provided by the bookratings service.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -859,7 +859,7 @@ func (m *HTTPRedirect) GetAuthority() string {
 // ratings service before making the actual API call.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -1051,7 +1051,7 @@ func _StringMatch_OneofSizer(msg proto.Message) (n int) {
 // calling ratings:v1 service, with a 2s timeout per retry attempt.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -1104,7 +1104,7 @@ func (m *HTTPRetry) GetPerTryTimeout() *google_protobuf.Duration {
 // exposes X-Foo-bar header and sets an expiry period of 1 day.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -1238,7 +1238,7 @@ func (m *HTTPFaultInjection) GetAbort() *HTTPFaultInjection_Abort {
 // service from all pods with label env: prod
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -1396,7 +1396,7 @@ func _HTTPFaultInjection_Delay_OneofSizer(msg proto.Message) (n int) {
 // 400 error code for 10% of the requests to the "ratings" service "v1".
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:

--- a/routing/v1alpha2/route_rule.proto
+++ b/routing/v1alpha2/route_rule.proto
@@ -71,7 +71,7 @@ option go_package = "istio.io/api/routing/v1alpha2";
 // "mesh").
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -188,7 +188,7 @@ message RouteRule {
 // to subset v2, in a kubernetes environment.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -234,7 +234,7 @@ message RouteRule {
 // pool.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-productpage-rule
 //     spec:
@@ -250,7 +250,7 @@ message RouteRule {
 // service wikipedia.org, as there is no internal service of that name.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-wiki-rule
 //     spec:
@@ -364,7 +364,7 @@ message HTTPRoute {
 // Mongo from 172.17.16.* subnet to another Mongo server on port 5555.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: bookinfo-Mongo
 //     spec:
@@ -400,7 +400,7 @@ message TCPRoute {
 // "user=jason".
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -507,7 +507,7 @@ message HTTPMatchRequest {
 // "v1".
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -594,7 +594,7 @@ message L4MatchAttributes {
 // /v1/bookRatings provided by the bookratings service.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -627,7 +627,7 @@ message HTTPRedirect {
 // ratings service before making the actual API call.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -675,7 +675,7 @@ message StringMatch {
 // calling ratings:v1 service, with a 2s timeout per retry attempt.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -710,7 +710,7 @@ message HTTPRetry {
 // exposes X-Foo-bar header and sets an expiry period of 1 day.
 //
 //     apiVersion: config.istio.io/v1alpha2
-//     kind: RouteRule
+//     kind: V1alpha2RouteRule
 //     metadata:
 //       name: my-rule
 //     spec:
@@ -784,7 +784,7 @@ message HTTPFaultInjection {
   // service from all pods with label env: prod
   //
   //     apiVersion: config.istio.io/v1alpha2
-  //     kind: RouteRule
+  //     kind: V1alpha2RouteRule
   //     metadata:
   //       name: my-rule
   //     spec:
@@ -828,7 +828,7 @@ message HTTPFaultInjection {
   // 400 error code for 10% of the requests to the "ratings" service "v1".
   //
   //     apiVersion: config.istio.io/v1alpha2
-  //     kind: RouteRule
+  //     kind: V1alpha2RouteRule
   //     metadata:
   //       name: my-rule
   //     spec:


### PR DESCRIPTION
since there is discussion of having a release with both v1alpha2 and v1alpha1 rules present, we need to update the inline examples with the correct kind for route rules so users have valid v1alpha2 examples to play with