### PR TITLE
attributes: grpc message and status

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -279,3 +279,7 @@
 
 - context.reporter.local
 - context.reporter.uid
+
+# gRPC trailer return status support
+- response.grpc-status
+- response.grpc-message


### PR DESCRIPTION
Add attributes to hold gRPC return status. 
gRPC uses h2 trailers which are missing right now in the attribute vocabulary (we only have h2 headers).

xref: https://github.com/istio/proxy/issues/1805
Signed-off-by: Kuat Yessenov <kuat@google.com>