### PR TITLE
clarify wildcard usage in gateway server hosts

### DIFF
--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -92,13 +92,13 @@ func (Server_TLSOptions_TLSmode) EnumDescriptor() ([]byte, []int) {
 //           name: http-wildcard
 //           protocol: HTTP
 //         hosts:
-//         - "*"
+//         - "*.bookinfo.com"
 //       - port:
 //           number: 2379 # to expose internal service via external port 2379
 //           name: mongo
 //           protocol: MONGO
 //         hosts:
-//         - "*"
+//         - "*.bookinfo.com"
 //
 // The Gateway specification above describes the L4-L6 properties of a load
 // balancer. A `VirtualService` can then be bound to a gateway to control
@@ -111,7 +111,7 @@ func (Server_TLSOptions_TLSmode) EnumDescriptor() ([]byte, []int) {
 // an internal reviews service on port 9080. In addition, requests
 // containing the cookie "user: dev-123" will be sent to special port 7777
 // in the qa version. The same rule is also applicable inside the mesh for
-// requests to the r"eviews.prod.svc.cluster.local" service. This rule is
+// requests to the "reviews.prod.svc.cluster.local" service. This rule is
 // applicable across ports 443, 9080. Note that "http://uk.bookinfo.com"
 // gets redirected to "https://uk.bookinfo.com" (i.e. 80 redirects to 443).
 //
@@ -266,7 +266,11 @@ type Server struct {
 	// REQUIRED. A list of hosts exposed by this gateway. At least one
 	// host is required. While typically applicable to
 	// HTTP services, it can also be used for TCP services using TLS with
-	// SNI. Standard DNS wildcard prefix syntax is permitted.
+	// SNI. May contain a wildcard prefix for the bottom-level domain of
+	// a domain name, e.g.`*.example.com`. Note that `prod.example.com`
+	// will be matched by the `prod.example.com` and `*.example.com` host
+	// names, but **not** by `*prod.example.com`, `*rod.example.com`,
+	// `*example.com`, `*.com` or `*`.
 	//
 	// **Note**: A `VirtualService` that is bound to a gateway must have one
 	// or more hosts that match the hosts specified in a server. The match

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -64,13 +64,13 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //           name: http-wildcard
 //           protocol: HTTP
 //         hosts:
-//         - "*"
+//         - "*.bookinfo.com"
 //       - port:
 //           number: 2379 # to expose internal service via external port 2379
 //           name: mongo
 //           protocol: MONGO
 //         hosts:
-//         - "*"
+//         - "*.bookinfo.com"
 //
 // The Gateway specification above describes the L4-L6 properties of a load
 // balancer. A `VirtualService` can then be bound to a gateway to control
@@ -83,7 +83,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // an internal reviews service on port 9080. In addition, requests
 // containing the cookie "user: dev-123" will be sent to special port 7777
 // in the qa version. The same rule is also applicable inside the mesh for
-// requests to the r"eviews.prod.svc.cluster.local" service. This rule is
+// requests to the "reviews.prod.svc.cluster.local" service. This rule is
 // applicable across ports 443, 9080. Note that "http://uk.bookinfo.com"
 // gets redirected to "https://uk.bookinfo.com" (i.e. 80 redirects to 443).
 //
@@ -221,7 +221,11 @@ message Server {
   // REQUIRED. A list of hosts exposed by this gateway. At least one
   // host is required. While typically applicable to
   // HTTP services, it can also be used for TCP services using TLS with
-  // SNI. Standard DNS wildcard prefix syntax is permitted.
+  // SNI. May contain a wildcard prefix for the bottom-level domain of
+  // a domain name, e.g.`*.example.com`. Note that `prod.example.com`
+  // will be matched by the `prod.example.com` and `*.example.com` host
+  // names, but **not** by `*prod.example.com`, `*rod.example.com`,
+  // `*example.com`, `*.com` or `*`.
   //
   // **Note**: A `VirtualService` that is bound to a gateway must have one
   // or more hosts that match the hosts specified in a server. The match
@@ -253,7 +257,7 @@ message Server {
 
     // Optional: Indicates whether connections to this port should be
     // secured using TLS. The value of this field determines how TLS is
-    // enforced.  
+    // enforced.
     TLSmode mode = 2;
 
     // REQUIRED if mode is `SIMPLE` or `MUTUAL`. The path to the file

--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -724,13 +724,13 @@ spec:
       name: http-wildcard
       protocol: HTTP
     hosts:
-    - &quot;*&quot;
+    - &quot;*.bookinfo.com&quot;
   - port:
       number: 2379 # to expose internal service via external port 2379
       name: mongo
       protocol: MONGO
     hosts:
-    - &quot;*&quot;
+    - &quot;*.bookinfo.com&quot;
 </code></pre>
 
 <p>The Gateway specification above describes the L4-L6 properties of a load
@@ -744,7 +744,7 @@ the forwarding of traffic arriving at a particular host or gateway port.</p>
 an internal reviews service on port 9080. In addition, requests
 containing the cookie &ldquo;user: dev-123&rdquo; will be sent to special port 7777
 in the qa version. The same rule is also applicable inside the mesh for
-requests to the r&rdquo;eviews.prod.svc.cluster.local&rdquo; service. This rule is
+requests to the &ldquo;reviews.prod.svc.cluster.local&rdquo; service. This rule is
 applicable across ports 443, 9080. Note that &ldquo;http://uk.bookinfo.com&rdquo;
 gets redirected to &ldquo;https://uk.bookinfo.com&rdquo; (i.e. 80 redirects to 443).</p>
 
@@ -1977,7 +1977,11 @@ connections</p>
 <p>REQUIRED. A list of hosts exposed by this gateway. At least one
 host is required. While typically applicable to
 HTTP services, it can also be used for TCP services using TLS with
-SNI. Standard DNS wildcard prefix syntax is permitted.</p>
+SNI. May contain a wildcard prefix for the bottom-level domain of
+a domain name, e.g.<code>*.example.com</code>. Note that <code>prod.example.com</code>
+will be matched by the <code>prod.example.com</code> and <code>*.example.com</code> host
+names, but <strong>not</strong> by <code>*prod.example.com</code>, <code>*rod.example.com</code>,
+<code>*example.com</code>, <code>*.com</code> or <code>*</code>.</p>
 
 <p><strong>Note</strong>: A <code>VirtualService</code> that is bound to a gateway must have one
 or more hosts that match the hosts specified in a server. The match


### PR DESCRIPTION
based on the documentation of Envoy sni_domains - https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener/listener.proto.html?highlight=sni_domains 

> May contain a wildcard prefix for the bottom-level domain of a domain name, e.g. *.example.com. Note that foo.example.com will be matched by foo.example.com and *.example.com SNI domain names, but not by *foo.example.com, *oo.example.com, *example.com, *.com or *.