### PR TITLE
attributes: add context reporter attributes

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -277,5 +277,5 @@
 - destination.container.name
 - destination.container.image
 
-- context.reporter.proxy
+- context.reporter.local
 - context.reporter.uid

--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -219,10 +219,10 @@
 - destination.namespace
 - destination.labels
 # destination.user is deprecated, please refer to destination.principal
-- destination.user 
+- destination.user
 
 # source.service is deprecated. please do not use moving forward.
-- source.service 
+- source.service
 
 # api attributes
 - api.service
@@ -276,3 +276,6 @@
 - destination.service.host
 - destination.container.name
 - destination.container.image
+
+- context.reporter.proxy
+- context.reporter.uid


### PR DESCRIPTION
`context.reporter.proxy` has values `client` or `server` for the two sidecars on the data path.
`context.reporter.uid` carries the UID value of the pod.

Signed-off-by: Kuat Yessenov <kuat@google.com>