### PR TITLE
Fix VirtualService in Gateway example for v1alpha3

### DIFF
--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -138,7 +138,7 @@ func (Server_TLSOptions_TLSmode) EnumDescriptor() ([]byte, []int) {
 //     - destination:
 //         port:
 //           number: 7777
-//         name: reviews.qa.svc.cluster.local
+//         host: reviews.qa.svc.cluster.local
 //   - match:
 //       uri:
 //         prefix: /reviews/
@@ -146,10 +146,10 @@ func (Server_TLSOptions_TLSmode) EnumDescriptor() ([]byte, []int) {
 //     - destination:
 //         port:
 //           number: 9080 # can be omitted if its the only port for reviews
-//         name: reviews.prod.svc.cluster.local
+//         host: reviews.prod.svc.cluster.local
 //       weight: 80
 //     - destination:
-//         name: reviews.qa.svc.cluster.local
+//         host: reviews.qa.svc.cluster.local
 //       weight: 20
 // ```
 //
@@ -175,7 +175,7 @@ func (Server_TLSOptions_TLSmode) EnumDescriptor() ([]byte, []int) {
 //       sourceSubnet: "172.17.16.0/24"
 //     route:
 //     - destination:
-//         name: mongo.prod.svc.cluster.local
+//         host: mongo.prod.svc.cluster.local
 // ```
 type Gateway struct {
 	// REQUIRED: A list of server specifications.

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -110,7 +110,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //     - destination:
 //         port:
 //           number: 7777
-//         name: reviews.qa.svc.cluster.local
+//         host: reviews.qa.svc.cluster.local
 //   - match:
 //       uri:
 //         prefix: /reviews/
@@ -118,10 +118,10 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //     - destination:
 //         port:
 //           number: 9080 # can be omitted if its the only port for reviews
-//         name: reviews.prod.svc.cluster.local
+//         host: reviews.prod.svc.cluster.local
 //       weight: 80
 //     - destination:
-//         name: reviews.qa.svc.cluster.local
+//         host: reviews.qa.svc.cluster.local
 //       weight: 20
 // ```
 //
@@ -147,7 +147,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //       sourceSubnet: "172.17.16.0/24"
 //     route:
 //     - destination:
-//         name: mongo.prod.svc.cluster.local
+//         host: mongo.prod.svc.cluster.local
 // ```
 message Gateway {
   // REQUIRED: A list of server specifications.

--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -765,7 +765,7 @@ spec:
     - destination:
         port:
           number: 7777
-        name: reviews.qa.svc.cluster.local
+        host: reviews.qa.svc.cluster.local
   - match:
       uri:
         prefix: /reviews/
@@ -773,10 +773,10 @@ spec:
     - destination:
         port:
           number: 9080 # can be omitted if its the only port for reviews
-        name: reviews.prod.svc.cluster.local
+        host: reviews.prod.svc.cluster.local
       weight: 80
     - destination:
-        name: reviews.qa.svc.cluster.local
+        host: reviews.qa.svc.cluster.local
       weight: 20
 </code></pre>
 
@@ -801,7 +801,7 @@ spec:
       sourceSubnet: &quot;172.17.16.0/24&quot;
     route:
     - destination:
-        name: mongo.prod.svc.cluster.local
+        host: mongo.prod.svc.cluster.local
 </code></pre>
 
 <table class="message-fields">

--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -765,7 +765,7 @@ spec:
     - destination:
         port:
           number: 7777
-        host: reviews.qa.svc.cluster.local
+        name: reviews.qa.svc.cluster.local
   - match:
       uri:
         prefix: /reviews/
@@ -773,10 +773,10 @@ spec:
     - destination:
         port:
           number: 9080 # can be omitted if its the only port for reviews
-        host: reviews.prod.svc.cluster.local
+        name: reviews.prod.svc.cluster.local
       weight: 80
     - destination:
-        host: reviews.qa.svc.cluster.local
+        name: reviews.qa.svc.cluster.local
       weight: 20
 </code></pre>
 
@@ -801,7 +801,7 @@ spec:
       sourceSubnet: &quot;172.17.16.0/24&quot;
     route:
     - destination:
-        host: mongo.prod.svc.cluster.local
+        name: mongo.prod.svc.cluster.local
 </code></pre>
 
 <table class="message-fields">


### PR DESCRIPTION
Correct destination field from "name" to "host" in VirtualService for Gateway example.