### PR TITLE
Rename bytes_total to total_bytes

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -182,8 +182,10 @@
 # connection attributes
 - connection.id
 - connection.received.bytes
+# connection.received.bytes_total is deprecated; please use connection.received.total_bytes
 - connection.received.bytes_total
 - connection.sent.bytes
+# connection.sent.bytes_total is deprecated; please use connection.sent.total_bytes
 - connection.sent.bytes_total
 - connection.duration
 
@@ -279,3 +281,6 @@
 
 - context.reporter.local
 - context.reporter.uid
+
+- connection.received.total_bytes
+- connection.sent.total_bytes


### PR DESCRIPTION
This PR takes over for the older PR meant to rename the `connection.(sent|received).bytes_total`
attributes to better align with the style guide for attributes.