### PR TITLE
hide unused fields in networking protos from docs

### DIFF
--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -440,15 +440,9 @@ DestinationRule.</p>
 <td><code>port</code></td>
 <td><code><a href="#PortSelector">PortSelector</a></code></td>
 <td>
-<p>Specifies the port on the host that is being addressed. Many services
-only expose a single port or label ports with the protocols they support,
-in these cases it is not required to explicitly select the port. Note that
-selection priority is to first match by name and then match by number.</p>
-
-<p>Names must comply with DNS label syntax (rfc1035) and therefore cannot
-collide with numbers. If there are multiple ports on a service with
-the same protocol the names should be of the form <protocol-name>-<DNS
-label>.</p>
+<p>Specifies the port on the host that is being addressed. If a service
+exposes only a single port it is not required to explicitly select the
+port.</p>
 
 </td>
 </tr>
@@ -935,22 +929,6 @@ not specified, all requests are aborted.</p>
 
 </td>
 </tr>
-<tr id="HTTPFaultInjection.Abort.grpc_status" class="oneof">
-<td><code>grpcStatus</code></td>
-<td><code>string (oneof)</code></td>
-<td>
-<p>(&ndash; NOT IMPLEMENTED &ndash;)</p>
-
-</td>
-</tr>
-<tr id="HTTPFaultInjection.Abort.http2_error" class="oneof">
-<td><code>http2Error</code></td>
-<td><code>string (oneof)</code></td>
-<td>
-<p>(&ndash; NOT IMPLEMENTED &ndash;)</p>
-
-</td>
-</tr>
 </tbody>
 </table>
 </section>
@@ -1010,16 +988,6 @@ unspecified, all request will be delayed.</p>
 <td>
 <p>REQUIRED. Add a fixed delay before forwarding the request. Format:
 1h/1m/1s/1ms. MUST be &gt;=1ms.</p>
-
-</td>
-</tr>
-<tr id="HTTPFaultInjection.Delay.exponential_delay" class="oneof">
-<td><code>exponentialDelay</code></td>
-<td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">google.protobuf.Duration (oneof)</a></code></td>
-<td>
-<p>(&ndash; Add a delay (based on an exponential function) before forwarding
-the request. mean delay needed to derive the exponential delay
-values &ndash;)</p>
 
 </td>
 </tr>
@@ -1860,7 +1828,7 @@ TCP-TLS is used to indicate secure connections to non HTTP services.</p>
 </section>
 <h2 id="PortSelector">PortSelector</h2>
 <section>
-<p>PortSelector specifies the name or number of a port to be used for
+<p>PortSelector specifies the number of a port to be used for
 matching or selection for final routing.</p>
 
 <table class="message-fields">
@@ -1877,14 +1845,6 @@ matching or selection for final routing.</p>
 <td><code>uint32 (oneof)</code></td>
 <td>
 <p>Valid port number</p>
-
-</td>
-</tr>
-<tr id="PortSelector.name" class="oneof">
-<td><code>name</code></td>
-<td><code>string (oneof)</code></td>
-<td>
-<p>Port name</p>
 
 </td>
 </tr>
@@ -2135,7 +2095,7 @@ metadata:
   name: external-svc-mongocluster
 spec:
   hosts:
-  - mymongodb.somedomain # not used
+  - mymongodb.somedomain
   addresses:
   - 192.192.192.192/24 # VIPs
   ports:

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -118,7 +118,7 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 //       name: external-svc-mongocluster
 //     spec:
 //       hosts:
-//       - mymongodb.somedomain # not used
+//       - mymongodb.somedomain
 //       addresses:
 //       - 192.192.192.192/24 # VIPs
 //       ports:

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -39,7 +39,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //       name: external-svc-mongocluster
 //     spec:
 //       hosts:
-//       - mymongodb.somedomain # not used
+//       - mymongodb.somedomain
 //       addresses:
 //       - 192.192.192.192/24 # VIPs
 //       ports:

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -288,15 +288,9 @@ type Destination struct {
 	// within the mesh. The subset must be defined in a corresponding
 	// DestinationRule.
 	Subset string `protobuf:"bytes,2,opt,name=subset,proto3" json:"subset,omitempty"`
-	// Specifies the port on the host that is being addressed. Many services
-	// only expose a single port or label ports with the protocols they support,
-	// in these cases it is not required to explicitly select the port. Note that
-	// selection priority is to first match by name and then match by number.
-	//
-	// Names must comply with DNS label syntax (rfc1035) and therefore cannot
-	// collide with numbers. If there are multiple ports on a service with
-	// the same protocol the names should be of the form <protocol-name>-<DNS
-	// label>.
+	// Specifies the port on the host that is being addressed. If a service
+	// exposes only a single port it is not required to explicitly select the
+	// port.
 	Port *PortSelector `protobuf:"bytes,3,opt,name=port" json:"port,omitempty"`
 }
 
@@ -1599,7 +1593,7 @@ func _HTTPFaultInjection_Abort_OneofSizer(msg proto.Message) (n int) {
 	return n
 }
 
-// PortSelector specifies the name or number of a port to be used for
+// PortSelector specifies the number of a port to be used for
 // matching or selection for final routing.
 type PortSelector struct {
 	// Types that are valid to be assigned to Port:

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -296,15 +296,9 @@ message Destination {
   // DestinationRule.
   string subset = 2;
 
-  // Specifies the port on the host that is being addressed. Many services
-  // only expose a single port or label ports with the protocols they support,
-  // in these cases it is not required to explicitly select the port. Note that
-  // selection priority is to first match by name and then match by number.
-  //
-  // Names must comply with DNS label syntax (rfc1035) and therefore cannot
-  // collide with numbers. If there are multiple ports on a service with
-  // the same protocol the names should be of the form <protocol-name>-<DNS
-  // label>.
+  // Specifies the port on the host that is being addressed. If a service
+  // exposes only a single port it is not required to explicitly select the
+  // port.
   PortSelector port = 3;
 }
 
@@ -836,9 +830,7 @@ message HTTPFaultInjection {
       // 1h/1m/1s/1ms. MUST be >=1ms.
       google.protobuf.Duration fixed_delay = 2;
 
-      // (-- Add a delay (based on an exponential function) before forwarding
-      // the request. mean delay needed to derive the exponential delay
-      // values --)
+      // $hide_from_docs
       google.protobuf.Duration exponential_delay = 3 ;
     }
   }
@@ -876,22 +868,22 @@ message HTTPFaultInjection {
       // REQUIRED. HTTP status code to use to abort the Http request.
       int32 http_status = 2;
 
-      // (-- NOT IMPLEMENTED --)
+      // $hide_from_docs
       string grpc_status = 3;
 
-      // (-- NOT IMPLEMENTED --)
+      // $hide_from_docs
       string http2_error = 4;
     }
   }
 }
 
-// PortSelector specifies the name or number of a port to be used for
+// PortSelector specifies the number of a port to be used for
 // matching or selection for final routing.
 message PortSelector {
   oneof port {
     // Valid port number
     uint32 number = 1;
-    // Port name
+    // $hide_from_docs
     string name = 2;
   }
 }


### PR DESCRIPTION
Especially hide portselector.name, which is not implemented.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>