### PR TITLE
Syntax fix to the examples in the docs of networking

### DIFF
--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -799,7 +799,7 @@ func (m *OutlierDetection_HTTPSettings) GetMaxEjectionPercent() int32 {
 //     metadata:
 //       name: tls-foo
 //     spec:
-//       name: *.foo.com
+//       name: "*.foo.com"
 //       trafficPolicy:
 //         tls:
 //           mode: SIMPLE

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -386,7 +386,7 @@ message OutlierDetection {
 //     metadata:
 //       name: tls-foo
 //     spec:
-//       name: *.foo.com
+//       name: "*.foo.com"
 //       trafficPolicy:
 //         tls:
 //           mode: SIMPLE

--- a/networking/v1alpha3/external_service.pb.go
+++ b/networking/v1alpha3/external_service.pb.go
@@ -137,7 +137,7 @@ func (ExternalService_Discovery) EnumDescriptor() ([]byte, []int) {
 //       name: external-svc-wildcard-example
 //     spec:
 //       hosts:
-//       - *.bar.com
+//       - "*.bar.com"
 //       ports:
 //       - number: 80
 //         name: http

--- a/networking/v1alpha3/external_service.pb.go
+++ b/networking/v1alpha3/external_service.pb.go
@@ -167,13 +167,13 @@ func (ExternalService_Discovery) EnumDescriptor() ([]byte, []int) {
 //       endpoints:
 //       - address: us.foo.bar.com
 //         ports:
-//         - https: 8443
+//           https: 8443
 //       - address: uk.foo.bar.com
 //         ports:
-//         - https: 9443
+//           https: 9443
 //       - address: in.foo.bar.com
 //         ports:
-//         - https: 7443
+//           https: 7443
 //
 // and a destination rule to initiate TLS connections to the external service.
 //

--- a/networking/v1alpha3/external_service.proto
+++ b/networking/v1alpha3/external_service.proto
@@ -103,7 +103,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //       name: external-svc-wildcard-example
 //     spec:
 //       hosts:
-//       - *.bar.com
+//       - "*.bar.com"
 //       ports:
 //       - number: 80
 //         name: http

--- a/networking/v1alpha3/external_service.proto
+++ b/networking/v1alpha3/external_service.proto
@@ -133,13 +133,13 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //       endpoints:
 //       - address: us.foo.bar.com
 //         ports:
-//         - https: 8443
+//           https: 8443
 //       - address: uk.foo.bar.com
 //         ports:
-//         - https: 9443
+//           https: 9443
 //       - address: in.foo.bar.com
 //         ports:
-//         - https: 7443
+//           https: 7443
 //
 // and a destination rule to initiate TLS connections to the external service.
 //

--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -678,7 +678,7 @@ metadata:
   name: external-svc-wildcard-example
 spec:
   hosts:
-  - *.bar.com
+  - &quot;*.bar.com&quot;
   ports:
   - number: 80
     name: http
@@ -2458,7 +2458,7 @@ kind: DestinationRule
 metadata:
   name: tls-foo
 spec:
-  name: *.foo.com
+  name: &quot;*.foo.com&quot;
   trafficPolicy:
     tls:
       mode: SIMPLE

--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -709,13 +709,13 @@ spec:
   endpoints:
   - address: us.foo.bar.com
     ports:
-    - https: 8443
+      https: 8443
   - address: uk.foo.bar.com
     ports:
-    - https: 9443
+      https: 9443
   - address: in.foo.bar.com
     ports:
-    - https: 7443
+      https: 7443
 </code></pre>
 
 <p>and a destination rule to initiate TLS connections to the external service.</p>


### PR DESCRIPTION
Without these fixes, istioctl won't accept those examples
- Quoted names with wildcard
- Removed redundant dash before keys of a map