### PR TITLE
Switch to the actual gogo googleapis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ importmaps := \
 	google/protobuf/descriptor.proto=github.com/gogo/protobuf/protoc-gen-gogo/descriptor \
 	google/protobuf/duration.proto=github.com/gogo/protobuf/types \
 	google/protobuf/timestamp.proto=github.com/gogo/protobuf/types \
-	google/rpc/status.proto=istio.io/gogo-genproto/googleapis/google/rpc \
-	google/rpc/code.proto=istio.io/gogo-genproto/googleapis/google/rpc \
-	google/rpc/error_details.proto=istio.io/gogo-genproto/googleapis/google/rpc \
+	google/rpc/status.proto=github.com/gogo/googleapis/google/rpc \
+	google/rpc/code.proto=github.com/gogo/googleapis/google/rpc \
+	google/rpc/error_details.proto=github.com/gogo/googleapis/google/rpc \
 
 # generate mapping directive with M<proto>:<go pkg>, format for each proto file
 mapping_with_spaces := $(foreach map,$(importmaps),M$(map),)

--- a/mixer/v1/check.pb.go
+++ b/mixer/v1/check.pb.go
@@ -8,7 +8,7 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/protobuf/gogoproto"
 import _ "github.com/gogo/protobuf/types"
-import google_rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+import google_rpc "github.com/gogo/googleapis/google/rpc"
 
 import time "time"
 


### PR DESCRIPTION
Without it, we get a panic about dual registration of googleapis protos:
https://storage.googleapis.com/istio-prow/pull/istio_istio/4300/istio-unit-tests/2402/build-log.txt

Signed-off-by: Kuat Yessenov <kuat@google.com>