### PR TITLE
Unix domain sockets on ServiceEntry

### DIFF
--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -2181,6 +2181,27 @@ spec:
   resolution: NONE
 </code></pre>
 
+<p>The following example demonstrates a service that is available via a
+Unix Domain Socket on the host of the client. The resolution must be
+set to STATIC to use unix address endpoints.</p>
+
+<pre><code>apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: unix-domain-socket-example
+spec:
+  hosts:
+  - &quot;example.unix.local&quot;
+  location: MESH_EXTERNAL
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  resolution: STATIC
+  endpoints:
+  - address: unix:///var/run/example/socket
+</code></pre>
+
 <p>For HTTP based services, it is possible to create a VirtualService
 backed by multiple DNS addressible endpoints. In such a scenario, the
 application can use the HTTP_PROXY environment variable to transparently
@@ -2271,7 +2292,8 @@ solely based on the destination port. In such scenarios, the port on
 which the service is being accessed must not be shared by any other
 service in the mesh. In other words, the sidecar will behave as a
 simple TCP proxy, forwarding incoming traffic on a specified port to
-the specified destination endpoint IP/host.</p>
+the specified destination endpoint IP/host. Unix domain socket
+addresses are not supported in this field.</p>
 
 </td>
 </tr>
@@ -2279,7 +2301,9 @@ the specified destination endpoint IP/host.</p>
 <td><code>ports</code></td>
 <td><code><a href="#Port">Port[]</a></code></td>
 <td>
-<p>REQUIRED. The ports associated with the external service.</p>
+<p>REQUIRED. The ports associated with the external service. If the
+Endpoints are unix domain socket addresses, there must be exactly one
+port.</p>
 
 </td>
 </tr>
@@ -2331,8 +2355,9 @@ the mesh service.</p>
 <td><code>string</code></td>
 <td>
 <p>REQUIRED: Address associated with the network endpoint without the
-port ( IP or fully qualified domain name without wildcards). Domain
-names can be used if and only if the resolution is set to DNS.</p>
+port.  Domain names can be used if and only if the resolution is set
+to DNS, and must be fully-qualified without wildcards. Use the form
+unix:///absolute/path/to/socket for unix domain socket endpoints.</p>
 
 </td>
 </tr>
@@ -2342,7 +2367,7 @@ names can be used if and only if the resolution is set to DNS.</p>
 <td>
 <p>Set of ports associated with the endpoint. The ports must be
 associated with a port name that was declared as part of the
-service.</p>
+service. Do not use for unix:// addresses.</p>
 
 </td>
 </tr>
@@ -2443,7 +2468,8 @@ during request processing. If no endpoints are specified, the proxy
 will resolve the DNS address specified in the hosts field, if
 wildcards are not used. If endpoints are specified, the DNS
 addresses specified in the endpoints will be resolved to determine
-the destination IP address.</p>
+the destination IP address.  DNS resolution cannot be used with unix
+domain socket endpoints.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -86,6 +86,27 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //         protocol: HTTP
 //       resolution: NONE
 //
+//
+// The following example demonstrates a service that is available via a
+// Unix Domain Socket on the host of the client. The resolution must be
+// set to STATIC to use unix address endpoints.
+//
+//     apiVersion: networking.istio.io/v1alpha3
+//     kind: ServiceEntry
+//     metadata:
+//       name: unix-domain-socket-example
+//     spec:
+//       hosts:
+//       - "example.unix.local"
+//       location: MESH_EXTERNAL
+//       ports:
+//       - number: 80
+//         name: http
+//         protocol: HTTP
+//       resolution: STATIC
+//       endpoints:
+//       - address: unix:///var/run/example/socket
+//
 // For HTTP based services, it is possible to create a VirtualService
 // backed by multiple DNS addressible endpoints. In such a scenario, the
 // application can use the HTTP_PROXY environment variable to transparently
@@ -156,10 +177,13 @@ message ServiceEntry {
   // which the service is being accessed must not be shared by any other
   // service in the mesh. In other words, the sidecar will behave as a
   // simple TCP proxy, forwarding incoming traffic on a specified port to
-  // the specified destination endpoint IP/host.
+  // the specified destination endpoint IP/host. Unix domain socket
+  // addresses are not supported in this field.
   repeated string addresses = 2;
 
-  // REQUIRED. The ports associated with the external service.
+  // REQUIRED. The ports associated with the external service. If the
+  // Endpoints are unix domain socket addresses, there must be exactly one
+  // port.
   repeated Port ports = 3;
 
   // Location specifies whether the service is part of Istio mesh or
@@ -211,7 +235,8 @@ message ServiceEntry {
     // will resolve the DNS address specified in the hosts field, if
     // wildcards are not used. If endpoints are specified, the DNS
     // addresses specified in the endpoints will be resolved to determine
-    // the destination IP address.
+    // the destination IP address.  DNS resolution cannot be used with unix
+    // domain socket endpoints.
     DNS = 2;
   };
 
@@ -223,13 +248,14 @@ message ServiceEntry {
   // the mesh service.
   message Endpoint {
     // REQUIRED: Address associated with the network endpoint without the
-    // port ( IP or fully qualified domain name without wildcards). Domain
-    // names can be used if and only if the resolution is set to DNS.
+    // port.  Domain names can be used if and only if the resolution is set
+    // to DNS, and must be fully-qualified without wildcards. Use the form
+    // unix:///absolute/path/to/socket for unix domain socket endpoints.
     string address = 1;
 
     // Set of ports associated with the endpoint. The ports must be
     // associated with a port name that was declared as part of the
-    // service.
+    // service. Do not use for unix:// addresses.
     map<string, uint32> ports = 2;
     
     // One or more labels associated with the endpoint.


### PR DESCRIPTION
Docstrings only.  Explains how to use ServiceEntry for unix domain socket endpoints.

Signed-off-by: Spike Curtis <spike@tigera.io>