### PR TITLE
[Proposal] Generate README.md files for all packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ repo_dir = .
 docker_gen = /usr/bin/protoc -I/protobuf -I$(repo_dir)
 out_path = $(OUT_PATH)
 else
-gen_img := gcr.io/istio-testing/protoc:2018-06-12
+gen_img := gcr.io/istio-testing/protoc:2018-06-14
 pwd := $(shell pwd)
 mount_dir := /src
 repo_dir := istio.io/api
@@ -74,6 +74,12 @@ gogoslick_plugin := $(gogoslick_plugin_prefix)$(gogo_mapping):$(out_path)
 protoc_gen_docs_plugin := --docs_out=warnings=true,mode=html_fragment_with_front_matter:$(repo_dir)/
 
 #####################
+# markdown generator
+#####################
+
+protoc_markdown_plugin := --doc_opt=markdown,README.md --doc_out=$(repo_dir)/
+
+#####################
 # Generation Rules
 #####################
 
@@ -103,13 +109,13 @@ broker_v1_path := broker/dev
 broker_v1_protos := $(shell find $(broker_v1_path) -type f -name '*.proto' | sort)
 broker_v1_pb_gos := $(broker_v1_protos:.proto=.pb.go)
 broker_v1_pb_pythons := $(broker_v1_protos:.proto=_pb2.py)
-broker_v1_pb_doc := $(broker_v1_path)/istio.broker.dev.pb.html
+broker_v1_pb_doc := $(broker_v1_path)/istio.broker.dev.pb.html $(broker_v1_path)/README.md
 
 generate-broker-go: $(broker_v1_pb_gos) $(broker_v1_pb_doc)
 
 $(broker_v1_pb_gos) $(broker_v1_pb_doc): $(broker_v1_protos)
 	## Generate broker/dev/*.pb.go + $(broker_v1_pb_doc)
-	@$(docker_gen) $(protoc_gen_go_plugin) $(protoc_gen_docs_plugin)$(broker_v1_path) $^
+	@$(docker_gen) $(protoc_gen_go_plugin) $(protoc_markdown_plugin)$(broker_v1_path) $(protoc_gen_docs_plugin)$(broker_v1_path) $^
 
 generate-broker-python: $(broker_v1_pb_pythons)
 
@@ -129,13 +135,13 @@ config_mcp_path := config/mcp/v1alpha1
 config_mcp_protos := $(shell find $(config_mcp_path) -type f -name '*.proto' | sort)
 config_mcp_pb_gos := $(config_mcp_protos:.proto=.pb.go)
 config_mcp_pb_pythons := $(config_mcp_protos:.proto=_pb2.py)
-config_mcp_pb_doc := $(config_mcp_path)/istio.config.mcp.v1alpha1.pb.html
+config_mcp_pb_doc := $(config_mcp_path)/istio.config.mcp.v1alpha1.pb.html $(config_mcp_path)/README.md
 
 generate-config-mcp-go: $(config_mcp_pb_gos) $(config_mcp_pb_doc)
 
 $(config_mcp_pb_gos) $(config_mcp_pb_doc): $(config_mcp_protos)
 	## Generate config/mcp/v1alpha1/*.pb.go + $(config_mcp_pb_doc)
-	@$(docker_gen) $(protoc_gen_go_plugin) $(protoc_gen_docs_plugin)$(config_mcp_path) $^
+	@$(docker_gen) $(protoc_gen_go_plugin) $(protoc_markdown_plugin)$(config_mcp_path) $(protoc_gen_docs_plugin)$(config_mcp_path) $^
 
 generate-config-mcp-python: $(config_mcp_pb_pythons)
 
@@ -155,13 +161,13 @@ mesh_path := mesh/v1alpha1
 mesh_protos := $(shell find $(mesh_path) -type f -name '*.proto' | sort)
 mesh_pb_gos := $(mesh_protos:.proto=.pb.go)
 mesh_pb_pythons := $(mesh_protos:.proto=_pb2.py)
-mesh_pb_doc := $(mesh_path)/istio.mesh.v1alpha1.pb.html
+mesh_pb_doc := $(mesh_path)/istio.mesh.v1alpha1.pb.html $(mesh_path)/README.md
 
 generate-mesh-go: $(mesh_pb_gos) $(mesh_pb_doc)
 
 $(mesh_pb_gos) $(mesh_pb_doc): $(mesh_protos)
 	## Generate mesh/v1alpha1/*.pb.go + $(mesh_pb_doc)
-	@$(docker_gen) $(protoc_gen_go_plugin) $(protoc_gen_docs_plugin)$(mesh_path) $^
+	@$(docker_gen) $(protoc_gen_go_plugin) $(protoc_markdown_plugin)$(mesh_path) $(protoc_gen_docs_plugin)$(mesh_path) $^
 
 generate-mesh-python: $(mesh_pb_pythons)
 
@@ -181,25 +187,25 @@ mixer_v1_path := mixer/v1
 mixer_v1_protos :=  $(shell find $(mixer_v1_path) -maxdepth 1 -type f -name '*.proto' | sort)
 mixer_v1_pb_gos := $(mixer_v1_protos:.proto=.pb.go)
 mixer_v1_pb_pythons := $(mixer_v1_protos:.proto=_pb2.py)
-mixer_v1_pb_doc := $(mixer_v1_path)/istio.mixer.v1.pb.html
+mixer_v1_pb_doc := $(mixer_v1_path)/istio.mixer.v1.pb.html $(mixer_v1_path)/README.md
 
 mixer_config_client_path := mixer/v1/config/client
 mixer_config_client_protos := $(shell find $(mixer_config_client_path) -maxdepth 1 -type f -name '*.proto' | sort)
 mixer_config_client_pb_gos := $(mixer_config_client_protos:.proto=.pb.go)
 mixer_config_client_pb_pythons := $(mixer_config_client_protos:.proto=_pb2.py)
-mixer_config_client_pb_doc := $(mixer_config_client_path)/istio.mixer.v1.config.client.pb.html
+mixer_config_client_pb_doc := $(mixer_config_client_path)/istio.mixer.v1.config.client.pb.html $(mixer_config_client_path)/README.md
 
 mixer_adapter_model_v1beta1_path := mixer/adapter/model/v1beta1
 mixer_adapter_model_v1beta1_protos := $(shell find $(mixer_adapter_model_v1beta1_path) -maxdepth 1 -type f -name '*.proto' | sort)
 mixer_adapter_model_v1beta1_pb_gos := $(mixer_adapter_model_v1beta1_protos:.proto=.pb.go)
 mixer_adapter_model_v1beta1_pb_pythons := $(mixer_adapter_model_v1beta1_protos:.proto=_pb2.py)
-mixer_adapter_model_v1beta1_pb_doc := $(mixer_adapter_model_v1beta1_path)/istio.mixer.adapter.model.v1beta1.pb.html
+mixer_adapter_model_v1beta1_pb_doc := $(mixer_adapter_model_v1beta1_path)/istio.mixer.adapter.model.v1beta1.pb.html $(mixer_adapter_model_v1beta1_path)/README.md
 
 policy_v1beta1_path := policy/v1beta1
 policy_v1beta1_protos := $(shell find $(policy_v1beta1_path) -maxdepth 1 -type f -name '*.proto' | sort)
 policy_v1beta1_pb_gos := $(policy_v1beta1_protos:.proto=.pb.go)
 policy_v1beta1_pb_pythons := $(policy_v1beta1_protos:.proto=_pb2.py)
-policy_v1beta1_pb_doc := $(policy_v1beta1_path)/istio.policy.v1beta1.pb.html
+policy_v1beta1_pb_doc := $(policy_v1beta1_path)/istio.policy.v1beta1.pb.html $(policy_v1beta1_path)/README.md
 
 generate-mixer-go: \
 	$(mixer_v1_pb_gos) $(mixer_v1_pb_doc) \
@@ -209,19 +215,19 @@ generate-mixer-go: \
 
 $(mixer_v1_pb_gos) $(mixer_v1_pb_doc): $(mixer_v1_protos)
 	## Generate mixer/v1/*.pb.go + $(mixer_v1_pb_doc)
-	@$(docker_gen) $(gogoslick_plugin) $(protoc_gen_docs_plugin)$(mixer_v1_path) $^
+	@$(docker_gen) $(gogoslick_plugin) $(protoc_markdown_plugin)$(mixer_v1_path) $(protoc_gen_docs_plugin)$(mixer_v1_path) $^
 
 $(mixer_config_client_pb_gos) $(mixer_config_client_pb_doc): $(mixer_config_client_protos)
 	## Generate mixer/v1/config/client/*.pb.go + $(mixer_config_client_pb_doc)
-	@$(docker_gen) $(gogoslick_plugin) $(protoc_gen_docs_plugin)$(mixer_config_client_path) $^
+	@$(docker_gen) $(gogoslick_plugin) $(protoc_markdown_plugin)$(mixer_config_client_path) $(protoc_gen_docs_plugin)$(mixer_config_client_path) $^
 
 $(mixer_adapter_model_v1beta1_pb_gos) $(mixer_adapter_model_v1beta1_pb_doc) : $(mixer_adapter_model_v1beta1_protos)
 	## Generate mixer/adapter/model/v1beta1/*.pb.go + $(mixer_adapter_model_v1beta1_pb_doc)
-	@$(docker_gen) $(gogoslick_plugin) $(protoc_gen_docs_plugin)$(mixer_adapter_model_v1beta1_path) $^
+	@$(docker_gen) $(gogoslick_plugin) $(protoc_markdown_plugin)$(mixer_adapter_model_v1beta1_path) $(protoc_gen_docs_plugin)$(mixer_adapter_model_v1beta1_path) $^
 
 $(policy_v1beta1_pb_gos) $(policy_v1beta1_pb_doc) : $(policy_v1beta1_protos)
 	## Generate policy/v1beta1/*.pb.go + $(policy_v1beta1_pb_doc)
-	@$(docker_gen) $(gogoslick_plugin) $(protoc_gen_docs_plugin)$(policy_v1beta1_path) $^
+	@$(docker_gen) $(gogoslick_plugin) $(protoc_markdown_plugin)$(policy_v1beta1_path) $(protoc_gen_docs_plugin)$(policy_v1beta1_path) $^
 	## Generate policy/v1beta1/fixed_cfg.pb.go (requires alternate plugin and sed scripting due to issues with google.protobuf.Struct
 	@$(docker_gen) $(gogo_plugin) policy/v1beta1/cfg.proto
 	@if [ -f "policy/v1beta1/cfg.pb.go" ]; then\
@@ -268,23 +274,23 @@ routing_v1alpha1_path := routing/v1alpha1
 routing_v1alpha1_protos := $(shell find $(routing_v1alpha1_path) -type f -name '*.proto' | sort)
 routing_v1alpha1_pb_gos := $(routing_v1alpha1_protos:.proto=.pb.go)
 routing_v1alpha1_pb_pythons := $(routing_v1alpha1_protos:.proto=_pb2.py)
-routing_v1alpha1_pb_doc := $(routing_v1alpha1_path)/istio.routing.v1alpha1.pb.html
+routing_v1alpha1_pb_doc := $(routing_v1alpha1_path)/istio.routing.v1alpha1.pb.html $(routing_v1alpha1_path)/README.md
 
 routing_v1alpha3_path := networking/v1alpha3
 routing_v1alpha3_protos := $(shell find networking/v1alpha3 -type f -name '*.proto' | sort)
 routing_v1alpha3_pb_gos := $(routing_v1alpha3_protos:.proto=.pb.go)
 routing_v1alpha3_pb_pythons := $(routing_v1alpha3_protos:.proto=_pb2.py)
-routing_v1alpha3_pb_doc := $(routing_v1alpha3_path)/istio.routing.v1alpha3.pb.html
+routing_v1alpha3_pb_doc := $(routing_v1alpha3_path)/istio.routing.v1alpha3.pb.html $(routing_v1alpha3_path)/README.md
 
 generate-routing-go: $(routing_v1alpha1_pb_gos) $(routing_v1alpha1_pb_doc) $(routing_v1alpha3_pb_gos) $(routing_v1alpha3_pb_doc)
 
 $(routing_v1alpha1_pb_gos) $(routing_v1alpha1_pb_doc): $(routing_v1alpha1_protos)
 	## Generate routing/v1alpha1/*.pb.go +
-	@$(docker_gen) $(protoc_gen_go_plugin) $(protoc_gen_docs_plugin)$(routing_v1alpha1_path) $^
+	$(docker_gen) $(protoc_gen_go_plugin) $(protoc_markdown_plugin)$(routing_v1alpha1_path) $(protoc_gen_docs_plugin)$(routing_v1alpha1_path) $^
 
 $(routing_v1alpha3_pb_gos) $(routing_v1alpha3_pb_doc): $(routing_v1alpha3_protos)
 	## Generate networking/v1alpha3/*.pb.go
-	@$(docker_gen) $(gogofast_plugin) $(protoc_gen_docs_plugin)$(routing_v1alpha3_path) $^
+	@$(docker_gen) $(gogofast_plugin) $(protoc_markdown_plugin)$(routing_v1alpha3_path) $(protoc_gen_docs_plugin)$(routing_v1alpha3_path) $^
 
 generate-routing-python: $(routing_v1alpha1_pb_pythons) $(routing_v1alpha3_pb_pythons)
 
@@ -308,13 +314,13 @@ rbac_v1alpha1_path := rbac/v1alpha1
 rbac_v1alpha1_protos := $(shell find $(rbac_v1alpha1_path) -type f -name '*.proto' | sort)
 rbac_v1alpha1_pb_gos := $(rbac_v1alpha1_protos:.proto=.pb.go)
 rbac_v1alpha1_pb_pythons := $(rbac_v1alpha1_protos:.proto=_pb2.py)
-rbac_v1alpha1_pb_doc := $(rbac_v1alpha1_path)/istio.rbac.v1alpha1.pb.html
+rbac_v1alpha1_pb_doc := $(rbac_v1alpha1_path)/istio.rbac.v1alpha1.pb.html $(rbac_v1alpha1_path)/README.md
 
 generate-rbac-go: $(rbac_v1alpha1_pb_gos) $(rbac_v1alpha1_pb_doc)
 
 $(rbac_v1alpha1_pb_gos) $(rbac_v1alpha1_pb_doc): $(rbac_v1alpha1_protos)
 	## Generate rbac/v1alpha1/*.pb.go
-	@$(docker_gen) $(protoc_gen_go_plugin) $(protoc_gen_docs_plugin)$(rbac_v1alpha1_path) $^
+	@$(docker_gen) $(protoc_gen_go_plugin) $(protoc_markdown_plugin)$(routing_v1alpha1_path) $(protoc_gen_docs_plugin)$(rbac_v1alpha1_path) $^
 
 generate-rbac-python: $(rbac_v1alpha1_protos)
 
@@ -335,13 +341,13 @@ authn_v1alpha1_path := authentication/v1alpha1
 authn_v1alpha1_protos := $(shell find $(authn_v1alpha1_path) -type f -name '*.proto' | sort)
 authn_v1alpha1_pb_gos := $(authn_v1alpha1_protos:.proto=.pb.go)
 authn_v1alpha1_pb_pythons := $(authn_v1alpha1_protos:.proto=_pb2.py)
-authn_v1alpha1_pb_doc := $(authn_v1alpha1_path)/istio.authentication.v1alpha1.pb.html
+authn_v1alpha1_pb_doc := $(authn_v1alpha1_path)/istio.authentication.v1alpha1.pb.html $(authn_v1alpha1_path)/README.md
 
 generate-authn-go: $(authn_v1alpha1_pb_gos) $(authn_v1alpha1_pb_doc)
 
 $(authn_v1alpha1_pb_gos) $(authn_v1alpha1_pb_doc): $(authn_v1alpha1_protos)
 	## Generate authentication/v1alpha1/*.pb.go
-	@$(docker_gen) $(gogofast_plugin) $(protoc_gen_docs_plugin)$(authn_v1alpha1_path) $^
+	@$(docker_gen) $(gogofast_plugin) $(protoc_markdown_plugin)$(authn_v1alpha1_path) $(protoc_gen_docs_plugin)$(authn_v1alpha1_path) $^
 
 generate-authn-python: $(authn_v1alpha1_pb_pythons)
 

--- a/authentication/v1alpha1/README.md
+++ b/authentication/v1alpha1/README.md
@@ -1,0 +1,322 @@
+# Protocol Documentation
+<a name="top"/>
+
+## Table of Contents
+
+- [authentication/v1alpha1/policy.proto](#authentication/v1alpha1/policy.proto)
+    - [Jwt](#istio.authentication.v1alpha1.Jwt)
+    - [MutualTls](#istio.authentication.v1alpha1.MutualTls)
+    - [OriginAuthenticationMethod](#istio.authentication.v1alpha1.OriginAuthenticationMethod)
+    - [PeerAuthenticationMethod](#istio.authentication.v1alpha1.PeerAuthenticationMethod)
+    - [Policy](#istio.authentication.v1alpha1.Policy)
+    - [PortSelector](#istio.authentication.v1alpha1.PortSelector)
+    - [TargetSelector](#istio.authentication.v1alpha1.TargetSelector)
+  
+    - [MutualTls.Mode](#istio.authentication.v1alpha1.MutualTls.Mode)
+    - [PrincipalBinding](#istio.authentication.v1alpha1.PrincipalBinding)
+  
+  
+  
+
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="authentication/v1alpha1/policy.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## authentication/v1alpha1/policy.proto
+
+
+
+<a name="istio.authentication.v1alpha1.Jwt"/>
+
+### Jwt
+JSON Web Token (JWT) token format for authentication as defined by
+https://tools.ietf.org/html/rfc7519. See [OAuth
+2.0](https://tools.ietf.org/html/rfc6749) and [OIDC
+1.0](http://openid.net/connect) for how this is used in the whole
+authentication flow.
+
+Example,
+
+```yaml
+issuer: https://example.com
+audiences:
+- bookstore_android.apps.googleusercontent.com
+  bookstore_web.apps.googleusercontent.com
+jwksUri: https://example.com/.well-known/jwks.json
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| issuer | [string](#string) |  | Identifies the issuer that issued the JWT. See [issuer](https://tools.ietf.org/html/rfc7519#section-4.1.1) Usually a URL or an email address.  Example: https://securetoken.google.com Example: 1234567-compute@developer.gserviceaccount.com |
+| audiences | [string](#string) | repeated | The list of JWT [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3). that are allowed to access. A JWT containing any of these audiences will be accepted.  The service name will be accepted if audiences is empty.  Example:  ```yaml audiences: - bookstore_android.apps.googleusercontent.com bookstore_web.apps.googleusercontent.com ``` |
+| jwks_uri | [string](#string) |  | URL of the provider&#39;s public key set to validate signature of the JWT. See [OpenID Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).  Optional if the key set document can either (a) be retrieved from [OpenID Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html) of the issuer or (b) inferred from the email domain of the issuer (e.g. a Google service account).  Example: https://www.googleapis.com/oauth2/v1/certs |
+| jwt_headers | [string](#string) | repeated | JWT is sent in a request header. `header` represents the header name.  For example, if `header=x-goog-iap-jwt-assertion`, the header format will be x-goog-iap-jwt-assertion: &lt;JWT&gt;. |
+| jwt_params | [string](#string) | repeated | JWT is sent in a query parameter. `query` represents the query parameter name.  For example, `query=jwt_token`. |
+
+
+
+
+
+
+<a name="istio.authentication.v1alpha1.MutualTls"/>
+
+### MutualTls
+TLS authentication params.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| allow_tls | [bool](#bool) |  | WILL BE DEPRECATED, if set, will translates to `TLS_PERMISSIVE` mode. Set this flag to true to allow regular TLS (i.e without client x509 certificate). If request carries client certificate, identity will be extracted and used (set to peer identity). Otherwise, peer identity will be left unset. When the flag is false (default), request must have client certificate. |
+| mode | [MutualTls.Mode](#istio.authentication.v1alpha1.MutualTls.Mode) |  | Defines the mode of mTLS authentication. |
+
+
+
+
+
+
+<a name="istio.authentication.v1alpha1.OriginAuthenticationMethod"/>
+
+### OriginAuthenticationMethod
+OriginAuthenticationMethod defines authentication method/params for origin
+authentication. Origin could be end-user, device, delegate service etc.
+Currently, only JWT is supported for origin authentication.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| jwt | [Jwt](#istio.authentication.v1alpha1.Jwt) |  | Jwt params for the method. |
+
+
+
+
+
+
+<a name="istio.authentication.v1alpha1.PeerAuthenticationMethod"/>
+
+### PeerAuthenticationMethod
+PeerAuthenticationMethod defines one particular type of authentication, e.g
+mutual TLS, JWT etc, (no authentication is one type by itself) that can
+be used for peer authentication.
+The type can be progammatically determine by checking the type of the
+&#34;params&#34; field.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| mtls | [MutualTls](#istio.authentication.v1alpha1.MutualTls) |  | Set if mTLS is used. |
+| jwt | [Jwt](#istio.authentication.v1alpha1.Jwt) |  | $hide_from_docs Set if JWT is used. This option is not yet available. |
+
+
+
+
+
+
+<a name="istio.authentication.v1alpha1.Policy"/>
+
+### Policy
+Policy defines what authentication methods can be accepted on workload(s),
+and if authenticated, which method/certificate will set the request principal
+(i.e request.auth.principal attribute).
+
+Authentication policy is composed of 2-part authentication:
+- peer: verify caller service credentials. This part will set source.user
+(peer identity).
+- origin: verify the origin credentials. This part will set request.auth.user
+(origin identity), as well as other attributes like request.auth.presenter,
+request.auth.audiences and raw claims. Note that the identity could be
+end-user, service account, device etc.
+
+Last but not least, the principal binding rule defines which identity (peer
+or origin) should be used as principal. By default, it uses peer.
+
+Examples:
+
+Policy to enable mTLS for all services in namespace frod
+
+```yaml
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: mTLS_enable
+  namespace: frod
+spec:
+  peers:
+  - mtls:
+```
+Policy to disable mTLS for &#34;productpage&#34; service
+
+```yaml
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: mTLS_disable
+  namespace: frod
+spec:
+  targets:
+  - name: productpage
+```
+Policy to require mTLS for peer authentication, and JWT for origin authenticationn
+for productpage:9000. Principal is set from origin identity.
+
+```yaml
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: mTLS_enable
+  namespace: frod
+spec:
+  target:
+  - name: productpage
+    ports:
+    - number: 9000
+  peers:
+  - mtls:
+  origins:
+  - jwt:
+      issuer: &#34;https://securetoken.google.com&#34;
+      audiences:
+      - &#34;productpage&#34;
+      jwksUri: &#34;https://www.googleapis.com/oauth2/v1/certs&#34;
+      jwt_headers:
+      - &#34;x-goog-iap-jwt-assertion&#34;
+  principaBinding: USE_ORIGIN
+```
+
+Policy to require mTLS for peer authentication, and JWT for origin authenticationn
+for productpage:9000, but allow origin authentication failed. Principal is set
+from origin identity.
+Note: this example can be used for use cases when we want to allow request from
+certain peers, given it comes with an approperiate authorization poicy to check
+and reject request accoridingly.
+
+```yaml
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: mTLS_enable
+  namespace: frod
+spec:
+  target:
+  - name: productpage
+    ports:
+    - number: 9000
+  peers:
+  - mtls:
+  origins:
+  - jwt:
+      issuer: &#34;https://securetoken.google.com&#34;
+      audiences:
+      - &#34;productpage&#34;
+      jwksUri: &#34;https://www.googleapis.com/oauth2/v1/certs&#34;
+      jwt_headers:
+      - &#34;x-goog-iap-jwt-assertion&#34;
+  originIsOptional: true
+  principalBinding: USE_ORIGIN
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| targets | [TargetSelector](#istio.authentication.v1alpha1.TargetSelector) | repeated | List rules to select destinations that the policy should be applied on. If empty, policy will be used on all destinations in the same namespace. |
+| peers | [PeerAuthenticationMethod](#istio.authentication.v1alpha1.PeerAuthenticationMethod) | repeated | List of authentication methods that can be used for peer authentication. They will be evaluated in order; the first validate one will be used to set peer identity (source.user) and other peer attributes. If none of these methods pass, and peer_is_optional flag is false (see below), request will be rejected with authentication failed error (401). Leave the list empty if peer authentication is not required |
+| peer_is_optional | [bool](#bool) |  | Set this flag to true to accept request (for peer authentication perspective), even when none of the peer authentication methods defined above satisfied. Typically, this is used to delay the rejection decision to next layer (e.g authorization). This flag is ignored if no authentication defined for peer (peers field is empty). |
+| origins | [OriginAuthenticationMethod](#istio.authentication.v1alpha1.OriginAuthenticationMethod) | repeated | List of authentication methods that can be used for origin authentication. Similar to peers, these will be evaluated in order; the first validate one will be used to set origin identity and attributes (i.e request.auth.user, request.auth.issuer etc). If none of these methods pass, and origin_is_optional is false (see below), request will be rejected with authentication failed error (401). Leave the list empty if origin authentication is not required. |
+| origin_is_optional | [bool](#bool) |  | Set this flag to true to accept request (for origin authentication perspective), even when none of the origin authentication methods defined above satisfied. Typically, this is used to delay the rejection decision to next layer (e.g authorization). This flag is ignored if no authentication defined for origin (origins field is empty). |
+| principal_binding | [PrincipalBinding](#istio.authentication.v1alpha1.PrincipalBinding) |  | Define whether peer or origin identity should be use for principal. Default value is USE_PEER. If peer (or orgin) identity is not available, either because of peer/origin authentication is not defined, or failed, principal will be left unset. In other words, binding rule does not affect the decision to accept or reject request. |
+
+
+
+
+
+
+<a name="istio.authentication.v1alpha1.PortSelector"/>
+
+### PortSelector
+PortSelector specifies the name or number of a port to be used for
+matching targets for authenticationn policy. This is copied from
+networking API to avoid dependency.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| number | [uint32](#uint32) |  | Valid port number |
+| name | [string](#string) |  | Port name |
+
+
+
+
+
+
+<a name="istio.authentication.v1alpha1.TargetSelector"/>
+
+### TargetSelector
+TargetSelector defines a matching rule to a service/destination.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | REQUIRED. The name must be a short name from the service registry. The fully qualified domain name will be resolved in a platform specific manner. |
+| ports | [PortSelector](#istio.authentication.v1alpha1.PortSelector) | repeated | Specifies the ports on the destination. Leave empty to match all ports that are exposed. |
+
+
+
+
+
+ 
+
+
+<a name="istio.authentication.v1alpha1.MutualTls.Mode"/>
+
+### MutualTls.Mode
+Defines the acceptable connection TLS mode.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| STRICT | 0 | Client cert must be presented, connection is in TLS. |
+| PERMISSIVE | 1 | Connection can be either plaintext or TLS, and client cert can be omitted. |
+
+
+
+<a name="istio.authentication.v1alpha1.PrincipalBinding"/>
+
+### PrincipalBinding
+Associates authentication with request principal.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| USE_PEER | 0 | Principal will be set to the identity from peer authentication. |
+| USE_ORIGIN | 1 | Principal will be set to the identity from origin authentication. |
+
+
+ 
+
+ 
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | Java Type | Python Type |
+| ----------- | ----- | -------- | --------- | ----------- |
+| <a name="double" /> double |  | double | double | float |
+| <a name="float" /> float |  | float | float | float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
+| <a name="bool" /> bool |  | bool | boolean | boolean |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+

--- a/broker/dev/README.md
+++ b/broker/dev/README.md
@@ -1,0 +1,195 @@
+# Protocol Documentation
+<a name="top"/>
+
+## Table of Contents
+
+- [broker/dev/service_class.proto](#broker/dev/service_class.proto)
+    - [CatalogEntry](#istio.broker.dev.CatalogEntry)
+    - [Deployment](#istio.broker.dev.Deployment)
+    - [ServiceClass](#istio.broker.dev.ServiceClass)
+  
+  
+  
+  
+
+- [broker/dev/service_plan.proto](#broker/dev/service_plan.proto)
+    - [CatalogPlan](#istio.broker.dev.CatalogPlan)
+    - [ServicePlan](#istio.broker.dev.ServicePlan)
+  
+  
+  
+  
+
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="broker/dev/service_class.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## broker/dev/service_class.proto
+Copyright 2017 Istio Authors
+
+  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+
+<a name="istio.broker.dev.CatalogEntry"/>
+
+### CatalogEntry
+$hide_from_docs
+CatalogEntry defines listing information for this service within the exposed
+catalog.  The message is a subset of OSBI service fields defined in
+https://github.com/openservicebrokerapi
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | Required. Public service name. |
+| id | [string](#string) |  | Required. Public unique service guid. |
+| description | [string](#string) |  | Required. Public short service description. |
+
+
+
+
+
+
+<a name="istio.broker.dev.Deployment"/>
+
+### Deployment
+$hide_from_docs
+Deployment defines how the service instances are deployed.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| instance | [string](#string) |  | For truely multi-tenant service, the deployed service instance name. |
+
+
+
+
+
+
+<a name="istio.broker.dev.ServiceClass"/>
+
+### ServiceClass
+$hide_from_docs
+ServiceClass defines a service that are exposed to Istio service consumers.
+The service is linked into one or more ServicePlan.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| deployment | [Deployment](#istio.broker.dev.Deployment) |  | Required. Istio deployment spec for the service class. |
+| entry | [CatalogEntry](#istio.broker.dev.CatalogEntry) |  | Required. Listing information for the public catalog. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="broker/dev/service_plan.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## broker/dev/service_plan.proto
+Copyright 2017 Istio Authors
+
+  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+
+<a name="istio.broker.dev.CatalogPlan"/>
+
+### CatalogPlan
+$hide_from_docs
+CatalogPlan defines listing information for this service plan within the
+exposed catalog.  The message is a subset of OSBI plan fields defined in
+https://github.com/openservicebrokerapi
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | Required. Public service plan name. |
+| id | [string](#string) |  | Required. Public unique service plan guid. |
+| description | [string](#string) |  | Required. Public short service plan description. |
+
+
+
+
+
+
+<a name="istio.broker.dev.ServicePlan"/>
+
+### ServicePlan
+$hide_from_docs
+ServicePlan defines the type of services available to Istio service
+consumers.  One or more services are included in a plan. The plan is flexible
+and subject to change along with business requirements.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| plan | [CatalogPlan](#istio.broker.dev.CatalogPlan) |  | Required. Public plan information. |
+| services | [string](#string) | repeated | Required. List of the Keys of serviceclass config instance that are included in the plan. ServiceClass is a type of CRD resource. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | Java Type | Python Type |
+| ----------- | ----- | -------- | --------- | ----------- |
+| <a name="double" /> double |  | double | double | float |
+| <a name="float" /> float |  | float | float | float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
+| <a name="bool" /> bool |  | bool | boolean | boolean |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+

--- a/config/mcp/v1alpha1/README.md
+++ b/config/mcp/v1alpha1/README.md
@@ -1,0 +1,107 @@
+# Protocol Documentation
+<a name="top"/>
+
+## Table of Contents
+
+- [config/mcp/v1alpha1/envelope.proto](#config/mcp/v1alpha1/envelope.proto)
+    - [Envelope](#istio.config.mcp.v1alpha1.Envelope)
+  
+  
+  
+  
+
+- [config/mcp/v1alpha1/metadata.proto](#config/mcp/v1alpha1/metadata.proto)
+    - [Metadata](#istio.config.mcp.v1alpha1.Metadata)
+  
+  
+  
+  
+
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="config/mcp/v1alpha1/envelope.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## config/mcp/v1alpha1/envelope.proto
+
+
+
+<a name="istio.config.mcp.v1alpha1.Envelope"/>
+
+### Envelope
+Envelope for a configuration resource as transferred via the Mesh Configuration Protocol.
+Each envelope is made up of common metadata, and a type-specific resource payload.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| metadata | [Metadata](#istio.config.mcp.v1alpha1.Metadata) |  | Common metadata describing the resource. |
+| resource | [google.protobuf.Any](#google.protobuf.Any) |  | The resource itself. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="config/mcp/v1alpha1/metadata.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## config/mcp/v1alpha1/metadata.proto
+
+
+
+<a name="istio.config.mcp.v1alpha1.Metadata"/>
+
+### Metadata
+Metadata information that all resources within the Mesh Configuration Protocol must have.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | The name of the resource. It is unique within the context of a resource type and the origin server of the resource. The resource type is identified by the TypeUrl of the resource field of the Envelope message. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | Java Type | Python Type |
+| ----------- | ----- | -------- | --------- | ----------- |
+| <a name="double" /> double |  | double | double | float |
+| <a name="float" /> float |  | float | float | float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
+| <a name="bool" /> bool |  | bool | boolean | boolean |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN go get -u -v -ldflags '-w -s' \
         github.com/gogo/protobuf/protoc-gen-gogofaster \
         github.com/gogo/protobuf/protoc-gen-gogoslick \
         github.com/istio/tools/protoc-gen-docs \
+        github.com/douglas-reid/protoc-gen-doc/cmd/protoc-gen-doc \
         && install -c ${GOPATH}/bin/protoc-gen* ${OUTDIR}/usr/bin/
 
 FROM znly/upx as packer

--- a/mesh/v1alpha1/README.md
+++ b/mesh/v1alpha1/README.md
@@ -59,6 +59,7 @@ tracing configuration).
 | default_config | [ProxyConfig](#istio.mesh.v1alpha1.ProxyConfig) |  | Default proxy config used by the proxy injection mechanism operating in the mesh (e.g. Kubernetes admission controller) In case of Kubernetes, the proxy config is applied once during the injection process, and remain constant for the duration of the pod. The rest of the mesh config can be changed at runtime and config gets distributed dynamically. |
 | mixer_address | [string](#string) |  | DEPRECATED. Mixer address. This option will be removed soon. Please use mixer_check and mixer_report. |
 | outbound_traffic_policy | [MeshConfig.OutboundTrafficPolicy](#istio.mesh.v1alpha1.MeshConfig.OutboundTrafficPolicy) |  | Set the default behavior of the sidecar for handling outbound traffic from the application. While the default mode should work out of the box, if your application uses one or more external services that are not known apriori, setting the policy to ALLOW_ANY will cause the sidecars to route traffic to the any requested destination. Users are strongly encouraged to use ServiceEntries to explicitly declare any external dependencies, instead of using allow_any. |
+| enable_client_side_policy_check | [bool](#bool) |  | Enables clide side policy checks. |
 
 
 

--- a/mesh/v1alpha1/README.md
+++ b/mesh/v1alpha1/README.md
@@ -1,0 +1,198 @@
+# Protocol Documentation
+<a name="top"/>
+
+## Table of Contents
+
+- [mesh/v1alpha1/config.proto](#mesh/v1alpha1/config.proto)
+    - [MeshConfig](#istio.mesh.v1alpha1.MeshConfig)
+    - [MeshConfig.OutboundTrafficPolicy](#istio.mesh.v1alpha1.MeshConfig.OutboundTrafficPolicy)
+    - [ProxyConfig](#istio.mesh.v1alpha1.ProxyConfig)
+  
+    - [AuthenticationPolicy](#istio.mesh.v1alpha1.AuthenticationPolicy)
+    - [MeshConfig.AuthPolicy](#istio.mesh.v1alpha1.MeshConfig.AuthPolicy)
+    - [MeshConfig.IngressControllerMode](#istio.mesh.v1alpha1.MeshConfig.IngressControllerMode)
+    - [ProxyConfig.InboundInterceptionMode](#istio.mesh.v1alpha1.ProxyConfig.InboundInterceptionMode)
+  
+  
+  
+
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="mesh/v1alpha1/config.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mesh/v1alpha1/config.proto
+
+
+
+<a name="istio.mesh.v1alpha1.MeshConfig"/>
+
+### MeshConfig
+MeshConfig defines mesh-wide variables shared by all Envoy instances in the
+Istio service mesh.
+
+NOTE: This configuration type should be used for the low-level global
+configuration, such as component addresses and port numbers. It should not
+be used for the features of the mesh that can be scoped by service or by
+namespace. Some of the fields in the mesh config are going to be deprecated
+and replaced with several individual configuration types (for example,
+tracing configuration).
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| mixer_check_server | [string](#string) |  | Address of the server that will be used by the proxies for policy check calls. By using different names for mixerCheckServer and mixerReportServer, it is possible to have one set of mixer servers handle policy check calls while another set of mixer servers handle telemetry calls.  NOTE: Omitting mixerCheckServer while specifying mixerReportServer is equivalent to setting disablePolicyChecks to true. |
+| mixer_report_server | [string](#string) |  | Address of the server that will be used by the proxies for policy report calls. |
+| disable_policy_checks | [bool](#bool) |  | Disable policy checks by the mixer service. Default is false, i.e. mixer policy check is enabled by default. |
+| proxy_listen_port | [int32](#int32) |  | Port on which Envoy should listen for incoming connections from other services. |
+| proxy_http_port | [int32](#int32) |  | Port on which Envoy should listen for HTTP PROXY requests if set. |
+| connect_timeout | [google.protobuf.Duration](#google.protobuf.Duration) |  | Connection timeout used by Envoy. (MUST BE &gt;=1ms) |
+| ingress_class | [string](#string) |  | Class of ingress resources to be processed by Istio ingress controller. This corresponds to the value of &#34;kubernetes.io/ingress.class&#34; annotation. |
+| ingress_service | [string](#string) |  | Name of the kubernetes service used for the istio ingress controller. |
+| ingress_controller_mode | [MeshConfig.IngressControllerMode](#istio.mesh.v1alpha1.MeshConfig.IngressControllerMode) |  | Defines whether to use Istio ingress controller for annotated or all ingress resources. |
+| auth_policy | [MeshConfig.AuthPolicy](#istio.mesh.v1alpha1.MeshConfig.AuthPolicy) |  | Authentication policy defines the global switch to control authentication for Envoy-to-Envoy communication. Use authentication_policy instead. |
+| rds_refresh_delay | [google.protobuf.Duration](#google.protobuf.Duration) |  | Polling interval for RDS (MUST BE &gt;=1ms) |
+| enable_tracing | [bool](#bool) |  | Flag to control generation of trace spans and request IDs. Requires a trace span collector defined in the proxy configuration. |
+| access_log_file | [string](#string) |  | File address for the proxy access log (e.g. /dev/stdout). Empty value disables access logging. |
+| default_config | [ProxyConfig](#istio.mesh.v1alpha1.ProxyConfig) |  | Default proxy config used by the proxy injection mechanism operating in the mesh (e.g. Kubernetes admission controller) In case of Kubernetes, the proxy config is applied once during the injection process, and remain constant for the duration of the pod. The rest of the mesh config can be changed at runtime and config gets distributed dynamically. |
+| mixer_address | [string](#string) |  | DEPRECATED. Mixer address. This option will be removed soon. Please use mixer_check and mixer_report. |
+| outbound_traffic_policy | [MeshConfig.OutboundTrafficPolicy](#istio.mesh.v1alpha1.MeshConfig.OutboundTrafficPolicy) |  | Set the default behavior of the sidecar for handling outbound traffic from the application. While the default mode should work out of the box, if your application uses one or more external services that are not known apriori, setting the policy to ALLOW_ANY will cause the sidecars to route traffic to the any requested destination. Users are strongly encouraged to use ServiceEntries to explicitly declare any external dependencies, instead of using allow_any. |
+
+
+
+
+
+
+<a name="istio.mesh.v1alpha1.MeshConfig.OutboundTrafficPolicy"/>
+
+### MeshConfig.OutboundTrafficPolicy
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| mode | [MeshConfig.OutboundTrafficPolicy.Mode](#istio.mesh.v1alpha1.MeshConfig.OutboundTrafficPolicy.Mode) |  |  |
+
+
+
+
+
+
+<a name="istio.mesh.v1alpha1.ProxyConfig"/>
+
+### ProxyConfig
+ProxyConfig defines variables for individual Envoy instances.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| config_path | [string](#string) |  | Path to the generated configuration file directory. Proxy agent generates the actual configuration and stores it in this directory. |
+| binary_path | [string](#string) |  | Path to the proxy binary |
+| service_cluster | [string](#string) |  | Service cluster defines the name for the service_cluster that is shared by all Envoy instances. This setting corresponds to _--service-cluster_ flag in Envoy. In a typical Envoy deployment, the _service-cluster_ flag is used to identify the caller, for source-based routing scenarios.  Since Istio does not assign a local service/service version to each Envoy instance, the name is same for all of them. However, the source/caller&#39;s identity (e.g., IP address) is encoded in the _--service-node_ flag when launching Envoy. When the RDS service receives API calls from Envoy, it uses the value of the _service-node_ flag to compute routes that are relative to the service instances located at that IP address. |
+| drain_duration | [google.protobuf.Duration](#google.protobuf.Duration) |  | The time in seconds that Envoy will drain connections during a hot restart. MUST be &gt;=1s (e.g., _1s/1m/1h_) |
+| parent_shutdown_duration | [google.protobuf.Duration](#google.protobuf.Duration) |  | The time in seconds that Envoy will wait before shutting down the parent process during a hot restart. MUST be &gt;=1s (e.g., _1s/1m/1h_). MUST BE greater than _drain_duration_ parameter. |
+| discovery_address | [string](#string) |  | Address of the discovery service exposing xDS with mTLS connection. |
+| discovery_refresh_delay | [google.protobuf.Duration](#google.protobuf.Duration) |  | Polling interval for service discovery (used by EDS, CDS, LDS, but not RDS). (MUST BE &gt;=1ms) |
+| zipkin_address | [string](#string) |  | Address of the Zipkin service (e.g. _zipkin:9411_). |
+| connect_timeout | [google.protobuf.Duration](#google.protobuf.Duration) |  | Connection timeout used by Envoy for supporting services. (MUST BE &gt;=1ms) |
+| statsd_udp_address | [string](#string) |  | IP Address and Port of a statsd UDP listener (e.g. _10.75.241.127:9125_). |
+| proxy_admin_port | [int32](#int32) |  | Port on which Envoy should listen for administrative commands. |
+| availability_zone | [string](#string) |  | The availability zone where this Envoy instance is running. When running Envoy as a sidecar in Kubernetes, this flag must be one of the availability zones assigned to a node using failure-domain.beta.kubernetes.io/zone annotation. |
+| control_plane_auth_policy | [AuthenticationPolicy](#istio.mesh.v1alpha1.AuthenticationPolicy) |  | Authentication policy defines the global switch to control authentication for Envoy-to-Envoy communication for istio components Mixer and Pilot. |
+| custom_config_file | [string](#string) |  | File path of custom proxy configuration, currently used by proxies in front of Mixer and Pilot. |
+| stat_name_length | [int32](#int32) |  | Maximum length of name field in Envoy&#39;s metrics. The length of the name field is determined by the length of a name field in a service and the set of labels that comprise a particular version of the service. The default value is set to 189 characters. Envoy&#39;s internal metrics take up 67 characters, for a total of 256 character name per metric. Increase the value of this field if you find that the metrics from Envoys are truncated. |
+| concurrency | [int32](#int32) |  | The number of worker threads to run. Default value is number of cores on the machine. |
+| proxy_bootstrap_template_path | [string](#string) |  | Path to the proxy bootstrap template file |
+| interception_mode | [ProxyConfig.InboundInterceptionMode](#istio.mesh.v1alpha1.ProxyConfig.InboundInterceptionMode) |  | The mode used to redirect inbound traffic to Envoy. |
+
+
+
+
+
+ 
+
+
+<a name="istio.mesh.v1alpha1.AuthenticationPolicy"/>
+
+### AuthenticationPolicy
+AuthenticationPolicy defines authentication policy. It can be set for
+different scopes (mesh, service …), and the most narrow scope with
+non-INHERIT value will be used.
+Mesh policy cannot be INHERIT.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| NONE | 0 | Do not encrypt Envoy to Envoy traffic. |
+| MUTUAL_TLS | 1 | Envoy to Envoy traffic is wrapped into mutual TLS connections. |
+| INHERIT | 1000 | Use the policy defined by the parent scope. Should not be used for mesh policy. |
+
+
+
+<a name="istio.mesh.v1alpha1.MeshConfig.AuthPolicy"/>
+
+### MeshConfig.AuthPolicy
+TODO AuthPolicy needs to be removed and merged with AuthPolicy defined above
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| NONE | 0 | Do not encrypt Envoy to Envoy traffic. |
+| MUTUAL_TLS | 1 | Envoy to Envoy traffic is wrapped into mutual TLS connections. |
+
+
+
+<a name="istio.mesh.v1alpha1.MeshConfig.IngressControllerMode"/>
+
+### MeshConfig.IngressControllerMode
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| OFF | 0 | Disables Istio ingress controller. |
+| DEFAULT | 1 | Istio ingress controller will act on ingress resources that do not contain any annotation or whose annotations match the value specified in the ingress_class parameter described earlier. Use this mode if Istio ingress controller will be the default ingress controller for the entire kubernetes cluster. |
+| STRICT | 2 | Istio ingress controller will only act on ingress resources whose annotations match the value specified in the ingress_class parameter described earlier. Use this mode if Istio ingress controller will be a secondary ingress controller (e.g., in addition to a cloud-provided ingress controller). |
+
+
+
+<a name="istio.mesh.v1alpha1.ProxyConfig.InboundInterceptionMode"/>
+
+### ProxyConfig.InboundInterceptionMode
+The mode used to redirect inbound traffic to Envoy.
+This setting has no effect on outbound traffic: iptables REDIRECT is always used for
+outbound connections.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| REDIRECT | 0 | The REDIRECT mode uses iptables REDIRECT to NAT and redirect to Envoy. This mode loses source IP addresses during redirection. |
+| TPROXY | 1 | The TPROXY mode uses iptables TPROXY to redirect to Envoy. This mode preserves both the source and destination IP addresses and ports, so that they can be used for advanced filtering and manipulation. This mode also configures the sidecar to run with the CAP_NET_ADMIN capability, which is required to use TPROXY. |
+
+
+ 
+
+ 
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | Java Type | Python Type |
+| ----------- | ----- | -------- | --------- | ----------- |
+| <a name="double" /> double |  | double | double | float |
+| <a name="float" /> float |  | float | float | float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
+| <a name="bool" /> bool |  | bool | boolean | boolean |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+

--- a/mixer/adapter/model/v1beta1/README.md
+++ b/mixer/adapter/model/v1beta1/README.md
@@ -1,0 +1,532 @@
+# Protocol Documentation
+<a name="top"/>
+
+## Table of Contents
+
+- [mixer/adapter/model/v1beta1/check.proto](#mixer/adapter/model/v1beta1/check.proto)
+    - [CheckResult](#istio.mixer.adapter.model.v1beta1.CheckResult)
+  
+  
+  
+  
+
+- [mixer/adapter/model/v1beta1/extensions.proto](#mixer/adapter/model/v1beta1/extensions.proto)
+  
+    - [TemplateVariety](#istio.mixer.adapter.model.v1beta1.TemplateVariety)
+  
+    - [File-level Extensions](#mixer/adapter/model/v1beta1/extensions.proto-extensions)
+    - [File-level Extensions](#mixer/adapter/model/v1beta1/extensions.proto-extensions)
+  
+  
+
+- [mixer/adapter/model/v1beta1/info.proto](#mixer/adapter/model/v1beta1/info.proto)
+    - [Info](#istio.mixer.adapter.model.v1beta1.Info)
+  
+  
+  
+  
+
+- [mixer/adapter/model/v1beta1/infrastructure_backend.proto](#mixer/adapter/model/v1beta1/infrastructure_backend.proto)
+    - [CloseSessionRequest](#istio.mixer.adapter.model.v1beta1.CloseSessionRequest)
+    - [CloseSessionResponse](#istio.mixer.adapter.model.v1beta1.CloseSessionResponse)
+    - [CreateSessionRequest](#istio.mixer.adapter.model.v1beta1.CreateSessionRequest)
+    - [CreateSessionRequest.InferredTypesEntry](#istio.mixer.adapter.model.v1beta1.CreateSessionRequest.InferredTypesEntry)
+    - [CreateSessionResponse](#istio.mixer.adapter.model.v1beta1.CreateSessionResponse)
+    - [ValidateRequest](#istio.mixer.adapter.model.v1beta1.ValidateRequest)
+    - [ValidateRequest.InferredTypesEntry](#istio.mixer.adapter.model.v1beta1.ValidateRequest.InferredTypesEntry)
+    - [ValidateResponse](#istio.mixer.adapter.model.v1beta1.ValidateResponse)
+  
+  
+  
+    - [InfrastructureBackend](#istio.mixer.adapter.model.v1beta1.InfrastructureBackend)
+  
+
+- [mixer/adapter/model/v1beta1/quota.proto](#mixer/adapter/model/v1beta1/quota.proto)
+    - [QuotaRequest](#istio.mixer.adapter.model.v1beta1.QuotaRequest)
+    - [QuotaRequest.QuotaParams](#istio.mixer.adapter.model.v1beta1.QuotaRequest.QuotaParams)
+    - [QuotaRequest.QuotasEntry](#istio.mixer.adapter.model.v1beta1.QuotaRequest.QuotasEntry)
+    - [QuotaResult](#istio.mixer.adapter.model.v1beta1.QuotaResult)
+    - [QuotaResult.QuotasEntry](#istio.mixer.adapter.model.v1beta1.QuotaResult.QuotasEntry)
+    - [QuotaResult.Result](#istio.mixer.adapter.model.v1beta1.QuotaResult.Result)
+  
+  
+  
+  
+
+- [mixer/adapter/model/v1beta1/report.proto](#mixer/adapter/model/v1beta1/report.proto)
+    - [ReportResult](#istio.mixer.adapter.model.v1beta1.ReportResult)
+  
+  
+  
+  
+
+- [mixer/adapter/model/v1beta1/template.proto](#mixer/adapter/model/v1beta1/template.proto)
+    - [Template](#istio.mixer.adapter.model.v1beta1.Template)
+  
+  
+  
+  
+
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="mixer/adapter/model/v1beta1/check.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/adapter/model/v1beta1/check.proto
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.CheckResult"/>
+
+### CheckResult
+Expresses the result of a precondition check.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| status | [google.rpc.Status](#google.rpc.Status) |  | A status code of OK indicates preconditions were satisfied. Any other code indicates preconditions were not satisfied and details describe why. |
+| valid_duration | [google.protobuf.Duration](#google.protobuf.Duration) |  | The amount of time for which this result can be considered valid. |
+| valid_use_count | [int32](#int32) |  | The number of uses for which this result can be considered valid. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="mixer/adapter/model/v1beta1/extensions.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/adapter/model/v1beta1/extensions.proto
+
+
+ 
+
+
+<a name="istio.mixer.adapter.model.v1beta1.TemplateVariety"/>
+
+### TemplateVariety
+The available varieties of templates, controlling the semantics of what an adapter does with each instance.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| TEMPLATE_VARIETY_CHECK | 0 | Makes the template applicable for Mixer&#39;s check calls. Instances of such template are created during report calls in Mixer and passed to the handlers based on the rule configurations. |
+| TEMPLATE_VARIETY_REPORT | 1 | Makes the template applicable for Mixer&#39;s report calls. Instances of such template are created during check calls in Mixer and passed to the handlers based on the rule configurations. |
+| TEMPLATE_VARIETY_QUOTA | 2 | Makes the template applicable for Mixer&#39;s quota calls. Instances of such template are created during quota check calls in Mixer and passed to the handlers based on the rule configurations. |
+| TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR | 3 | Makes the template applicable for Mixer&#39;s attribute generation phase. Instances of such template are created during pre-processing attribute generation phase and passed to the handlers based on the rule configurations. |
+
+
+ 
+
+
+<a name="mixer/adapter/model/v1beta1/extensions.proto-extensions"/>
+
+### File-level Extensions
+| Extension | Type | Base | Number | Description |
+| --------- | ---- | ---- | ------ | ----------- |
+| template_name | string | .google.protobuf.FileOptions | 72295888 | Optional: option for the template name. If not specified, the last segment of the template proto&#39;s package name is used to derive the template name. |
+| template_variety | TemplateVariety | .google.protobuf.FileOptions | 72295727 | Required: option for the TemplateVariety. |
+
+ 
+
+ 
+
+
+
+<a name="mixer/adapter/model/v1beta1/info.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/adapter/model/v1beta1/info.proto
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.Info"/>
+
+### Info
+Info describes an adapter or a backend that wants to provide telemetry and policy functionality to Mixer as an
+out of process adapter.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | Name of the adapter. It must be an RFC 1035 compatible DNS label matching the `^[a-z]([-a-z0-9]*[a-z0-9])?$` regular expression. Name is used in Istio configuration, therefore it should be descriptive but short. example: denier Vendor adapters should use a vendor prefix. example: mycompany-denier |
+| description | [string](#string) |  | User-friendly description of the adapter. |
+| templates | [string](#string) | repeated | Names of the templates the adapter supports. |
+| config | [string](#string) |  | Base64 encoded proto descriptor of the adapter configuration. |
+| session_based | [bool](#bool) |  | True if backend has implemented the [InfrastructureBackend](https://github.com/istio/api/blob/master/mixer/adapter/model/v1beta1/infrastructure_backend.proto) service; false otherwise.  If true, during configuration time, Mixer calls the `InfrastructureBackend`&#39; rpcs to validate and pass the handler configuration. And during request-time, Mixer does not pass the handler configuration, and only passes the template-specific Instance payload using the template-specific handle service (Example [HandlerMetricService](https://github.com/istio/istio/blob/master/mixer/template/metric/template_handler_service.proto), [HandlerListEntryService](https://github.com/istio/istio/blob/master/mixer/template/logentry/template_handler_service.proto), [HandleQuotaService](https://github.com/istio/istio/blob/master/mixer/template/quota/template_handler_service.proto) and more). If `session_based` is false, Mixer does not expect backend to implement `InfrastructureBackend` service, and only communicates with the backends during request-time through the template-specific handle service. Without `InfrastructureBackend` service, Mixer passes the handler configuration on each call during request-time. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="mixer/adapter/model/v1beta1/infrastructure_backend.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/adapter/model/v1beta1/infrastructure_backend.proto
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.CloseSessionRequest"/>
+
+### CloseSessionRequest
+Request message for `CloseSession` method.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| session_id | [string](#string) |  | Id of the session to be closed. |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.CloseSessionResponse"/>
+
+### CloseSessionResponse
+Response message for `CloseSession` method.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| status | [google.rpc.Status](#google.rpc.Status) |  | The success/failure status of close session call. |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.CreateSessionRequest"/>
+
+### CreateSessionRequest
+Request message for `CreateSession` method.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| adapter_config | [google.protobuf.Any](#google.protobuf.Any) |  | Adapter specific configuration. |
+| inferred_types | [CreateSessionRequest.InferredTypesEntry](#istio.mixer.adapter.model.v1beta1.CreateSessionRequest.InferredTypesEntry) | repeated | Map of instance names to their template-specific inferred type. |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.CreateSessionRequest.InferredTypesEntry"/>
+
+### CreateSessionRequest.InferredTypesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.CreateSessionResponse"/>
+
+### CreateSessionResponse
+Response message for `CreateSession` method.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| session_id | [string](#string) |  | Id of the created session. |
+| status | [google.rpc.Status](#google.rpc.Status) |  | The success/failure status of create session call. |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.ValidateRequest"/>
+
+### ValidateRequest
+Request message for `Validate` method.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| adapter_config | [google.protobuf.Any](#google.protobuf.Any) |  | Adapter specific configuration. |
+| inferred_types | [ValidateRequest.InferredTypesEntry](#istio.mixer.adapter.model.v1beta1.ValidateRequest.InferredTypesEntry) | repeated | Map of instance names to their template-specific inferred type. |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.ValidateRequest.InferredTypesEntry"/>
+
+### ValidateRequest.InferredTypesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.ValidateResponse"/>
+
+### ValidateResponse
+Response message for `Validate` method.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| status | [google.rpc.Status](#google.rpc.Status) |  | The success/failure status of validation call. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="istio.mixer.adapter.model.v1beta1.InfrastructureBackend"/>
+
+### InfrastructureBackend
+`InfrastructureBackend` is implemented by backends that wants to provide telemetry and policy functionality to Mixer as an
+out of process adapter.
+
+`InfrastructureBackend` allows Mixer and the backends to have a session based model. In a session based model, Mixer passes
+the relevant configuration state to the backend only once and estabilshes a session using a session identifier.
+All future communications between Mixer and the backend uses the session identifier which refers to the previously
+passed in configuration data.
+
+For a given `InfrastructureBackend`, Mixer calls the `Validate` function, followed by `CreateSession`. The `session_id`
+returned from `CreateSession` is used to make subsequent request-time Handle calls and the eventual `CloseSession` function.
+Mixer assumes that, given the `session_id`, the backend can retrieve the necessary context to serve the
+Handle calls that contains the request-time payload (template-specific instance protobuf).
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Validate | [ValidateRequest](#istio.mixer.adapter.model.v1beta1.ValidateRequest) | [ValidateResponse](#istio.mixer.adapter.model.v1beta1.ValidateRequest) | Validates the handler configuration along with the template-specific instances that would be routed to that handler. The `CreateSession` for a specific handler configuration is invoked only if its associated `Validate` call has returned success. |
+| CreateSession | [CreateSessionRequest](#istio.mixer.adapter.model.v1beta1.CreateSessionRequest) | [CreateSessionResponse](#istio.mixer.adapter.model.v1beta1.CreateSessionRequest) | Creates a session for a given handler configuration and the template-specific instances that would be routed to that handler. For every handler configuration, Mixer creates a separate session by invoking `CreateSession` on the backend.  `CreateSessionRequest` contains the adapter specific handler configuration and the inferred type information about the instances the handler would receive during request processing.  `CreateSession` must return a `session_id` which Mixer uses to invoke template-specific Handle functions during request processing. The `session_id` provides the Handle functions a way to retrieve the necessary configuration associated with the session. Upon Mixer configuration change, Mixer will re-invoke `CreateSession` for all handler configurations whose existing sessions are invalidated or didn&#39;t existed.  Backend is allowed to return the same session id if given the same configuration block. This would happen when multiple instances of Mixer in a deployment all create sessions with the same configuration. Note that given individial instances of Mixer can call `CloseSession`, reusing `session_id` by the backend assumes that the backend is doing reference counting.  If the backend couldn&#39;t create a session for a specific handler configuration and returns non S_OK status, Mixer will not make request-time Handle calls associated with that handler configuration. |
+| CloseSession | [CloseSessionRequest](#istio.mixer.adapter.model.v1beta1.CloseSessionRequest) | [CloseSessionResponse](#istio.mixer.adapter.model.v1beta1.CloseSessionRequest) | Closes the session associated with the `session_id`. Mixer closes a session when its associated handler configuration or the instance configuration changes. Backend is supposed to cleanup all the resources associated with the session_id referenced by CloseSessionRequest. |
+
+ 
+
+
+
+<a name="mixer/adapter/model/v1beta1/quota.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/adapter/model/v1beta1/quota.proto
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.QuotaRequest"/>
+
+### QuotaRequest
+Expresses the quota allocation request.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| quotas | [QuotaRequest.QuotasEntry](#istio.mixer.adapter.model.v1beta1.QuotaRequest.QuotasEntry) | repeated | The individual quotas to allocate |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.QuotaRequest.QuotaParams"/>
+
+### QuotaRequest.QuotaParams
+parameters for a quota allocation
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| amount | [int64](#int64) |  | Amount of quota to allocate |
+| best_effort | [bool](#bool) |  | When true, supports returning less quota than what was requested. |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.QuotaRequest.QuotasEntry"/>
+
+### QuotaRequest.QuotasEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [QuotaRequest.QuotaParams](#istio.mixer.adapter.model.v1beta1.QuotaRequest.QuotaParams) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.QuotaResult"/>
+
+### QuotaResult
+Expresses the result of multiple quota allocations.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| quotas | [QuotaResult.QuotasEntry](#istio.mixer.adapter.model.v1beta1.QuotaResult.QuotasEntry) | repeated | The resulting quota, one entry per requested quota. |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.QuotaResult.QuotasEntry"/>
+
+### QuotaResult.QuotasEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [QuotaResult.Result](#istio.mixer.adapter.model.v1beta1.QuotaResult.Result) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.QuotaResult.Result"/>
+
+### QuotaResult.Result
+Expresses the result of a quota allocation.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| valid_duration | [google.protobuf.Duration](#google.protobuf.Duration) |  | The amount of time for which this result can be considered valid. |
+| granted_amount | [int64](#int64) |  | The amount of granted quota. When `QuotaParams.best_effort` is true, this will be &gt;= 0. If `QuotaParams.best_effort` is false, this will be either 0 or &gt;= `QuotaParams.amount`. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="mixer/adapter/model/v1beta1/report.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/adapter/model/v1beta1/report.proto
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.ReportResult"/>
+
+### ReportResult
+Expresses the result of a report call.
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="mixer/adapter/model/v1beta1/template.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/adapter/model/v1beta1/template.proto
+
+
+
+<a name="istio.mixer.adapter.model.v1beta1.Template"/>
+
+### Template
+Template provides the details of a mixer template.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| descriptor | [string](#string) |  | Base64 encoded proto descriptor of the template. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | Java Type | Python Type |
+| ----------- | ----- | -------- | --------- | ----------- |
+| <a name="double" /> double |  | double | double | float |
+| <a name="float" /> float |  | float | float | float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
+| <a name="bool" /> bool |  | bool | boolean | boolean |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+

--- a/mixer/v1/README.md
+++ b/mixer/v1/README.md
@@ -1,0 +1,710 @@
+# Protocol Documentation
+<a name="top"/>
+
+## Table of Contents
+
+- [mixer/v1/attributes.proto](#mixer/v1/attributes.proto)
+    - [Attributes](#istio.mixer.v1.Attributes)
+    - [Attributes.AttributeValue](#istio.mixer.v1.Attributes.AttributeValue)
+    - [Attributes.AttributesEntry](#istio.mixer.v1.Attributes.AttributesEntry)
+    - [Attributes.StringMap](#istio.mixer.v1.Attributes.StringMap)
+    - [CompressedAttributes](#istio.mixer.v1.CompressedAttributes)
+    - [CompressedAttributes.BoolsEntry](#istio.mixer.v1.CompressedAttributes.BoolsEntry)
+    - [CompressedAttributes.BytesEntry](#istio.mixer.v1.CompressedAttributes.BytesEntry)
+    - [CompressedAttributes.DoublesEntry](#istio.mixer.v1.CompressedAttributes.DoublesEntry)
+    - [CompressedAttributes.DurationsEntry](#istio.mixer.v1.CompressedAttributes.DurationsEntry)
+    - [CompressedAttributes.Int64sEntry](#istio.mixer.v1.CompressedAttributes.Int64sEntry)
+    - [CompressedAttributes.StringMapsEntry](#istio.mixer.v1.CompressedAttributes.StringMapsEntry)
+    - [CompressedAttributes.StringsEntry](#istio.mixer.v1.CompressedAttributes.StringsEntry)
+    - [CompressedAttributes.TimestampsEntry](#istio.mixer.v1.CompressedAttributes.TimestampsEntry)
+    - [StringMap](#istio.mixer.v1.StringMap)
+    - [StringMap.EntriesEntry](#istio.mixer.v1.StringMap.EntriesEntry)
+  
+  
+  
+  
+
+- [mixer/v1/check.proto](#mixer/v1/check.proto)
+    - [CheckRequest](#istio.mixer.v1.CheckRequest)
+    - [CheckRequest.QuotaParams](#istio.mixer.v1.CheckRequest.QuotaParams)
+    - [CheckRequest.QuotasEntry](#istio.mixer.v1.CheckRequest.QuotasEntry)
+    - [CheckResponse](#istio.mixer.v1.CheckResponse)
+    - [CheckResponse.PreconditionResult](#istio.mixer.v1.CheckResponse.PreconditionResult)
+    - [CheckResponse.QuotaResult](#istio.mixer.v1.CheckResponse.QuotaResult)
+    - [CheckResponse.QuotasEntry](#istio.mixer.v1.CheckResponse.QuotasEntry)
+    - [HeaderOperation](#istio.mixer.v1.HeaderOperation)
+    - [ReferencedAttributes](#istio.mixer.v1.ReferencedAttributes)
+    - [ReferencedAttributes.AttributeMatch](#istio.mixer.v1.ReferencedAttributes.AttributeMatch)
+    - [RouteDirective](#istio.mixer.v1.RouteDirective)
+  
+    - [HeaderOperation.Operation](#istio.mixer.v1.HeaderOperation.Operation)
+    - [ReferencedAttributes.Condition](#istio.mixer.v1.ReferencedAttributes.Condition)
+  
+  
+  
+
+- [mixer/v1/report.proto](#mixer/v1/report.proto)
+    - [ReportRequest](#istio.mixer.v1.ReportRequest)
+    - [ReportResponse](#istio.mixer.v1.ReportResponse)
+  
+  
+  
+  
+
+- [mixer/v1/service.proto](#mixer/v1/service.proto)
+  
+  
+  
+    - [Mixer](#istio.mixer.v1.Mixer)
+  
+
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="mixer/v1/attributes.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/v1/attributes.proto
+
+
+
+<a name="istio.mixer.v1.Attributes"/>
+
+### Attributes
+Attributes represents a set of typed name/value pairs. Many of Mixer&#39;s
+API either consume and/or return attributes.
+
+Istio uses attributes to control the runtime behavior of services running in the service mesh.
+Attributes are named and typed pieces of metadata describing ingress and egress traffic and the
+environment this traffic occurs in. An Istio attribute carries a specific piece
+of information such as the error code of an API request, the latency of an API request, or the
+original IP address of a TCP connection. For example:
+
+```
+request.path: xyz/abc
+request.size: 234
+request.time: 12:34:56.789 04/17/2017
+source.ip: 192.168.0.1
+target.service: example
+```
+
+A given Istio deployment has a fixed vocabulary of attributes that it understands.
+The specific vocabulary is determined by the set of attribute producers being used
+in the deployment. The primary attribute producer in Istio is Envoy, although
+specialized Mixer adapters and services can also generate attributes.
+
+The common baseline set of attributes available in most Istio deployments is defined
+[here](https://istio.io/docs/reference/config/mixer/attribute-vocabulary.html).
+
+Attributes are strongly typed. The supported attribute types are defined by
+[ValueType](https://github.com/istio/api/blob/master/policy/v1beta1/value_type.proto).
+Each type of value is encoded into one of the so-called transport types present
+in this message.
+
+Defines a map of attributes in uncompressed format.
+Following places may use this message:
+1) Configure Istio/Proxy with static per-proxy attributes, such as source.uid.
+2) Service IDL definition to extract api attributes for active requests.
+3) Forward attributes from client proxy to server proxy for HTTP requests.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| attributes | [Attributes.AttributesEntry](#istio.mixer.v1.Attributes.AttributesEntry) | repeated | A map of attribute name to its value. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.Attributes.AttributeValue"/>
+
+### Attributes.AttributeValue
+Specifies one attribute value with different type.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| string_value | [string](#string) |  | Used for values of type STRING, DNS_NAME, EMAIL_ADDRESS, and URI |
+| int64_value | [int64](#int64) |  | Used for values of type INT64 |
+| double_value | [double](#double) |  | Used for values of type DOUBLE |
+| bool_value | [bool](#bool) |  | Used for values of type BOOL |
+| bytes_value | [bytes](#bytes) |  | Used for values of type BYTES |
+| timestamp_value | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Used for values of type TIMESTAMP |
+| duration_value | [google.protobuf.Duration](#google.protobuf.Duration) |  | Used for values of type DURATION |
+| string_map_value | [Attributes.StringMap](#istio.mixer.v1.Attributes.StringMap) |  | Used for values of type STRING_MAP |
+
+
+
+
+
+
+<a name="istio.mixer.v1.Attributes.AttributesEntry"/>
+
+### Attributes.AttributesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [Attributes.AttributeValue](#istio.mixer.v1.Attributes.AttributeValue) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.Attributes.StringMap"/>
+
+### Attributes.StringMap
+Defines a string map.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entries | [Attributes.StringMap.EntriesEntry](#istio.mixer.v1.Attributes.StringMap.EntriesEntry) | repeated | Holds a set of name/value pairs. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CompressedAttributes"/>
+
+### CompressedAttributes
+Defines a list of attributes in compressed format optimized for transport.
+Within this message, strings are referenced using integer indices into
+one of two string dictionaries. Positive integers index into the global
+deployment-wide dictionary, whereas negative integers index into the message-level
+dictionary instead. The message-level dictionary is carried by the
+`words` field of this message, the deployment-wide dictionary is determined via
+configuration.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| words | [string](#string) | repeated | The message-level dictionary. |
+| strings | [CompressedAttributes.StringsEntry](#istio.mixer.v1.CompressedAttributes.StringsEntry) | repeated | Holds attributes of type STRING, DNS_NAME, EMAIL_ADDRESS, URI |
+| int64s | [CompressedAttributes.Int64sEntry](#istio.mixer.v1.CompressedAttributes.Int64sEntry) | repeated | Holds attributes of type INT64 |
+| doubles | [CompressedAttributes.DoublesEntry](#istio.mixer.v1.CompressedAttributes.DoublesEntry) | repeated | Holds attributes of type DOUBLE |
+| bools | [CompressedAttributes.BoolsEntry](#istio.mixer.v1.CompressedAttributes.BoolsEntry) | repeated | Holds attributes of type BOOL |
+| timestamps | [CompressedAttributes.TimestampsEntry](#istio.mixer.v1.CompressedAttributes.TimestampsEntry) | repeated | Holds attributes of type TIMESTAMP |
+| durations | [CompressedAttributes.DurationsEntry](#istio.mixer.v1.CompressedAttributes.DurationsEntry) | repeated | Holds attributes of type DURATION |
+| bytes | [CompressedAttributes.BytesEntry](#istio.mixer.v1.CompressedAttributes.BytesEntry) | repeated | Holds attributes of type BYTES |
+| string_maps | [CompressedAttributes.StringMapsEntry](#istio.mixer.v1.CompressedAttributes.StringMapsEntry) | repeated | Holds attributes of type STRING_MAP |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CompressedAttributes.BoolsEntry"/>
+
+### CompressedAttributes.BoolsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [sint32](#sint32) |  |  |
+| value | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CompressedAttributes.BytesEntry"/>
+
+### CompressedAttributes.BytesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [sint32](#sint32) |  |  |
+| value | [bytes](#bytes) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CompressedAttributes.DoublesEntry"/>
+
+### CompressedAttributes.DoublesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [sint32](#sint32) |  |  |
+| value | [double](#double) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CompressedAttributes.DurationsEntry"/>
+
+### CompressedAttributes.DurationsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [sint32](#sint32) |  |  |
+| value | [google.protobuf.Duration](#google.protobuf.Duration) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CompressedAttributes.Int64sEntry"/>
+
+### CompressedAttributes.Int64sEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [sint32](#sint32) |  |  |
+| value | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CompressedAttributes.StringMapsEntry"/>
+
+### CompressedAttributes.StringMapsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [sint32](#sint32) |  |  |
+| value | [StringMap](#istio.mixer.v1.StringMap) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CompressedAttributes.StringsEntry"/>
+
+### CompressedAttributes.StringsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [sint32](#sint32) |  |  |
+| value | [sint32](#sint32) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CompressedAttributes.TimestampsEntry"/>
+
+### CompressedAttributes.TimestampsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [sint32](#sint32) |  |  |
+| value | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.StringMap"/>
+
+### StringMap
+A map of string to string. The keys and values in this map are dictionary
+indices (see the [Attributes][istio.mixer.v1.CompressedAttributes] message for an explanation)
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entries | [StringMap.EntriesEntry](#istio.mixer.v1.StringMap.EntriesEntry) | repeated | Holds a set of name/value pairs. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.StringMap.EntriesEntry"/>
+
+### StringMap.EntriesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [sint32](#sint32) |  |  |
+| value | [sint32](#sint32) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="mixer/v1/check.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/v1/check.proto
+
+
+
+<a name="istio.mixer.v1.CheckRequest"/>
+
+### CheckRequest
+Used to get a thumbs-up/thumbs-down before performing an action.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| attributes | [CompressedAttributes](#istio.mixer.v1.CompressedAttributes) |  | The attributes to use for this request.  Mixer&#39;s configuration determines how these attributes are used to establish the result returned in the response. |
+| global_word_count | [uint32](#uint32) |  | The number of words in the global dictionary, used with to populate the attributes. This value is used as a quick way to determine whether the client is using a dictionary that the server understands. |
+| deduplication_id | [string](#string) |  | Used for deduplicating `Check` calls in the case of failed RPCs and retries. This should be a UUID per call, where the same UUID is used for retries of the same call. |
+| quotas | [CheckRequest.QuotasEntry](#istio.mixer.v1.CheckRequest.QuotasEntry) | repeated | The individual quotas to allocate |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CheckRequest.QuotaParams"/>
+
+### CheckRequest.QuotaParams
+parameters for a quota allocation
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| amount | [int64](#int64) |  | Amount of quota to allocate |
+| best_effort | [bool](#bool) |  | When true, supports returning less quota than what was requested. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CheckRequest.QuotasEntry"/>
+
+### CheckRequest.QuotasEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [CheckRequest.QuotaParams](#istio.mixer.v1.CheckRequest.QuotaParams) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CheckResponse"/>
+
+### CheckResponse
+The response generated by the Check method.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| precondition | [CheckResponse.PreconditionResult](#istio.mixer.v1.CheckResponse.PreconditionResult) |  | The precondition check results. |
+| quotas | [CheckResponse.QuotasEntry](#istio.mixer.v1.CheckResponse.QuotasEntry) | repeated | The resulting quota, one entry per requested quota. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CheckResponse.PreconditionResult"/>
+
+### CheckResponse.PreconditionResult
+Expresses the result of a precondition check.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| status | [google.rpc.Status](#google.rpc.Status) |  | A status code of OK indicates all preconditions were satisfied. Any other code indicates not all preconditions were satisfied and details describe why. |
+| valid_duration | [google.protobuf.Duration](#google.protobuf.Duration) |  | The amount of time for which this result can be considered valid. |
+| valid_use_count | [int32](#int32) |  | The number of uses for which this result can be considered valid. |
+| referenced_attributes | [ReferencedAttributes](#istio.mixer.v1.ReferencedAttributes) |  | The total set of attributes that were used in producing the result along with matching conditions. |
+| route_directive | [RouteDirective](#istio.mixer.v1.RouteDirective) |  | An optional routing directive, used to manipulate the traffic metadata whenever all preconditions are satisfied. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CheckResponse.QuotaResult"/>
+
+### CheckResponse.QuotaResult
+Expresses the result of a quota allocation.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| valid_duration | [google.protobuf.Duration](#google.protobuf.Duration) |  | The amount of time for which this result can be considered valid. |
+| granted_amount | [int64](#int64) |  | The amount of granted quota. When `QuotaParams.best_effort` is true, this will be &gt;= 0. If `QuotaParams.best_effort` is false, this will be either 0 or &gt;= `QuotaParams.amount`. |
+| referenced_attributes | [ReferencedAttributes](#istio.mixer.v1.ReferencedAttributes) |  | The total set of attributes that were used in producing the result along with matching conditions. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.CheckResponse.QuotasEntry"/>
+
+### CheckResponse.QuotasEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [CheckResponse.QuotaResult](#istio.mixer.v1.CheckResponse.QuotaResult) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.HeaderOperation"/>
+
+### HeaderOperation
+Operation on HTTP headers to replace, append, or remove a header. Header
+names are normalized to lower-case with dashes, e.g.  &#34;x-request-id&#34;.
+Pseudo-headers &#34;:path&#34;, &#34;:authority&#34;, and &#34;:method&#34; are supported to modify
+the request headers.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | Header name. |
+| value | [string](#string) |  | Header value. |
+| operation | [HeaderOperation.Operation](#istio.mixer.v1.HeaderOperation.Operation) |  | Header operation. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.ReferencedAttributes"/>
+
+### ReferencedAttributes
+Describes the attributes that were used to determine the response.
+This can be used to construct a response cache.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| words | [string](#string) | repeated | The message-level dictionary. Refer to [CompressedAttributes][istio.mixer.v1.CompressedAttributes] for information on using dictionaries. |
+| attribute_matches | [ReferencedAttributes.AttributeMatch](#istio.mixer.v1.ReferencedAttributes.AttributeMatch) | repeated | Describes a set of attributes. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.ReferencedAttributes.AttributeMatch"/>
+
+### ReferencedAttributes.AttributeMatch
+Describes a single attribute match.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [sint32](#sint32) |  | The name of the attribute. This is a dictionary index encoded in a manner identical to all strings in the [CompressedAttributes][istio.mixer.v1.CompressedAttributes] message. |
+| condition | [ReferencedAttributes.Condition](#istio.mixer.v1.ReferencedAttributes.Condition) |  | The kind of match against the attribute value. |
+| regex | [string](#string) |  | If a REGEX condition is provided for a STRING_MAP attribute, clients should use the regex value to match against map keys. |
+| map_key | [sint32](#sint32) |  | A key in a STRING_MAP. When multiple keys from a STRING_MAP attribute were referenced, there will be multiple AttributeMatch messages with different map_key values. Values for map_key SHOULD be ignored for attributes that are not STRING_MAP.  Indices for the keys are used (taken either from the message dictionary from the `words` field or the global dictionary).  If no map_key value is provided for a STRING_MAP attribute, the entire STRING_MAP will be used. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.RouteDirective"/>
+
+### RouteDirective
+Expresses the routing manipulation actions to be performed on behalf of
+Mixer in response to a successful precondition check.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| request_header_operations | [HeaderOperation](#istio.mixer.v1.HeaderOperation) | repeated | Operations on the request headers. |
+| response_header_operations | [HeaderOperation](#istio.mixer.v1.HeaderOperation) | repeated | Operations on the response headers. |
+| direct_response_code | [uint32](#uint32) |  | If set, enables a direct response without proxying the request to the routing destination. Required to be a value in the 2xx or 3xx range. |
+| direct_response_body | [string](#string) |  | Supplies the response body for the direct response. If this setting is omitted, no body is included in the generated response. |
+
+
+
+
+
+ 
+
+
+<a name="istio.mixer.v1.HeaderOperation.Operation"/>
+
+### HeaderOperation.Operation
+Operation type.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| REPLACE | 0 | replaces the header with the given name |
+| REMOVE | 1 | removes the header with the given name (the value is ignored) |
+| APPEND | 2 | appends the value to the header value, or sets it if not present |
+
+
+
+<a name="istio.mixer.v1.ReferencedAttributes.Condition"/>
+
+### ReferencedAttributes.Condition
+How an attribute&#39;s value was matched
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| CONDITION_UNSPECIFIED | 0 | should not occur |
+| ABSENCE | 1 | match when attribute doesn&#39;t exist |
+| EXACT | 2 | match when attribute value is an exact byte-for-byte match |
+| REGEX | 3 | match when attribute value matches the included regex |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="mixer/v1/report.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/v1/report.proto
+
+
+
+<a name="istio.mixer.v1.ReportRequest"/>
+
+### ReportRequest
+Used to report telemetry after performing one or more actions.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| attributes | [CompressedAttributes](#istio.mixer.v1.CompressedAttributes) | repeated | The attributes to use for this request.  Each `Attributes` element represents the state of a single action. Multiple actions can be provided in a single message in order to improve communication efficiency. The client can accumulate a set of actions and send them all in one single message.  Although each `Attributes` message is semantically treated as an independent stand-alone entity unrelated to the other attributes within the message, this message format leverages delta-encoding between attribute messages in order to substantially reduce the request size and improve end-to-end efficiency. Each individual set of attributes is used to modify the previous set. This eliminates the need to redundantly send the same attributes multiple times over within a single request.  If a client is not sophisticated and doesn&#39;t want to use delta-encoding, a degenerate case is to include all attributes in every individual message. |
+| default_words | [string](#string) | repeated | The default message-level dictionary for all the attributes. Individual attribute messages can have their own dictionaries, but if they don&#39;t then this set of words, if it is provided, is used instead.  This makes it possible to share the same dictionary for all attributes in this request, which can substantially reduce the overall request size. |
+| global_word_count | [uint32](#uint32) |  | The number of words in the global dictionary. To detect global dictionary out of sync between client and server. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.ReportResponse"/>
+
+### ReportResponse
+Used to carry responses to telemetry reports
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="mixer/v1/service.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/v1/service.proto
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="istio.mixer.v1.Mixer"/>
+
+### Mixer
+Mixer provides three core features:
+
+- *Precondition Checking*. Enables callers to verify a number of preconditions
+before responding to an incoming request from a service consumer.
+Preconditions can include whether the service consumer is properly
+authenticated, is on the service’s whitelist, passes ACL checks, and more.
+
+- *Quota Management*. Enables services to allocate and free quota on a number
+of dimensions, Quotas are used as a relatively simple resource management tool
+to provide some fairness between service consumers when contending for limited
+resources. Rate limits are examples of quotas.
+
+- *Telemetry Reporting*. Enables services to report logging and monitoring.
+In the future, it will also enable tracing and billing streams intended for
+both the service operator as well as for service consumers.
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| Check | [CheckRequest](#istio.mixer.v1.CheckRequest) | [CheckResponse](#istio.mixer.v1.CheckRequest) | Checks preconditions and allocate quota before performing an operation. The preconditions enforced depend on the set of supplied attributes and the active configuration. |
+| Report | [ReportRequest](#istio.mixer.v1.ReportRequest) | [ReportResponse](#istio.mixer.v1.ReportRequest) | Reports telemetry, such as logs and metrics. The reported information depends on the set of supplied attributes and the active configuration. |
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | Java Type | Python Type |
+| ----------- | ----- | -------- | --------- | ----------- |
+| <a name="double" /> double |  | double | double | float |
+| <a name="float" /> float |  | float | float | float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
+| <a name="bool" /> bool |  | bool | boolean | boolean |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+

--- a/mixer/v1/config/client/README.md
+++ b/mixer/v1/config/client/README.md
@@ -1,0 +1,600 @@
+# Protocol Documentation
+<a name="top"/>
+
+## Table of Contents
+
+- [mixer/v1/config/client/api_spec.proto](#mixer/v1/config/client/api_spec.proto)
+    - [APIKey](#istio.mixer.v1.config.client.APIKey)
+    - [HTTPAPISpec](#istio.mixer.v1.config.client.HTTPAPISpec)
+    - [HTTPAPISpecBinding](#istio.mixer.v1.config.client.HTTPAPISpecBinding)
+    - [HTTPAPISpecPattern](#istio.mixer.v1.config.client.HTTPAPISpecPattern)
+    - [HTTPAPISpecReference](#istio.mixer.v1.config.client.HTTPAPISpecReference)
+  
+  
+  
+  
+
+- [mixer/v1/config/client/client_config.proto](#mixer/v1/config/client/client_config.proto)
+    - [HttpClientConfig](#istio.mixer.v1.config.client.HttpClientConfig)
+    - [HttpClientConfig.ServiceConfigsEntry](#istio.mixer.v1.config.client.HttpClientConfig.ServiceConfigsEntry)
+    - [NetworkFailPolicy](#istio.mixer.v1.config.client.NetworkFailPolicy)
+    - [ServiceConfig](#istio.mixer.v1.config.client.ServiceConfig)
+    - [TcpClientConfig](#istio.mixer.v1.config.client.TcpClientConfig)
+    - [TransportConfig](#istio.mixer.v1.config.client.TransportConfig)
+  
+    - [NetworkFailPolicy.FailPolicy](#istio.mixer.v1.config.client.NetworkFailPolicy.FailPolicy)
+  
+  
+  
+
+- [mixer/v1/config/client/quota.proto](#mixer/v1/config/client/quota.proto)
+    - [AttributeMatch](#istio.mixer.v1.config.client.AttributeMatch)
+    - [AttributeMatch.ClauseEntry](#istio.mixer.v1.config.client.AttributeMatch.ClauseEntry)
+    - [Quota](#istio.mixer.v1.config.client.Quota)
+    - [QuotaRule](#istio.mixer.v1.config.client.QuotaRule)
+    - [QuotaSpec](#istio.mixer.v1.config.client.QuotaSpec)
+    - [QuotaSpecBinding](#istio.mixer.v1.config.client.QuotaSpecBinding)
+    - [QuotaSpecBinding.QuotaSpecReference](#istio.mixer.v1.config.client.QuotaSpecBinding.QuotaSpecReference)
+    - [StringMatch](#istio.mixer.v1.config.client.StringMatch)
+  
+  
+  
+  
+
+- [mixer/v1/config/client/service.proto](#mixer/v1/config/client/service.proto)
+    - [IstioService](#istio.mixer.v1.config.client.IstioService)
+    - [IstioService.LabelsEntry](#istio.mixer.v1.config.client.IstioService.LabelsEntry)
+  
+  
+  
+  
+
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="mixer/v1/config/client/api_spec.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/v1/config/client/api_spec.proto
+
+
+
+<a name="istio.mixer.v1.config.client.APIKey"/>
+
+### APIKey
+APIKey defines the explicit configuration for generating the
+`request.api_key` attribute from HTTP requests.
+
+See https://swagger.io/docs/specification/authentication/api-keys
+for a general overview of API keys as defined by OpenAPI.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| query | [string](#string) |  | API Key is sent as a query parameter. `query` represents the query string parameter name.  For example, `query=api_key` should be used with the following request:   GET /something?api_key=abcdef12345 |
+| header | [string](#string) |  | API key is sent in a request header. `header` represents the header name.  For example, `header=X-API-KEY` should be used with the following request:   GET /something HTTP/1.1 X-API-Key: abcdef12345 |
+| cookie | [string](#string) |  | API key is sent in a [cookie](https://swagger.io/docs/specification/authentication/cookie-authentication),  For example, `cookie=X-API-KEY` should be used for the following request:   GET /something HTTP/1.1 Cookie: X-API-KEY=abcdef12345 |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.HTTPAPISpec"/>
+
+### HTTPAPISpec
+HTTPAPISpec defines the canonical configuration for generating
+API-related attributes from HTTP requests based on the method and
+uri templated path matches. It is sufficient for defining the API
+surface of a service for the purposes of API attribute
+generation. It is not intended to represent auth, quota,
+documentation, or other information commonly found in other API
+specifications, e.g. OpenAPI.
+
+Existing standards that define operations (or methods) in terms of
+HTTP methods and paths can be normalized to this format for use in
+Istio. For example, a simple petstore API described by OpenAPIv2
+[here](https://github.com/googleapis/gnostic/blob/master/examples/v2.0/yaml/petstore-simple.yaml)
+can be represented with the following HTTPAPISpec.
+
+```yaml
+apiVersion: config.istio.io/v1alpha2
+kind: HTTPAPISpec
+metadata:
+  name: petstore
+  namespace: default
+spec:
+  attributes:
+    api.service: petstore.swagger.io
+    api.version: 1.0.0
+  patterns:
+  - attributes:
+      api.operation: findPets
+    httpMethod: GET
+    uriTemplate: /api/pets
+  - attributes:
+      api.operation: addPet
+    httpMethod: POST
+    uriTemplate: /api/pets
+  - attributes:
+      api.operation: findPetById
+    httpMethod: GET
+    uriTemplate: /api/pets/{id}
+  - attributes:
+      api.operation: deletePet
+    httpMethod: DELETE
+    uriTemplate: /api/pets/{id}
+  api_keys:
+  - query: api-key
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| attributes | [istio.mixer.v1.Attributes](#istio.mixer.v1.Attributes) |  | List of attributes that are generated when *any* of the HTTP patterns match. This list typically includes the &#34;api.service&#34; and &#34;api.version&#34; attributes. |
+| patterns | [HTTPAPISpecPattern](#istio.mixer.v1.config.client.HTTPAPISpecPattern) | repeated | List of HTTP patterns to match. |
+| api_keys | [APIKey](#istio.mixer.v1.config.client.APIKey) | repeated | List of APIKey that describes how to extract an API-KEY from an HTTP request. The first API-Key match found in the list is used, i.e. &#39;OR&#39; semantics.  The following default policies are used to generate the `request.api_key` attribute if no explicit APIKey is defined.   `query: key, `query: api_key`, and then `header: x-api-key` |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.HTTPAPISpecBinding"/>
+
+### HTTPAPISpecBinding
+HTTPAPISpecBinding defines the binding between HTTPAPISpecs and one or more
+IstioService. For example, the following establishes a binding
+between the HTTPAPISpec `petstore` and service `foo` in namespace `bar`.
+
+```yaml
+apiVersion: config.istio.io/v1alpha2
+kind: HTTPAPISpecBinding
+metadata:
+  name: my-binding
+  namespace: default
+spec:
+  services:
+  - name: foo
+    namespace: bar
+  api_specs:
+  - name: petstore
+    namespace: default
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| services | [IstioService](#istio.mixer.v1.config.client.IstioService) | repeated | REQUIRED. One or more services to map the listed HTTPAPISpec onto. |
+| api_specs | [HTTPAPISpecReference](#istio.mixer.v1.config.client.HTTPAPISpecReference) | repeated | REQUIRED. One or more HTTPAPISpec references that should be mapped to the specified service(s). The aggregate collection of match conditions defined in the HTTPAPISpecs should not overlap. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.HTTPAPISpecPattern"/>
+
+### HTTPAPISpecPattern
+HTTPAPISpecPattern defines a single pattern to match against
+incoming HTTP requests. The per-pattern list of attributes is
+generated if both the http_method and uri_template match. In
+addition, the top-level list of attributes in the HTTPAPISpec is also
+generated.
+
+```yaml
+pattern:
+- attributes
+    api.operation: doFooBar
+  httpMethod: GET
+  uriTemplate: /foo/bar
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| attributes | [istio.mixer.v1.Attributes](#istio.mixer.v1.Attributes) |  | List of attributes that are generated if the HTTP request matches the specified http_method and uri_template. This typically includes the &#34;api.operation&#34; attribute. |
+| http_method | [string](#string) |  | HTTP request method to match against as defined by [rfc7231](https://tools.ietf.org/html/rfc7231#page-21). For example: GET, HEAD, POST, PUT, DELETE. |
+| uri_template | [string](#string) |  | URI template to match against as defined by [rfc6570](https://tools.ietf.org/html/rfc6570). For example, the following are valid URI templates:   /pets /pets/{id} /dictionary/{term:1}/{term} /search{?q*,lang} |
+| regex | [string](#string) |  | EXPERIMENTAL:  ecmascript style regex-based match as defined by [EDCA-262](http://en.cppreference.com/w/cpp/regex/ecmascript). For example,   &#34;^/pets/(.*?)?&#34; |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.HTTPAPISpecReference"/>
+
+### HTTPAPISpecReference
+HTTPAPISpecReference defines a reference to an HTTPAPISpec. This is
+typically used for establishing bindings between an HTTPAPISpec and an
+IstioService. For example, the following defines an
+HTTPAPISpecReference for service `foo` in namespace `bar`.
+
+```yaml
+- name: foo
+  namespace: bar
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | REQUIRED. The short name of the HTTPAPISpec. This is the resource name defined by the metadata name field. |
+| namespace | [string](#string) |  | Optional namespace of the HTTPAPISpec. Defaults to the encompassing HTTPAPISpecBinding&#39;s metadata namespace field. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="mixer/v1/config/client/client_config.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/v1/config/client/client_config.proto
+
+
+
+<a name="istio.mixer.v1.config.client.HttpClientConfig"/>
+
+### HttpClientConfig
+Defines the client config for HTTP.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| transport | [TransportConfig](#istio.mixer.v1.config.client.TransportConfig) |  | The transport config. |
+| service_configs | [HttpClientConfig.ServiceConfigsEntry](#istio.mixer.v1.config.client.HttpClientConfig.ServiceConfigsEntry) | repeated | Map of control configuration indexed by destination.service. This is used to support per-service configuration for cases where a mixerclient serves multiple services. |
+| default_destination_service | [string](#string) |  | Default destination service name if none was specified in the client request. |
+| mixer_attributes | [istio.mixer.v1.Attributes](#istio.mixer.v1.Attributes) |  | Default attributes to send to Mixer in both Check and Report. This typically includes &#34;destination.ip&#34; and &#34;destination.uid&#34; attributes. |
+| forward_attributes | [istio.mixer.v1.Attributes](#istio.mixer.v1.Attributes) |  | Default attributes to forward to upstream. This typically includes the &#34;source.ip&#34; and &#34;source.uid&#34; attributes. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.HttpClientConfig.ServiceConfigsEntry"/>
+
+### HttpClientConfig.ServiceConfigsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [ServiceConfig](#istio.mixer.v1.config.client.ServiceConfig) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.NetworkFailPolicy"/>
+
+### NetworkFailPolicy
+Specifies the behavior when the client is unable to connect to Mixer.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| policy | [NetworkFailPolicy.FailPolicy](#istio.mixer.v1.config.client.NetworkFailPolicy.FailPolicy) |  | Specifies the behavior when the client is unable to connect to Mixer. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.ServiceConfig"/>
+
+### ServiceConfig
+Defines the per-service client configuration.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| disable_check_calls | [bool](#bool) |  | If true, do not call Mixer Check. |
+| disable_report_calls | [bool](#bool) |  | If true, do not call Mixer Report. |
+| mixer_attributes | [istio.mixer.v1.Attributes](#istio.mixer.v1.Attributes) |  | Send these attributes to Mixer in both Check and Report. This typically includes the &#34;destination.service&#34; attribute. In case of a per-route override, per-route attributes take precedence over the attributes supplied in the client configuration. |
+| http_api_spec | [HTTPAPISpec](#istio.mixer.v1.config.client.HTTPAPISpec) | repeated | HTTP API specifications to generate API attributes. |
+| quota_spec | [QuotaSpec](#istio.mixer.v1.config.client.QuotaSpec) | repeated | Quota specifications to generate quota requirements. |
+| network_fail_policy | [NetworkFailPolicy](#istio.mixer.v1.config.client.NetworkFailPolicy) |  | Specifies the behavior when the client is unable to connect to Mixer. This is the service-level policy. It overrides [mesh-level policy][istio.mixer.v1.config.client.TransportConfig.network_fail_policy]. |
+| forward_attributes | [istio.mixer.v1.Attributes](#istio.mixer.v1.Attributes) |  | Default attributes to forward to upstream. This typically includes the &#34;source.ip&#34; and &#34;source.uid&#34; attributes. In case of a per-route override, per-route attributes take precedence over the attributes supplied in the client configuration.  Forwarded attributes take precedence over the static Mixer attributes. The full order of application is as follows: 1. static Mixer attributes from the filter config; 2. static Mixer attributes from the route config; 3. forwarded attributes from the source filter config (if any); 4. forwarded attributes from the source route config (if any); 5. derived attributes from the request metadata. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.TcpClientConfig"/>
+
+### TcpClientConfig
+Defines the client config for TCP.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| transport | [TransportConfig](#istio.mixer.v1.config.client.TransportConfig) |  | The transport config. |
+| mixer_attributes | [istio.mixer.v1.Attributes](#istio.mixer.v1.Attributes) |  | Default attributes to send to Mixer in both Check and Report. This typically includes &#34;destination.ip&#34; and &#34;destination.uid&#34; attributes. |
+| disable_check_calls | [bool](#bool) |  | If set to true, disables mixer check calls. |
+| disable_report_calls | [bool](#bool) |  | If set to true, disables mixer check calls. |
+| connection_quota_spec | [QuotaSpec](#istio.mixer.v1.config.client.QuotaSpec) |  | Quota specifications to generate quota requirements. It applies on the new TCP connections. |
+| report_interval | [google.protobuf.Duration](#google.protobuf.Duration) |  | Specify report interval to send periodical reports for long TCP connections. If not specified, the interval is 10 seconds. This interval should not be less than 1 second, otherwise it will be reset to 1 second. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.TransportConfig"/>
+
+### TransportConfig
+Defines the transport config on how to call Mixer.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| disable_check_cache | [bool](#bool) |  | The flag to disable check cache. |
+| disable_quota_cache | [bool](#bool) |  | The flag to disable quota cache. |
+| disable_report_batch | [bool](#bool) |  | The flag to disable report batch. |
+| network_fail_policy | [NetworkFailPolicy](#istio.mixer.v1.config.client.NetworkFailPolicy) |  | Specifies the behavior when the client is unable to connect to Mixer. This is the mesh level policy. The default value for policy is FAIL_OPEN. |
+| stats_update_interval | [google.protobuf.Duration](#google.protobuf.Duration) |  | Specify refresh interval to write mixer client statistics to Envoy share memory. If not specified, the interval is 10 seconds. |
+| check_cluster | [string](#string) |  | Name of the cluster that will forward check calls to a pool of mixer servers. Defaults to &#34;mixer_server&#34;. By using different names for checkCluster and reportCluster, it is possible to have one set of mixer servers handle check calls, while another set of mixer servers handle report calls.  NOTE: Any value other than the default &#34;mixer_server&#34; will require the Istio Grafana dashboards to be reconfigured to use the new name. |
+| report_cluster | [string](#string) |  | Name of the cluster that will forward report calls to a pool of mixer servers. Defaults to &#34;mixer_server&#34;. By using different names for checkCluster and reportCluster, it is possible to have one set of mixer servers handle check calls, while another set of mixer servers handle report calls.  NOTE: Any value other than the default &#34;mixer_server&#34; will require the Istio Grafana dashboards to be reconfigured to use the new name. |
+| attributes_for_mixer_proxy | [istio.mixer.v1.Attributes](#istio.mixer.v1.Attributes) |  | Default attributes to forward to mixer upstream. This typically includes the &#34;source.ip&#34; and &#34;source.uid&#34; attributes. These attributes are consumed by the proxy in front of mixer. |
+
+
+
+
+
+ 
+
+
+<a name="istio.mixer.v1.config.client.NetworkFailPolicy.FailPolicy"/>
+
+### NetworkFailPolicy.FailPolicy
+Describes the policy.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| FAIL_OPEN | 0 | If network connection fails, request is allowed and delivered to the service. |
+| FAIL_CLOSE | 1 | If network connection fails, request is rejected. |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="mixer/v1/config/client/quota.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/v1/config/client/quota.proto
+
+
+
+<a name="istio.mixer.v1.config.client.AttributeMatch"/>
+
+### AttributeMatch
+Specifies a match clause to match Istio attributes
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| clause | [AttributeMatch.ClauseEntry](#istio.mixer.v1.config.client.AttributeMatch.ClauseEntry) | repeated | Map of attribute names to StringMatch type. Each map element specifies one condition to match.  Example:   clause: source.uid: exact: SOURCE_UID request.http_method: exact: POST |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.AttributeMatch.ClauseEntry"/>
+
+### AttributeMatch.ClauseEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [StringMatch](#istio.mixer.v1.config.client.StringMatch) |  |  |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.Quota"/>
+
+### Quota
+Specifies a quota to use with quota name and amount.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| quota | [string](#string) |  | The quota name to charge |
+| charge | [int64](#int64) |  | The quota amount to charge |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.QuotaRule"/>
+
+### QuotaRule
+Specifies a rule with list of matches and list of quotas.
+If any clause matched, the list of quotas will be used.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| match | [AttributeMatch](#istio.mixer.v1.config.client.AttributeMatch) | repeated | If empty, match all request. If any of match is true, it is matched. |
+| quotas | [Quota](#istio.mixer.v1.config.client.Quota) | repeated | The list of quotas to charge. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.QuotaSpec"/>
+
+### QuotaSpec
+Determines the quotas used for individual requests.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| rules | [QuotaRule](#istio.mixer.v1.config.client.QuotaRule) | repeated | A list of Quota rules. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.QuotaSpecBinding"/>
+
+### QuotaSpecBinding
+QuotaSpecBinding defines the binding between QuotaSpecs and one or more
+IstioService.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| services | [IstioService](#istio.mixer.v1.config.client.IstioService) | repeated | REQUIRED. One or more services to map the listed QuotaSpec onto. |
+| quota_specs | [QuotaSpecBinding.QuotaSpecReference](#istio.mixer.v1.config.client.QuotaSpecBinding.QuotaSpecReference) | repeated | REQUIRED. One or more QuotaSpec references that should be mapped to the specified service(s). The aggregate collection of match conditions defined in the QuotaSpecs should not overlap. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.QuotaSpecBinding.QuotaSpecReference"/>
+
+### QuotaSpecBinding.QuotaSpecReference
+QuotaSpecReference uniquely identifies the QuotaSpec used in the
+Binding.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | REQUIRED. The short name of the QuotaSpec. This is the resource name defined by the metadata name field. |
+| namespace | [string](#string) |  | Optional namespace of the QuotaSpec. Defaults to the value of the metadata namespace field. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.StringMatch"/>
+
+### StringMatch
+Describes how to match a given string in HTTP headers. Match is
+case-sensitive.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| exact | [string](#string) |  | exact string match |
+| prefix | [string](#string) |  | prefix-based match |
+| regex | [string](#string) |  | ECMAscript style regex-based match |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="mixer/v1/config/client/service.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## mixer/v1/config/client/service.proto
+
+
+
+<a name="istio.mixer.v1.config.client.IstioService"/>
+
+### IstioService
+IstioService identifies a service and optionally service version.
+The FQDN of the service is composed from the name, namespace, and implementation-specific domain suffix
+(e.g. on Kubernetes, &#34;reviews&#34; &#43; &#34;default&#34; &#43; &#34;svc.cluster.local&#34; -&gt; &#34;reviews.default.svc.cluster.local&#34;).
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | The short name of the service such as &#34;foo&#34;. |
+| namespace | [string](#string) |  | Optional namespace of the service. Defaults to value of metadata namespace field. |
+| domain | [string](#string) |  | Domain suffix used to construct the service FQDN in implementations that support such specification. |
+| service | [string](#string) |  | The service FQDN. |
+| labels | [IstioService.LabelsEntry](#istio.mixer.v1.config.client.IstioService.LabelsEntry) | repeated | Optional one or more labels that uniquely identify the service version.  *Note:* When used for a RouteRule destination, labels MUST be empty. |
+
+
+
+
+
+
+<a name="istio.mixer.v1.config.client.IstioService.LabelsEntry"/>
+
+### IstioService.LabelsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | Java Type | Python Type |
+| ----------- | ----- | -------- | --------- | ----------- |
+| <a name="double" /> double |  | double | double | float |
+| <a name="float" /> float |  | float | float | float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
+| <a name="bool" /> bool |  | bool | boolean | boolean |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+

--- a/networking/v1alpha3/README.md
+++ b/networking/v1alpha3/README.md
@@ -1,0 +1,2140 @@
+# Protocol Documentation
+<a name="top"/>
+
+## Table of Contents
+
+- [networking/v1alpha3/destination_rule.proto](#networking/v1alpha3/destination_rule.proto)
+    - [ConnectionPoolSettings](#istio.networking.v1alpha3.ConnectionPoolSettings)
+    - [ConnectionPoolSettings.HTTPSettings](#istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings)
+    - [ConnectionPoolSettings.TCPSettings](#istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings)
+    - [DestinationRule](#istio.networking.v1alpha3.DestinationRule)
+    - [LoadBalancerSettings](#istio.networking.v1alpha3.LoadBalancerSettings)
+    - [LoadBalancerSettings.ConsistentHashLB](#istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB)
+    - [OutlierDetection](#istio.networking.v1alpha3.OutlierDetection)
+    - [OutlierDetection.HTTPSettings](#istio.networking.v1alpha3.OutlierDetection.HTTPSettings)
+    - [Subset](#istio.networking.v1alpha3.Subset)
+    - [Subset.LabelsEntry](#istio.networking.v1alpha3.Subset.LabelsEntry)
+    - [TLSSettings](#istio.networking.v1alpha3.TLSSettings)
+    - [TrafficPolicy](#istio.networking.v1alpha3.TrafficPolicy)
+    - [TrafficPolicy.PortTrafficPolicy](#istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy)
+  
+    - [LoadBalancerSettings.SimpleLB](#istio.networking.v1alpha3.LoadBalancerSettings.SimpleLB)
+    - [TLSSettings.TLSmode](#istio.networking.v1alpha3.TLSSettings.TLSmode)
+  
+  
+  
+
+- [networking/v1alpha3/envoy_filter.proto](#networking/v1alpha3/envoy_filter.proto)
+    - [EnvoyFilters](#istio.networking.v1alpha3.EnvoyFilters)
+    - [EnvoyFilters.Filter](#istio.networking.v1alpha3.EnvoyFilters.Filter)
+    - [EnvoyFilters.InsertPosition](#istio.networking.v1alpha3.EnvoyFilters.InsertPosition)
+    - [EnvoyFilters.ListenerMatch](#istio.networking.v1alpha3.EnvoyFilters.ListenerMatch)
+    - [EnvoyFilters.SelectorEntry](#istio.networking.v1alpha3.EnvoyFilters.SelectorEntry)
+  
+  
+  
+  
+
+- [networking/v1alpha3/gateway.proto](#networking/v1alpha3/gateway.proto)
+    - [Gateway](#istio.networking.v1alpha3.Gateway)
+    - [Gateway.SelectorEntry](#istio.networking.v1alpha3.Gateway.SelectorEntry)
+    - [Port](#istio.networking.v1alpha3.Port)
+    - [Server](#istio.networking.v1alpha3.Server)
+    - [Server.TLSOptions](#istio.networking.v1alpha3.Server.TLSOptions)
+  
+  
+  
+  
+
+- [networking/v1alpha3/service_entry.proto](#networking/v1alpha3/service_entry.proto)
+    - [ServiceEntry](#istio.networking.v1alpha3.ServiceEntry)
+    - [ServiceEntry.Endpoint](#istio.networking.v1alpha3.ServiceEntry.Endpoint)
+  
+    - [ServiceEntry.Location](#istio.networking.v1alpha3.ServiceEntry.Location)
+    - [ServiceEntry.Resolution](#istio.networking.v1alpha3.ServiceEntry.Resolution)
+  
+  
+  
+
+- [networking/v1alpha3/virtual_service.proto](#networking/v1alpha3/virtual_service.proto)
+    - [CorsPolicy](#istio.networking.v1alpha3.CorsPolicy)
+    - [Destination](#istio.networking.v1alpha3.Destination)
+    - [DestinationWeight](#istio.networking.v1alpha3.DestinationWeight)
+    - [HTTPFaultInjection](#istio.networking.v1alpha3.HTTPFaultInjection)
+    - [HTTPFaultInjection.Abort](#istio.networking.v1alpha3.HTTPFaultInjection.Abort)
+    - [HTTPFaultInjection.Delay](#istio.networking.v1alpha3.HTTPFaultInjection.Delay)
+    - [HTTPMatchRequest](#istio.networking.v1alpha3.HTTPMatchRequest)
+    - [HTTPMatchRequest.HeadersEntry](#istio.networking.v1alpha3.HTTPMatchRequest.HeadersEntry)
+    - [HTTPMatchRequest.SourceLabelsEntry](#istio.networking.v1alpha3.HTTPMatchRequest.SourceLabelsEntry)
+    - [HTTPRedirect](#istio.networking.v1alpha3.HTTPRedirect)
+    - [HTTPRetry](#istio.networking.v1alpha3.HTTPRetry)
+    - [HTTPRewrite](#istio.networking.v1alpha3.HTTPRewrite)
+    - [HTTPRoute](#istio.networking.v1alpha3.HTTPRoute)
+    - [HTTPRoute.AppendHeadersEntry](#istio.networking.v1alpha3.HTTPRoute.AppendHeadersEntry)
+    - [HTTPRoute.RemoveResponseHeadersEntry](#istio.networking.v1alpha3.HTTPRoute.RemoveResponseHeadersEntry)
+    - [L4MatchAttributes](#istio.networking.v1alpha3.L4MatchAttributes)
+    - [L4MatchAttributes.SourceLabelsEntry](#istio.networking.v1alpha3.L4MatchAttributes.SourceLabelsEntry)
+    - [PortSelector](#istio.networking.v1alpha3.PortSelector)
+    - [StringMatch](#istio.networking.v1alpha3.StringMatch)
+    - [TCPRoute](#istio.networking.v1alpha3.TCPRoute)
+    - [VirtualService](#istio.networking.v1alpha3.VirtualService)
+  
+  
+  
+  
+
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="networking/v1alpha3/destination_rule.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## networking/v1alpha3/destination_rule.proto
+Copyright 2018 Istio Authors
+
+  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+
+<a name="istio.networking.v1alpha3.ConnectionPoolSettings"/>
+
+### ConnectionPoolSettings
+Connection pool settings for an upstream host. The settings apply to
+each individual host in the upstream service.  See Envoy&#39;s [circuit
+breaker](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/circuit_breaking)
+for more details. Connection pool settings can be applied at the TCP
+level as well as at HTTP level.
+
+For example, the following rule sets a limit of 100 connections to redis
+service called myredissrv with a connect timeout of 30ms
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: bookinfo-redis
+spec:
+  host: myredissrv.prod.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+        connectTimeout: 30ms
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| tcp | [ConnectionPoolSettings.TCPSettings](#istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings) |  | Settings common to both HTTP and TCP upstream connections. |
+| http | [ConnectionPoolSettings.HTTPSettings](#istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings) |  | HTTP connection pool settings. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings"/>
+
+### ConnectionPoolSettings.HTTPSettings
+Settings applicable to HTTP1.1/HTTP2/GRPC connections.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| http1_max_pending_requests | [int32](#int32) |  | Maximum number of pending HTTP requests to a destination. Default 1024. |
+| http2_max_requests | [int32](#int32) |  | Maximum number of requests to a backend. Default 1024. |
+| max_requests_per_connection | [int32](#int32) |  | Maximum number of requests per connection to a backend. Setting this parameter to 1 disables keep alive. |
+| max_retries | [int32](#int32) |  | Maximum number of retries that can be outstanding to all hosts in a cluster at a given time. Defaults to 3. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings"/>
+
+### ConnectionPoolSettings.TCPSettings
+Settings common to both HTTP and TCP upstream connections.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| max_connections | [int32](#int32) |  | Maximum number of HTTP1 /TCP connections to a destination host. |
+| connect_timeout | [google.protobuf.Duration](#google.protobuf.Duration) |  | TCP connection timeout. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.DestinationRule"/>
+
+### DestinationRule
+`DestinationRule` defines policies that apply to traffic intended for a
+service after routing has occurred. These rules specify configuration
+for load balancing, connection pool size from the sidecar, and outlier
+detection settings to detect and evict unhealthy hosts from the load
+balancing pool. For example, a simple load balancing policy for the
+ratings service would look as follows:
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: bookinfo-ratings
+spec:
+  host: ratings.prod.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      simple: LEAST_CONN
+```
+
+Version specific policies can be specified by defining a named
+`subset` and overriding the settings specified at the service level. The
+following rule uses a round robin load balancing policy for all traffic
+going to a subset named testversion that is composed of endpoints (e.g.,
+pods) with labels (version:v3).
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: bookinfo-ratings
+spec:
+  host: ratings.prod.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      simple: LEAST_CONN
+  subsets:
+  - name: testversion
+    labels:
+      version: v3
+    trafficPolicy:
+      loadBalancer:
+        simple: ROUND_ROBIN
+```
+
+**Note:** Policies specified for subsets will not take effect until
+a route rule explicitly sends traffic to this subset.
+
+Traffic policies can be customized to specific ports as well. The
+following rule uses the least connection load balancing policy for all
+traffic to port 80, while uses a round robin load balancing setting for
+traffic to the port 9080.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: bookinfo-ratings-port
+spec:
+  host: ratings.prod.svc.cluster.local
+  trafficPolicy: # Apply to all ports
+    portLevelSettings:
+    - port:
+        number: 80
+      loadBalancer:
+        simple: LEAST_CONN
+    - port:
+        number: 9080
+      loadBalancer:
+        simple: ROUND_ROBIN
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| host | [string](#string) |  | REQUIRED. The name of a service from the service registry. Service names are looked up from the platform&#39;s service registry (e.g., Kubernetes services, Consul services, etc.) and from the hosts declared by [ServiceEntries](#ServiceEntry). Rules defined for services that do not exist in the service registry will be ignored.  *Note for Kubernetes users*: When short names are used (e.g. &#34;reviews&#34; instead of &#34;reviews.default.svc.cluster.local&#34;), Istio will interpret the short name based on the namespace of the rule, not the service. A rule in the &#34;default&#34; namespace containing a host &#34;reviews will be interpreted as &#34;reviews.default.svc.cluster.local&#34;, irrespective of the actual namespace associated with the reviews service. _To avoid potential misconfigurations, it is recommended to always use fully qualified domain names over short names._  Note that the host field applies to both HTTP and TCP services. |
+| traffic_policy | [TrafficPolicy](#istio.networking.v1alpha3.TrafficPolicy) |  | Traffic policies to apply (load balancing policy, connection pool sizes, outlier detection). |
+| subsets | [Subset](#istio.networking.v1alpha3.Subset) | repeated | One or more named sets that represent individual versions of a service. Traffic policies can be overridden at subset level. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.LoadBalancerSettings"/>
+
+### LoadBalancerSettings
+Load balancing policies to apply for a specific destination. See Envoy&#39;s
+load balancing
+[documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/load_balancing.html)
+for more details.
+
+For example, the following rule uses a round robin load balancing policy
+for all traffic going to the ratings service.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: bookinfo-ratings
+spec:
+  host: ratings.prod.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      simple: ROUND_ROBIN
+```
+
+The following example uses the consistent hashing based load balancer
+for the same ratings service using the Cookie header as the hash key.
+
+```yaml
+ apiVersion: networking.istio.io/v1alpha3
+ kind: DestinationRule
+ metadata:
+   name: bookinfo-ratings
+ spec:
+   host: ratings.prod.svc.cluster.local
+   trafficPolicy:
+     loadBalancer:
+       consistentHash:
+         http_header: Cookie
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| simple | [LoadBalancerSettings.SimpleLB](#istio.networking.v1alpha3.LoadBalancerSettings.SimpleLB) |  |  |
+| consistent_hash | [LoadBalancerSettings.ConsistentHashLB](#istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB) |  |  |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB"/>
+
+### LoadBalancerSettings.ConsistentHashLB
+Consistent hashing (ketama hash) based load balancer for even load
+distribution/redistribution when the connection pool changes. This
+load balancing policy is applicable only for HTTP-based
+connections. A user specified HTTP header is used as the key with
+[xxHash](http://cyan4973.github.io/xxHash) hashing.
+$hide_from_docs
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| http_header | [string](#string) |  | REQUIRED. The name of the HTTP request header that will be used to obtain the hash key. If the request header is not present, the load balancer will use a random number as the hash, effectively making the load balancing policy random. |
+| minimum_ring_size | [uint32](#uint32) |  | The minimum number of virtual nodes to use for the hash ring. Defaults to 1024. Larger ring sizes result in more granular load distributions. If the number of hosts in the load balancing pool is larger than the ring size, each host will be assigned a single virtual node. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.OutlierDetection"/>
+
+### OutlierDetection
+A Circuit breaker implementation that tracks the status of each
+individual host in the upstream service.  Applicable to both HTTP and
+TCP services.  For HTTP services, hosts that continually return 5xx
+errors for API calls are ejected from the pool for a pre-defined period
+of time. For TCP services, connection timeouts or connection
+failures to a given host counts as an error when measuring the
+consecutive errors metric. See Envoy&#39;s [outlier
+detection](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/outlier)
+for more details. 
+
+The following rule sets a connection pool size of 100 connections and
+1000 concurrent HTTP2 requests, with no more than 10 req/connection to
+&#34;reviews&#34; service. In addition, it configures upstream hosts to be
+scanned every 5 mins, such that any host that fails 7 consecutive times
+with 5XX error code will be ejected for 15 minutes.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-cb-policy
+spec:
+  host: reviews.prod.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        http2MaxRequests: 1000
+        maxRequestsPerConnection: 10
+    outlierDetection:
+      consecutiveErrors: 7
+      interval: 5m
+      baseEjectionTime: 15m
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| consecutive_errors | [int32](#int32) |  | Number of errors before a host is ejected from the connection pool. Defaults to 5. When the upstream host is accessed over HTTP, a 5xx return code qualifies as an error. When the upstream host is accessed over an opaque TCP connection, connect timeouts and connection error/failure events qualify as an error. |
+| interval | [google.protobuf.Duration](#google.protobuf.Duration) |  | Time interval between ejection sweep analysis. format: 1h/1m/1s/1ms. MUST BE &gt;=1ms. Default is 10s. |
+| base_ejection_time | [google.protobuf.Duration](#google.protobuf.Duration) |  | Minimum ejection duration. A host will remain ejected for a period equal to the product of minimum ejection duration and the number of times the host has been ejected. This technique allows the system to automatically increase the ejection period for unhealthy upstream servers. format: 1h/1m/1s/1ms. MUST BE &gt;=1ms. Default is 30s. |
+| max_ejection_percent | [int32](#int32) |  | Maximum % of hosts in the load balancing pool for the upstream service that can be ejected. Defaults to 10%. |
+| http | [OutlierDetection.HTTPSettings](#istio.networking.v1alpha3.OutlierDetection.HTTPSettings) |  | DEPRECATED. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.OutlierDetection.HTTPSettings"/>
+
+### OutlierDetection.HTTPSettings
+Outlier detection settings for HTTP1.1/HTTP2/GRPC connections.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| consecutive_errors | [int32](#int32) |  | Number of 5XX errors before a host is ejected from the connection pool. Defaults to 5. |
+| interval | [google.protobuf.Duration](#google.protobuf.Duration) |  | Time interval between ejection sweep analysis. format: 1h/1m/1s/1ms. MUST BE &gt;=1ms. Default is 10s. |
+| base_ejection_time | [google.protobuf.Duration](#google.protobuf.Duration) |  | Minimum ejection duration. A host will remain ejected for a period equal to the product of minimum ejection duration and the number of times the host has been ejected. This technique allows the system to automatically increase the ejection period for unhealthy upstream servers. format: 1h/1m/1s/1ms. MUST BE &gt;=1ms. Default is 30s. |
+| max_ejection_percent | [int32](#int32) |  | Maximum % of hosts in the load balancing pool for the upstream service that can be ejected. Defaults to 10%. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.Subset"/>
+
+### Subset
+A subset of endpoints of a service. Subsets can be used for scenarios
+like A/B testing, or routing to a specific version of a service. Refer
+to [VirtualService](#VirtualService) documentation for examples of using
+subsets in these scenarios. In addition, traffic policies defined at the
+service-level can be overridden at a subset-level. The following rule
+uses a round robin load balancing policy for all traffic going to a
+subset named testversion that is composed of endpoints (e.g., pods) with
+labels (version:v3).
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: bookinfo-ratings
+spec:
+  host: ratings.prod.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      simple: LEAST_CONN
+  subsets:
+  - name: testversion
+    labels:
+      version: v3
+    trafficPolicy:
+      loadBalancer:
+        simple: ROUND_ROBIN
+```
+
+**Note:** Policies specified for subsets will not take effect until
+a route rule explicitly sends traffic to this subset.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | REQUIRED. Name of the subset. The service name and the subset name can be used for traffic splitting in a route rule. |
+| labels | [Subset.LabelsEntry](#istio.networking.v1alpha3.Subset.LabelsEntry) | repeated | REQUIRED. Labels apply a filter over the endpoints of a service in the service registry. See route rules for examples of usage. |
+| traffic_policy | [TrafficPolicy](#istio.networking.v1alpha3.TrafficPolicy) |  | Traffic policies that apply to this subset. Subsets inherit the traffic policies specified at the DestinationRule level. Settings specified at the subset level will override the corresponding settings specified at the DestinationRule level. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.Subset.LabelsEntry"/>
+
+### Subset.LabelsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.TLSSettings"/>
+
+### TLSSettings
+SSL/TLS related settings for upstream connections. See Envoy&#39;s [TLS
+context](https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/cluster_ssl.html#config-cluster-manager-cluster-ssl)
+for more details. These settings are common to both HTTP and TCP upstreams.
+
+For example, the following rule configures a client to use mutual TLS
+for connections to upstream database cluster.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: db-mtls
+spec:
+  host: mydbserver.prod.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: MUTUAL
+      clientCertificate: /etc/certs/myclientcert.pem
+      privateKey: /etc/certs/client_private_key.pem
+      caCertificates: /etc/certs/rootcacerts.pem
+```
+
+The following rule configures a client to use TLS when talking to a
+foreign service whose domain matches *.foo.com.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: tls-foo
+spec:
+  host: &#34;*.foo.com&#34;
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+```
+
+The following rule configures a client to use Istio mutual TLS when talking
+to rating services.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ratings-istio-mtls
+spec:
+  host: ratings.prod.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| mode | [TLSSettings.TLSmode](#istio.networking.v1alpha3.TLSSettings.TLSmode) |  | REQUIRED: Indicates whether connections to this port should be secured using TLS. The value of this field determines how TLS is enforced. |
+| client_certificate | [string](#string) |  | REQUIRED if mode is `MUTUAL`. The path to the file holding the client-side TLS certificate to use. Should be empty if mode is `ISTIO_MUTUAL`. |
+| private_key | [string](#string) |  | REQUIRED if mode is `MUTUAL`. The path to the file holding the client&#39;s private key. Should be empty if mode is `ISTIO_MUTUAL`. |
+| ca_certificates | [string](#string) |  | OPTIONAL: The path to the file containing certificate authority certificates to use in verifying a presented server certificate. If omitted, the proxy will not verify the server&#39;s certificate. Should be empty if mode is `ISTIO_MUTUAL`. |
+| subject_alt_names | [string](#string) | repeated | A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate&#39;s subject alt name matches one of the specified values. Should be empty if mode is `ISTIO_MUTUAL`. |
+| sni | [string](#string) |  | SNI string to present to the server during TLS handshake. Should be empty if mode is `ISTIO_MUTUAL`. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.TrafficPolicy"/>
+
+### TrafficPolicy
+Traffic policies to apply for a specific destination, across all
+destination ports. See DestinationRule for examples.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| load_balancer | [LoadBalancerSettings](#istio.networking.v1alpha3.LoadBalancerSettings) |  | Settings controlling the load balancer algorithms. |
+| connection_pool | [ConnectionPoolSettings](#istio.networking.v1alpha3.ConnectionPoolSettings) |  | Settings controlling the volume of connections to an upstream service |
+| outlier_detection | [OutlierDetection](#istio.networking.v1alpha3.OutlierDetection) |  | Settings controlling eviction of unhealthy hosts from the load balancing pool |
+| tls | [TLSSettings](#istio.networking.v1alpha3.TLSSettings) |  | TLS related settings for connections to the upstream service. |
+| port_level_settings | [TrafficPolicy.PortTrafficPolicy](#istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy) | repeated | Traffic policies specific to individual ports. Note that port level settings will override the destination-level settings. Traffic settings specified at the destination-level will not be inherited when overridden by port-level settings, i.e. default values will be applied to fields omitted in port-level traffic policies. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy"/>
+
+### TrafficPolicy.PortTrafficPolicy
+Traffic policies that apply to specific ports of the service
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| port | [PortSelector](#istio.networking.v1alpha3.PortSelector) |  | Specifies the port name or number of a port on the destination service on which this policy is being applied.  Names must comply with DNS label syntax (rfc1035) and therefore cannot collide with numbers. If there are multiple ports on a service with the same protocol the names should be of the form &lt;protocol-name&gt;-&lt;DNS label&gt;. |
+| load_balancer | [LoadBalancerSettings](#istio.networking.v1alpha3.LoadBalancerSettings) |  | Settings controlling the load balancer algorithms. |
+| connection_pool | [ConnectionPoolSettings](#istio.networking.v1alpha3.ConnectionPoolSettings) |  | Settings controlling the volume of connections to an upstream service |
+| outlier_detection | [OutlierDetection](#istio.networking.v1alpha3.OutlierDetection) |  | Settings controlling eviction of unhealthy hosts from the load balancing pool |
+| tls | [TLSSettings](#istio.networking.v1alpha3.TLSSettings) |  | TLS related settings for connections to the upstream service. |
+
+
+
+
+
+ 
+
+
+<a name="istio.networking.v1alpha3.LoadBalancerSettings.SimpleLB"/>
+
+### LoadBalancerSettings.SimpleLB
+Standard load balancing algorithms that require no tuning.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| ROUND_ROBIN | 0 | Round Robin policy. Default |
+| LEAST_CONN | 1 | The least request load balancer uses an O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. |
+| RANDOM | 2 | The random load balancer selects a random healthy host. The random load balancer generally performs better than round robin if no health checking policy is configured. |
+| PASSTHROUGH | 3 | This option will forward the connection to the original IP address requested by the caller without doing any form of load balancing. This option must be used with care. It is meant for advanced use cases. Refer to Original Destination load balancer in Envoy for further details. |
+
+
+
+<a name="istio.networking.v1alpha3.TLSSettings.TLSmode"/>
+
+### TLSSettings.TLSmode
+TLS connection mode
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| DISABLE | 0 | Do not setup a TLS connection to the upstream endpoint. |
+| SIMPLE | 1 | Originate a TLS connection to the upstream endpoint. |
+| MUTUAL | 2 | Secure connections to the upstream using mutual TLS by presenting client certificates for authentication. |
+| ISTIO_MUTUAL | 3 | Secure connections to the upstream using mutual TLS by presenting client certificates for authentication. Compared to Mutual mode, this mode uses certificates generated automatically by Istio for mTLS authentication. When this mode is used, all other fields in `TLSSettings` should be empty. |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="networking/v1alpha3/envoy_filter.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## networking/v1alpha3/envoy_filter.proto
+
+
+
+<a name="istio.networking.v1alpha3.EnvoyFilters"/>
+
+### EnvoyFilters
+`EnvoyFilter` describes Envoy proxy-specific filters that can be used to
+customize the Envoy proxy configuration generated by Istio networking
+subsystem (Pilot). This feature must be used with care, as incorrect
+configurations could potentially destabilize the entire mesh.
+
+NOTE: Since this is break glass configuration, there will not be any
+backward compatibility across different Istio releases. In other words,
+this configuration is subject to change based on internal implementation
+of Istio networking subsystem.
+
+The following example for Kubernetes enables Envoy&#39;s Lua filter for all
+inbound calls arriving at port 18080 of the reviews service pod with
+labels &#34;app: reviews&#34;.
+
+    apiVersion: networking.istio.io/v1alpha3
+    kind: EnvoyFilter
+    metadata:
+      name: reviews-lua
+    spec:
+      selector:
+        app: reviews
+      filters:
+      - listenerMatch:
+          port: 18080
+          listenerType: SIDECAR_INBOUND #will match with the listener for the podIP:18080
+        filterName: envoy.lua
+        filterType: HTTP
+        filterConfig:
+          inlineCode: |
+            ... lua code ...
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| selector | [EnvoyFilters.SelectorEntry](#istio.networking.v1alpha3.EnvoyFilters.SelectorEntry) | repeated | One or more labels that indicate a specific set of pods/VMs whose proxies should be configured to use these additional filters. The scope of label search is platform dependent. On Kubernetes, for example, the scope includes pods running in all reachable namespaces. Omitting the selector applies the filter to all proxies in the mesh. |
+| filters | [EnvoyFilters.Filter](#istio.networking.v1alpha3.EnvoyFilters.Filter) | repeated | REQUIRED: Envoy network filters/http filters to be added to matching listeners. When adding network filters to http connections, care should be taken to ensure that the filter is added before envoy.http_connection_manager. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.EnvoyFilters.Filter"/>
+
+### EnvoyFilters.Filter
+Envoy filters to be added to a network or http filter chain.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| listener_match | [EnvoyFilters.ListenerMatch](#istio.networking.v1alpha3.EnvoyFilters.ListenerMatch) |  | Filter will be added to the listner only if the match conditions are true. If not specified, the filters will be applied to all listeners. |
+| insert_position | [EnvoyFilters.InsertPosition](#istio.networking.v1alpha3.EnvoyFilters.InsertPosition) |  | Insert position in the filter chain. Defaults to FIRST |
+| filter_type | [EnvoyFilters.Filter.FilterType](#istio.networking.v1alpha3.EnvoyFilters.Filter.FilterType) |  | REQUIRED: The type of filter to instantiate. |
+| filter_name | [string](#string) |  | REQUIRED: The name of the filter to instantiate. The name must match a supported filter _compiled into_ Envoy. |
+| filter_config | [google.protobuf.Struct](#google.protobuf.Struct) |  | REQUIRED: Filter specific configuration which depends on the filter being instantiated. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.EnvoyFilters.InsertPosition"/>
+
+### EnvoyFilters.InsertPosition
+Indicates the relative index in the filter chain where the filter should be inserted.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| index | [EnvoyFilters.InsertPosition.Index](#istio.networking.v1alpha3.EnvoyFilters.InsertPosition.Index) |  | Position of this filter in the filter chain. |
+| relative_to | [string](#string) |  | If BEFORE or AFTER position is specified, specify the name of the filter relative to which this filter should be inserted. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.EnvoyFilters.ListenerMatch"/>
+
+### EnvoyFilters.ListenerMatch
+Select a listener to add the filter to based on the match conditions.
+All conditions specified in the ListenerMatch must be met for the filter
+to be applied to a listener.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| port | [uint32](#uint32) |  | Port associated with the listener. If not specified, matches all listeners. |
+| listener_type | [EnvoyFilters.ListenerMatch.ListenerType](#istio.networking.v1alpha3.EnvoyFilters.ListenerMatch.ListenerType) |  | Inbound vs outbound sidecar listener or gateway listener. If not specified, matches all listeners. |
+| listener_protocol | [string](#string) |  | Selects a class of listeners for the same protocol. If not specified, applies to listeners on all protocols. Use the protocol selection to select all HTTP listeners (includes HTTP2/gRPC/HTTPS where Envoy terminates TLS) or all TCP listeners (includes HTTPS passthrough using SNI). Acceptable values are TCP/HTTP/MONGO. |
+| address | [string](#string) | repeated | One or more IP addresses to which the listener is bound. If specified, should match atleast one address in the list. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.EnvoyFilters.SelectorEntry"/>
+
+### EnvoyFilters.SelectorEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="networking/v1alpha3/gateway.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## networking/v1alpha3/gateway.proto
+
+
+
+<a name="istio.networking.v1alpha3.Gateway"/>
+
+### Gateway
+`Gateway` describes a load balancer operating at the edge of the mesh
+receiving incoming or outgoing HTTP/TCP connections. The specification
+describes a set of ports that should be exposed, the type of protocol to
+use, SNI configuration for the load balancer, etc.
+
+For example, the following Gateway configuration sets up a proxy to act
+as a load balancer exposing port 80 and 9080 (http), 443 (https), and
+port 2379 (TCP) for ingress.  The gateway will be applied to the proxy
+running on a pod with labels `app: my-gateway-controller`. While Istio
+will configure the proxy to listen on these ports, it is the
+responsibility of the user to ensure that external traffic to these
+ports are allowed into the mesh.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: my-gateway
+spec:
+  selector:
+    app: my-gatweway-controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - uk.bookinfo.com
+    - eu.bookinfo.com
+    tls:
+      httpsRedirect: true # sends 302 redirect for http requests
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    hosts:
+    - uk.bookinfo.com
+    - eu.bookinfo.com
+    tls:
+      mode: SIMPLE #enables HTTPS on this port
+      serverCertificate: /etc/certs/servercert.pem
+      privateKey: /etc/certs/privatekey.pem
+  - port:
+      number: 9080
+      name: http-wildcard
+      protocol: HTTP
+    hosts:
+    - &#34;*&#34;
+  - port:
+      number: 2379 # to expose internal service via external port 2379
+      name: mongo
+      protocol: MONGO
+    hosts:
+    - &#34;*&#34;
+```
+The Gateway specification above describes the L4-L6 properties of a load
+balancer. A `VirtualService` can then be bound to a gateway to control
+the forwarding of traffic arriving at a particular host or gateway port.
+
+For example, the following VirtualService splits traffic for
+&#34;https://uk.bookinfo.com/reviews&#34;, &#34;https://eu.bookinfo.com/reviews&#34;,
+&#34;http://uk.bookinfo.com:9080/reviews&#34;,
+&#34;http://eu.bookinfo.com:9080/reviews&#34; into two versions (prod and qa) of
+an internal reviews service on port 9080. In addition, requests
+containing the cookie &#34;user: dev-123&#34; will be sent to special port 7777
+in the qa version. The same rule is also applicable inside the mesh for
+requests to the &#34;reviews.prod.svc.cluster.local&#34; service. This rule is
+applicable across ports 443, 9080. Note that &#34;http://uk.bookinfo.com&#34;
+gets redirected to &#34;https://uk.bookinfo.com&#34; (i.e. 80 redirects to 443).
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: bookinfo-rule
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  - uk.bookinfo.com
+  - eu.bookinfo.com
+  gateways:
+  - my-gateway
+  - mesh # applies to all the sidecars in the mesh
+  http:
+  - match:
+    - headers:
+        cookie:
+          user: dev-123
+    route:
+    - destination:
+        port:
+          number: 7777
+        host: reviews.qa.svc.cluster.local
+  - match:
+      uri:
+        prefix: /reviews/
+    route:
+    - destination:
+        port:
+          number: 9080 # can be omitted if its the only port for reviews
+        host: reviews.prod.svc.cluster.local
+      weight: 80
+    - destination:
+        host: reviews.qa.svc.cluster.local
+      weight: 20
+```
+
+The following VirtualService forwards traffic arriving at (external)
+port 27017 from &#34;172.17.16.0/24&#34; subnet to internal Mongo server on port
+5555. This rule is not applicable internally in the mesh as the gateway
+list omits the reserved name `mesh`.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: bookinfo-Mongo
+spec:
+  hosts:
+  - mongosvr.prod.svc.cluster.local #name of internal Mongo service
+  gateways:
+  - my-gateway
+  tcp:
+  - match:
+    - port:
+        number: 27017
+      sourceSubnet: &#34;172.17.16.0/24&#34;
+    route:
+    - destination:
+        host: mongo.prod.svc.cluster.local
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| servers | [Server](#istio.networking.v1alpha3.Server) | repeated | REQUIRED: A list of server specifications. |
+| selector | [Gateway.SelectorEntry](#istio.networking.v1alpha3.Gateway.SelectorEntry) | repeated | REQUIRED: One or more labels that indicate a specific set of pods/VMs on which this gateway configuration should be applied. The scope of label search is platform dependent. On Kubernetes, for example, the scope includes pods running in all reachable namespaces. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.Gateway.SelectorEntry"/>
+
+### Gateway.SelectorEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.Port"/>
+
+### Port
+Port describes the properties of a specific port of a service.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| number | [uint32](#uint32) |  | REQUIRED: A valid non-negative integer port number. |
+| protocol | [string](#string) |  | REQUIRED: The protocol exposed on the port. MUST BE one of HTTP|HTTPS|GRPC|HTTP2|MONGO|TCP|TCP-TLS. TCP-TLS is used to indicate secure connections to non HTTP services. |
+| name | [string](#string) |  | Label assigned to the port. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.Server"/>
+
+### Server
+`Server` describes the properties of the proxy on a given load balancer
+port. For example,
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: my-ingress
+spec:
+  selector:
+    app: my-ingress-gateway
+  servers:
+  - port:
+      number: 80
+      name: http2
+      protocol: HTTP2
+    hosts:
+    - &#34;*&#34;
+```
+
+Another example
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: my-tcp-ingress
+spec:
+  selector:
+    app: my-tcp-ingress-gateway
+  servers:
+  - port:
+      number: 27018
+      name: mongo
+      protocol: MONGO
+    hosts:
+    - &#34;*&#34;
+```
+
+The following is an example of TLS configuration for port 443
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: my-tls-ingress
+spec:
+  selector:
+    app: my-tls-ingress-gateway
+  servers:
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    hosts:
+    - &#34;*&#34;
+    tls:
+      mode: SIMPLE
+      serverCertificate: /etc/certs/server.pem
+      privateKey: /etc/certs/privatekey.pem
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| port | [Port](#istio.networking.v1alpha3.Port) |  | REQUIRED: The Port on which the proxy should listen for incoming connections |
+| hosts | [string](#string) | repeated | REQUIRED. A list of hosts exposed by this gateway. At least one host is required. While typically applicable to HTTP services, it can also be used for TCP services using TLS with SNI. May contain a wildcard prefix for the bottom-level component of a domain name. For example `*.foo.com` matches `bar.foo.com` and `*.com` matches `bar.foo.com`, `example.com`, and so on.  **Note**: A `VirtualService` that is bound to a gateway must have one or more hosts that match the hosts specified in a server. The match could be an exact match or a suffix match with the server&#39;s hosts. For example, if the server&#39;s hosts specifies &#34;*.example.com&#34;, VirtualServices with hosts dev.example.com, prod.example.com will match. However, VirtualServices with hosts example.com or newexample.com will not match. |
+| tls | [Server.TLSOptions](#istio.networking.v1alpha3.Server.TLSOptions) |  | Set of TLS related options that govern the server&#39;s behavior. Use these options to control if all http requests should be redirected to https, and the TLS modes to use. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.Server.TLSOptions"/>
+
+### Server.TLSOptions
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| https_redirect | [bool](#bool) |  | If set to true, the load balancer will send a 302 redirect for all http connections, asking the clients to use HTTPS. |
+| mode | [Server.TLSOptions.TLSmode](#istio.networking.v1alpha3.Server.TLSOptions.TLSmode) |  | Optional: Indicates whether connections to this port should be secured using TLS. The value of this field determines how TLS is enforced. |
+| server_certificate | [string](#string) |  | REQUIRED if mode is `SIMPLE` or `MUTUAL`. The path to the file holding the server-side TLS certificate to use. |
+| private_key | [string](#string) |  | REQUIRED if mode is `SIMPLE` or `MUTUAL`. The path to the file holding the server&#39;s private key. |
+| ca_certificates | [string](#string) |  | REQUIRED if mode is `MUTUAL`. The path to a file containing certificate authority certificates to use in verifying a presented client side certificate. |
+| subject_alt_names | [string](#string) | repeated | A list of alternate names to verify the subject identity in the certificate presented by the client. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="networking/v1alpha3/service_entry.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## networking/v1alpha3/service_entry.proto
+
+
+
+<a name="istio.networking.v1alpha3.ServiceEntry"/>
+
+### ServiceEntry
+`ServiceEntry` enables adding additional entries into Istio&#39;s internal
+service registry, so that auto-discovered services in the mesh can
+access/route to these manually specified services. A service entry
+describes the properties of a service (DNS name, VIPs ,ports, protocols,
+endpoints). These services could be external to the mesh (e.g., web
+APIs) or mesh-internal services that are not part of the platform&#39;s
+service registry (e.g., a set of VMs talking to services in Kubernetes).
+
+The following configuration adds a set of MongoDB instances running on
+unmanaged VMs to Istio&#39;s registry, so that these services can be treated
+as any other service in the mesh. The associated DestinationRule is used
+to initiate mTLS connections to the database instances.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-svc-mongocluster
+spec:
+  hosts:
+  - mymongodb.somedomain # not used
+  addresses:
+  - 192.192.192.192/24 # VIPs
+  ports:
+  - number: 27018
+    name: mongodb
+    protocol: MONGO
+  location: MESH_INTERNAL
+  resolution: STATIC
+  endpoints:
+  - address: 2.2.2.2
+  - address: 3.3.3.3
+```
+
+and the associated DestinationRule
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: mtls-mongocluster
+spec:
+  host: mymongodb.somedomain
+  trafficPolicy:
+    tls:
+      mode: MUTUAL
+      clientCertificate: /etc/certs/myclientcert.pem
+      privateKey: /etc/certs/client_private_key.pem
+      caCertificates: /etc/certs/rootcacerts.pem
+```
+
+The following example demonstrates the use of wildcards in the hosts for
+external services. If the connection has to be routed to the IP address
+requested by the application (i.e. application resolves DNS and attempts
+to connect to a specific IP), the discovery mode must be set to `NONE`.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-svc-wildcard-example
+spec:
+  hosts:
+  - &#34;*.bar.com&#34;
+  location: MESH_EXTERNAL
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  resolution: NONE
+```
+
+
+The following example demonstrates a service that is available via a
+Unix Domain Socket on the host of the client. The resolution must be
+set to STATIC to use unix address endpoints.
+
+    apiVersion: networking.istio.io/v1alpha3
+    kind: ServiceEntry
+    metadata:
+      name: unix-domain-socket-example
+    spec:
+      hosts:
+      - &#34;example.unix.local&#34;
+      location: MESH_EXTERNAL
+      ports:
+      - number: 80
+        name: http
+        protocol: HTTP
+      resolution: STATIC
+      endpoints:
+      - address: unix:///var/run/example/socket
+
+For HTTP based services, it is possible to create a VirtualService
+backed by multiple DNS addressable endpoints. In such a scenario, the
+application can use the HTTP_PROXY environment variable to transparently
+reroute API calls for the VirtualService to a chosen backend. For
+example, the following configuration creates a non-existent external
+service called foo.bar.com backed by three domains: us.foo.bar.com:8443,
+uk.foo.bar.com:9443, and in.foo.bar.com:7443
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-svc-dns
+spec:
+  hosts:
+  - foo.bar.com
+  location: MESH_EXTERNAL
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTP
+  resolution: DNS
+  endpoints:
+  - address: us.foo.bar.com
+    ports:
+      https: 8443
+  - address: uk.foo.bar.com
+    ports:
+      https: 9443
+  - address: in.foo.bar.com
+    ports:
+      https: 7443
+```
+
+and a DestinationRule to initiate TLS connections to the ServiceEntry.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: tls-foobar
+spec:
+  host: foo.bar.com
+  trafficPolicy:
+    tls:
+      mode: SIMPLE # initiates HTTPS
+```
+
+With HTTP_PROXY=http://localhost:443, calls from the application to
+http://foo.bar.com will be upgraded to HTTPS and load balanced across
+the three domains specified above. In other words, a call to
+http://foo.bar.com/baz would be translated to
+https://uk.foo.bar.com/baz.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| hosts | [string](#string) | repeated | REQUIRED. The hosts associated with the ServiceEntry. Could be a DNS name with wildcard prefix (external services only). DNS names in hosts will be ignored if the application accesses the service over non-HTTP protocols such as mongo/opaque TCP/even HTTPS. In such scenarios, the IP addresses specified in the Addresses field or the port will be used to uniquely identify the destination. |
+| addresses | [string](#string) | repeated | The virtual IP addresses associated with the service. Could be CIDR prefix. For HTTP services, the addresses field will be ignored and the destination will be identified based on the HTTP Host/Authority header. For non-HTTP protocols such as mongo/opaque TCP/even HTTPS, the hosts will be ignored. If one or more IP addresses are specified, the incoming traffic will be idenfified as belonging to this service if the destination IP matches the IP/CIDRs specified in the addresses field. If the Addresses field is empty, traffic will be identified solely based on the destination port. In such scenarios, the port on which the service is being accessed must not be shared by any other service in the mesh. In other words, the sidecar will behave as a simple TCP proxy, forwarding incoming traffic on a specified port to the specified destination endpoint IP/host. Unix domain socket addresses are not supported in this field. |
+| ports | [Port](#istio.networking.v1alpha3.Port) | repeated | REQUIRED. The ports associated with the external service. If the Endpoints are unix domain socket addresses, there must be exactly one port. |
+| location | [ServiceEntry.Location](#istio.networking.v1alpha3.ServiceEntry.Location) |  | Specify whether the service should be considered external to the mesh or part of the mesh. |
+| resolution | [ServiceEntry.Resolution](#istio.networking.v1alpha3.ServiceEntry.Resolution) |  | Service discovery mode for the hosts. If not set, Istio will attempt to infer the discovery mode based on the value of hosts and endpoints. |
+| endpoints | [ServiceEntry.Endpoint](#istio.networking.v1alpha3.ServiceEntry.Endpoint) | repeated | One or more endpoints associated with the service. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.ServiceEntry.Endpoint"/>
+
+### ServiceEntry.Endpoint
+Endpoint defines a network address (IP or hostname) associated with
+the mesh service.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| address | [string](#string) |  | REQUIRED: Address associated with the network endpoint without the port. Domain names can be used if and only if the resolution is set to DNS, and must be fully-qualified without wildcards. Use the form unix:///absolute/path/to/socket for unix domain socket endpoints. |
+| ports | [ServiceEntry.Endpoint.PortsEntry](#istio.networking.v1alpha3.ServiceEntry.Endpoint.PortsEntry) | repeated | Set of ports associated with the endpoint. The ports must be associated with a port name that was declared as part of the service. Do not use for unix:// addresses. |
+| labels | [ServiceEntry.Endpoint.LabelsEntry](#istio.networking.v1alpha3.ServiceEntry.Endpoint.LabelsEntry) | repeated | One or more labels associated with the endpoint. |
+
+
+
+
+
+ 
+
+
+<a name="istio.networking.v1alpha3.ServiceEntry.Location"/>
+
+### ServiceEntry.Location
+Location specifies whether the service is part of Istio mesh or
+outside the mesh.  Location determines the behavior of several
+features, such as service-to-service mTLS authentication, policy
+enforcement, etc. When communicating with services outside the mesh,
+Istio&#39;s mTLS authentication is disabled, and policy enforcement is
+performed on the client-side as opposed to server-side.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| MESH_EXTERNAL | 0 | Signifies that the service is external to the mesh. Typically used to indicate external services consumed through APIs. |
+| MESH_INTERNAL | 1 | Signifies that the service is part of the mesh. Typically used to indicate services added explicitly as part of expanding the service mesh to include unmanaged infrastructure (e.g., VMs added to a Kubernetes based service mesh). |
+
+
+
+<a name="istio.networking.v1alpha3.ServiceEntry.Resolution"/>
+
+### ServiceEntry.Resolution
+Resolution determines how the proxy will resolve the IP addresses of
+the network endpoints associated with the service, so that it can
+route to one of them. The resolution mode specified here has no impact
+on how the application resolves the IP address associated with the
+service. The application may still have to use DNS to resolve the
+service to an IP so that the outbound traffic can be captured by the
+Proxy. Alternatively, for HTTP services, the application could
+directly communicate with the proxy (e.g., by setting HTTP_PROXY) to
+talk to these services.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| NONE | 0 | Assume that incoming connections have already been resolved (to a specific destination IP address). Such connections are typically routed via the proxy using mechanisms such as IP table REDIRECT/ eBPF. After performing any routing related transformations, the proxy will forward the connection to the IP address to which the connection was bound. |
+| STATIC | 1 | Use the static IP addresses specified in endpoints (see below) as the backing instances associated with the service. |
+| DNS | 2 | Attempt to resolve the IP address by querying the ambient DNS, during request processing. If no endpoints are specified, the proxy will resolve the DNS address specified in the hosts field, if wildcards are not used. If endpoints are specified, the DNS addresses specified in the endpoints will be resolved to determine the destination IP address. DNS resolution cannot be used with unix domain socket endpoints. |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="networking/v1alpha3/virtual_service.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## networking/v1alpha3/virtual_service.proto
+
+
+
+<a name="istio.networking.v1alpha3.CorsPolicy"/>
+
+### CorsPolicy
+Describes the Cross-Origin Resource Sharing (CORS) policy, for a given
+service. Refer to
+https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+for further details about cross origin resource sharing. For example,
+the following rule restricts cross origin requests to those originating
+from example.com domain using HTTP POST/GET, and sets the
+Access-Control-Allow-Credentials header to false. In addition, it only
+exposes X-Foo-bar header and sets an expiry period of 1 day.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings-route
+spec:
+  hosts:
+  - ratings.prod.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: ratings.prod.svc.cluster.local
+        subset: v1
+    corsPolicy:
+      allowOrigin:
+      - example.com
+      allowMethods:
+      - POST
+      - GET
+      allowCredentials: false
+      allowHeaders:
+      - X-Foo-Bar
+      maxAge: &#34;1d&#34;
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| allow_origin | [string](#string) | repeated | The list of origins that are allowed to perform CORS requests. The content will be serialized into the Access-Control-Allow-Origin header. Wildcard * will allow all origins. |
+| allow_methods | [string](#string) | repeated | List of HTTP methods allowed to access the resource. The content will be serialized into the Access-Control-Allow-Methods header. |
+| allow_headers | [string](#string) | repeated | List of HTTP headers that can be used when requesting the resource. Serialized to Access-Control-Allow-Methods header. |
+| expose_headers | [string](#string) | repeated | A white list of HTTP headers that the browsers are allowed to access. Serialized into Access-Control-Expose-Headers header. |
+| max_age | [google.protobuf.Duration](#google.protobuf.Duration) |  | Specifies how long the the results of a preflight request can be cached. Translates to the Access-Control-Max-Age header. |
+| allow_credentials | [google.protobuf.BoolValue](#google.protobuf.BoolValue) |  | Indicates whether the caller is allowed to send the actual request (not the preflight) using credentials. Translates to Access-Control-Allow-Credentials header. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.Destination"/>
+
+### Destination
+Destination indicates the network addressable service to which the
+request/connection will be sent after processing a routing rule. The
+destination.host should unambiguously refer to a service in the service
+registry. Istio&#39;s service registry is composed of all the services found
+in the platform&#39;s service registry (e.g., Kubernetes services, Consul
+services), as well as services declared through the
+[ServiceEntry](#ServiceEntry) resource.
+
+*Note for Kubernetes users*: When short names are used (e.g. &#34;reviews&#34;
+instead of &#34;reviews.default.svc.cluster.local&#34;), Istio will interpret
+the short name based on the namespace of the rule, not the service. A
+rule in the &#34;default&#34; namespace containing a host &#34;reviews will be
+interpreted as &#34;reviews.default.svc.cluster.local&#34;, irrespective of the
+actual namespace associated with the reviews service. _To avoid potential
+misconfigurations, it is recommended to always use fully qualified
+domain names over short names._
+
+The following Kubernetes example routes all traffic by default to pods
+of the reviews service with label &#34;version: v1&#34; (i.e., subset v1), and
+some to subset v2, in a kubernetes environment.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-route
+  namespace: foo
+spec:
+  hosts:
+  - reviews # interpreted as reviews.foo.svc.cluster.local
+  http:
+  - match:
+    - uri:
+        prefix: &#34;/wpcatalog&#34;
+    - uri:
+        prefix: &#34;/consumercatalog&#34;
+    rewrite:
+      uri: &#34;/newcatalog&#34;
+    route:
+    - destination:
+        host: reviews # interpreted as reviews.foo.svc.cluster.local
+        subset: v2
+  - route:
+    - destination:
+        host: reviews # interpreted as reviews.foo.svc.cluster.local
+        subset: v1
+```
+
+And the associated DestinationRule
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-destination
+  namespace: foo
+spec:
+  host: reviews # interpreted as reviews.foo.svc.cluster.local
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+```
+
+The following VirtualService sets a timeout of 5s for all calls to
+productpage.prod.svc.cluster.local service in Kubernetes. Notice that
+there are no subsets defined in this rule. Istio will fetch all
+instances of productpage.prod.svc.cluster.local service from the service
+registry and populate the sidecar&#39;s load balancing pool. Also, notice
+that this rule is set in the istio-system namespace but uses the fully
+qualified domain name of the productpage service,
+productpage.prod.svc.cluster.local. Therefore the rule&#39;s namespace does
+not have an impact in resolving the name of the productpage service.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: my-productpage-rule
+  namespace: istio-system
+spec:
+  hosts:
+  - productpage.prod.svc.cluster.local # ignores rule namespace
+  http:
+  - timeout: 5s
+    route:
+    - destination:
+        host: productpage.prod.svc.cluster.local
+```
+
+To control routing for traffic bound to services outside the mesh, external
+services must first be added to Istio&#39;s internal service registry using the
+ServiceEntry resource. VirtualServices can then be defined to control traffic
+bound to these external services. For example, the following rules define a
+Service for wikipedia.org and set a timeout of 5s for http requests.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-svc-wikipedia
+spec:
+  hosts:
+  - wikipedia.org
+  location: MESH_EXTERNAL
+  ports:
+  - number: 80
+    name: example-http
+    protocol: HTTP
+  resolution: DNS
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: my-wiki-rule
+spec:
+  hosts:
+  - wikipedia.org
+  http:
+  - timeout: 5s
+    route:
+    - destination:
+        host: wikipedia.org
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| host | [string](#string) |  | REQUIRED. The name of a service from the service registry. Service names are looked up from the platform&#39;s service registry (e.g., Kubernetes services, Consul services, etc.) and from the hosts declared by [ServiceEntry](#ServiceEntry). Traffic forwarded to destinations that are not found in either of the two, will be dropped.  *Note for Kubernetes users*: When short names are used (e.g. &#34;reviews&#34; instead of &#34;reviews.default.svc.cluster.local&#34;), Istio will interpret the short name based on the namespace of the rule, not the service. A rule in the &#34;default&#34; namespace containing a host &#34;reviews will be interpreted as &#34;reviews.default.svc.cluster.local&#34;, irrespective of the actual namespace associated with the reviews service. _To avoid potential misconfigurations, it is recommended to always use fully qualified domain names over short names._ |
+| subset | [string](#string) |  | The name of a subset within the service. Applicable only to services within the mesh. The subset must be defined in a corresponding DestinationRule. |
+| port | [PortSelector](#istio.networking.v1alpha3.PortSelector) |  | Specifies the port on the host that is being addressed. If a service exposes only a single port it is not required to explicitly select the port. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.DestinationWeight"/>
+
+### DestinationWeight
+Each routing rule is associated with one or more service versions (see
+glossary in beginning of document). Weights associated with the version
+determine the proportion of traffic it receives. For example, the
+following rule will route 25% of traffic for the &#34;reviews&#34; service to
+instances with the &#34;v2&#34; tag and the remaining traffic (i.e., 75%) to
+&#34;v1&#34;.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v2
+      weight: 25
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v1
+      weight: 75
+```
+
+And the associated DestinationRule
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-destination
+spec:
+  host: reviews.prod.svc.cluster.local
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+```
+
+Traffic can also be split across two entirely different services without
+having to define new subsets. For example, the following rule forwards 25% of
+traffic to reviews.com to dev.reviews.com
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-route-two-domains
+spec:
+  hosts:
+  - reviews.com
+  http:
+  - route:
+    - destination:
+        host: dev.reviews.com
+      weight: 25
+    - destination:
+        host: reviews.com
+      weight: 75
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| destination | [Destination](#istio.networking.v1alpha3.Destination) |  | REQUIRED. Destination uniquely identifies the instances of a service to which the request/connection should be forwarded to. |
+| weight | [int32](#int32) |  | REQUIRED. The proportion of traffic to be forwarded to the service version. (0-100). Sum of weights across destinations SHOULD BE == 100. If there is only destination in a rule, the weight value is assumed to be 100. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPFaultInjection"/>
+
+### HTTPFaultInjection
+HTTPFaultInjection can be used to specify one or more faults to inject
+while forwarding http requests to the destination specified in a route.
+Fault specification is part of a VirtualService rule. Faults include
+aborting the Http request from downstream service, and/or delaying
+proxying of requests. A fault rule MUST HAVE delay or abort or both.
+
+*Note:* Delay and abort faults are independent of one another, even if
+both are specified simultaneously.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| delay | [HTTPFaultInjection.Delay](#istio.networking.v1alpha3.HTTPFaultInjection.Delay) |  | Delay requests before forwarding, emulating various failures such as network issues, overloaded upstream service, etc. |
+| abort | [HTTPFaultInjection.Abort](#istio.networking.v1alpha3.HTTPFaultInjection.Abort) |  | Abort Http request attempts and return error codes back to downstream service, giving the impression that the upstream service is faulty. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPFaultInjection.Abort"/>
+
+### HTTPFaultInjection.Abort
+Abort specification is used to prematurely abort a request with a
+pre-specified error code. The following example will return an HTTP
+400 error code for 10% of the requests to the &#34;ratings&#34; service &#34;v1&#34;.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings-route
+spec:
+  hosts:
+  - ratings.prod.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: ratings.prod.svc.cluster.local
+        subset: v1
+    fault:
+      abort:
+        percent: 10
+        httpStatus: 400
+```
+
+The _httpStatus_ field is used to indicate the HTTP status code to
+return to the caller. The optional _percent_ field, a value between 0
+and 100, is used to only abort a certain percentage of requests. If
+not specified, all requests are aborted.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| percent | [int32](#int32) |  | Percentage of requests to be aborted with the error code provided (0-100). |
+| http_status | [int32](#int32) |  | REQUIRED. HTTP status code to use to abort the Http request. |
+| grpc_status | [string](#string) |  | $hide_from_docs |
+| http2_error | [string](#string) |  | $hide_from_docs |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPFaultInjection.Delay"/>
+
+### HTTPFaultInjection.Delay
+Delay specification is used to inject latency into the request
+forwarding path. The following example will introduce a 5 second delay
+in 10% of the requests to the &#34;v1&#34; version of the &#34;reviews&#34;
+service from all pods with label env: prod
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - match:
+    - sourceLabels:
+        env: prod
+    route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v1
+    fault:
+      delay:
+        percent: 10
+        fixedDelay: 5s
+```
+
+The _fixedDelay_ field is used to indicate the amount of delay in
+seconds. An optional _percent_ field, a value between 0 and 100, can
+be used to only delay a certain percentage of requests. If left
+unspecified, all request will be delayed.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| percent | [int32](#int32) |  | Percentage of requests on which the delay will be injected (0-100). |
+| fixed_delay | [google.protobuf.Duration](#google.protobuf.Duration) |  | REQUIRED. Add a fixed delay before forwarding the request. Format: 1h/1m/1s/1ms. MUST be &gt;=1ms. |
+| exponential_delay | [google.protobuf.Duration](#google.protobuf.Duration) |  | $hide_from_docs |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPMatchRequest"/>
+
+### HTTPMatchRequest
+HttpMatchRequest specifies a set of criterion to be met in order for the
+rule to be applied to the HTTP request. For example, the following
+restricts the rule to match only requests where the URL path
+starts with /ratings/v2/ and the request contains a `cookie` with value
+`user=jason`.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings-route
+spec:
+  hosts:
+  - ratings.prod.svc.cluster.local
+  http:
+  - match:
+    - headers:
+        cookie:
+          regex: &#34;^(.*?;)?(user=jason)(;.*)?&#34;
+        uri:
+          prefix: &#34;/ratings/v2/&#34;
+    route:
+    - destination:
+        host: ratings.prod.svc.cluster.local
+```
+
+HTTPMatchRequest CANNOT be empty.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| uri | [StringMatch](#istio.networking.v1alpha3.StringMatch) |  | URI to match values are case-sensitive and formatted as follows:  - `exact: &#34;value&#34;` for exact string match  - `prefix: &#34;value&#34;` for prefix-based match  - `regex: &#34;value&#34;` for ECMAscript style regex-based match |
+| scheme | [StringMatch](#istio.networking.v1alpha3.StringMatch) |  | URI Scheme values are case-sensitive and formatted as follows:  - `exact: &#34;value&#34;` for exact string match  - `prefix: &#34;value&#34;` for prefix-based match  - `regex: &#34;value&#34;` for ECMAscript style regex-based match |
+| method | [StringMatch](#istio.networking.v1alpha3.StringMatch) |  | HTTP Method values are case-sensitive and formatted as follows:  - `exact: &#34;value&#34;` for exact string match  - `prefix: &#34;value&#34;` for prefix-based match  - `regex: &#34;value&#34;` for ECMAscript style regex-based match |
+| authority | [StringMatch](#istio.networking.v1alpha3.StringMatch) |  | HTTP Authority values are case-sensitive and formatted as follows:  - `exact: &#34;value&#34;` for exact string match  - `prefix: &#34;value&#34;` for prefix-based match  - `regex: &#34;value&#34;` for ECMAscript style regex-based match |
+| headers | [HTTPMatchRequest.HeadersEntry](#istio.networking.v1alpha3.HTTPMatchRequest.HeadersEntry) | repeated | The header keys must be lowercase and use hyphen as the separator, e.g. _x-request-id_.  Header values are case-sensitive and formatted as follows:  - `exact: &#34;value&#34;` for exact string match  - `prefix: &#34;value&#34;` for prefix-based match  - `regex: &#34;value&#34;` for ECMAscript style regex-based match  **Note:** The keys `uri`, `scheme`, `method`, and `authority` will be ignored. |
+| port | [uint32](#uint32) |  | Specifies the ports on the host that is being addressed. Many services only expose a single port or label ports with the protocols they support, in these cases it is not required to explicitly select the port. |
+| source_labels | [HTTPMatchRequest.SourceLabelsEntry](#istio.networking.v1alpha3.HTTPMatchRequest.SourceLabelsEntry) | repeated | One or more labels that constrain the applicability of a rule to workloads with the given labels. If the VirtualService has a list of gateways specified at the top, it should include the reserved gateway `mesh` in order for this field to be applicable. |
+| gateways | [string](#string) | repeated | Names of gateways where the rule should be applied to. Gateway names at the top of the VirtualService (if any) are overridden. The gateway match is independent of sourceLabels. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPMatchRequest.HeadersEntry"/>
+
+### HTTPMatchRequest.HeadersEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [StringMatch](#istio.networking.v1alpha3.StringMatch) |  |  |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPMatchRequest.SourceLabelsEntry"/>
+
+### HTTPMatchRequest.SourceLabelsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPRedirect"/>
+
+### HTTPRedirect
+HTTPRedirect can be used to send a 302 redirect response to the caller,
+where the Authority/Host and the URI in the response can be swapped with
+the specified values. For example, the following rule redirects
+requests for /v1/getProductRatings API on the ratings service to
+/v1/bookRatings provided by the bookratings service.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings-route
+spec:
+  hosts:
+  - ratings.prod.svc.cluster.local
+  http:
+  - match:
+    - uri:
+        exact: /v1/getProductRatings
+  redirect:
+    uri: /v1/bookRatings
+    authority: newratings.default.svc.cluster.local
+  ...
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| uri | [string](#string) |  | On a redirect, overwrite the Path portion of the URL with this value. Note that the entire path will be replaced, irrespective of the request URI being matched as an exact path or prefix. |
+| authority | [string](#string) |  | On a redirect, overwrite the Authority/Host portion of the URL with this value. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPRetry"/>
+
+### HTTPRetry
+Describes the retry policy to use when a HTTP request fails. For
+example, the following rule sets the maximum number of retries to 3 when
+calling ratings:v1 service, with a 2s timeout per retry attempt.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings-route
+spec:
+  hosts:
+  - ratings.prod.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: ratings.prod.svc.cluster.local
+        subset: v1
+    retries:
+      attempts: 3
+      perTryTimeout: 2s
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| attempts | [int32](#int32) |  | REQUIRED. Number of retries for a given request. The interval between retries will be determined automatically (25ms&#43;). Actual number of retries attempted depends on the httpReqTimeout. |
+| per_try_timeout | [google.protobuf.Duration](#google.protobuf.Duration) |  | Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE &gt;=1ms. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPRewrite"/>
+
+### HTTPRewrite
+HTTPRewrite can be used to rewrite specific parts of a HTTP request
+before forwarding the request to the destination. Rewrite primitive can
+be used only with the DestinationWeights. The following example
+demonstrates how to rewrite the URL prefix for api call (/ratings) to
+ratings service before making the actual API call.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings-route
+spec:
+  hosts:
+  - ratings.prod.svc.cluster.local
+  http:
+  - match:
+    - uri:
+        prefix: /ratings
+    rewrite:
+      uri: /v1/bookRatings
+    route:
+    - destination:
+        host: ratings.prod.svc.cluster.local
+        subset: v1
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| uri | [string](#string) |  | rewrite the path (or the prefix) portion of the URI with this value. If the original URI was matched based on prefix, the value provided in this field will replace the corresponding matched prefix. |
+| authority | [string](#string) |  | rewrite the Authority/Host header with this value. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPRoute"/>
+
+### HTTPRoute
+Describes match conditions and actions for routing HTTP/1.1, HTTP2, and
+gRPC traffic. See VirtualService for usage examples.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| match | [HTTPMatchRequest](#istio.networking.v1alpha3.HTTPMatchRequest) | repeated | Match conditions to be satisfied for the rule to be activated. All conditions inside a single match block have AND semantics, while the list of match blocks have OR semantics. The rule is matched if any one of the match blocks succeed. |
+| route | [DestinationWeight](#istio.networking.v1alpha3.DestinationWeight) | repeated | A http rule can either redirect or forward (default) traffic. The forwarding target can be one of several versions of a service (see glossary in beginning of document). Weights associated with the service version determine the proportion of traffic it receives. |
+| redirect | [HTTPRedirect](#istio.networking.v1alpha3.HTTPRedirect) |  | A http rule can either redirect or forward (default) traffic. If traffic passthrough option is specified in the rule, route/redirect will be ignored. The redirect primitive can be used to send a HTTP 302 redirect to a different URI or Authority. |
+| rewrite | [HTTPRewrite](#istio.networking.v1alpha3.HTTPRewrite) |  | Rewrite HTTP URIs and Authority headers. Rewrite cannot be used with Redirect primitive. Rewrite will be performed before forwarding. |
+| websocket_upgrade | [bool](#bool) |  | Indicates that a HTTP/1.1 client connection to this particular route should be allowed (and expected) to upgrade to a WebSocket connection. The default is false. Istio&#39;s reference sidecar implementation (Envoy) expects the first request to this route to contain the WebSocket upgrade headers. Otherwise, the request will be rejected. Note that Websocket allows secondary protocol negotiation which may then be subject to further routing rules based on the protocol selected. |
+| timeout | [google.protobuf.Duration](#google.protobuf.Duration) |  | Timeout for HTTP requests. |
+| retries | [HTTPRetry](#istio.networking.v1alpha3.HTTPRetry) |  | Retry policy for HTTP requests. |
+| fault | [HTTPFaultInjection](#istio.networking.v1alpha3.HTTPFaultInjection) |  | Fault injection policy to apply on HTTP traffic. |
+| mirror | [Destination](#istio.networking.v1alpha3.Destination) |  | Mirror HTTP traffic to a another destination in addition to forwarding the requests to the intended destination. Mirrored traffic is on a best effort basis where the sidecar/gateway will not wait for the mirrored cluster to respond before returning the response from the original destination. Statistics will be generated for the mirrored destination. |
+| cors_policy | [CorsPolicy](#istio.networking.v1alpha3.CorsPolicy) |  | Cross-Origin Resource Sharing policy (CORS). Refer to https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS for further details about cross origin resource sharing. |
+| append_headers | [HTTPRoute.AppendHeadersEntry](#istio.networking.v1alpha3.HTTPRoute.AppendHeadersEntry) | repeated | Additional HTTP headers to add before forwarding a request to the destination service. |
+| remove_response_headers | [HTTPRoute.RemoveResponseHeadersEntry](#istio.networking.v1alpha3.HTTPRoute.RemoveResponseHeadersEntry) | repeated | Http headers to remove before returning the response to the caller $hide_from_docs |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPRoute.AppendHeadersEntry"/>
+
+### HTTPRoute.AppendHeadersEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.HTTPRoute.RemoveResponseHeadersEntry"/>
+
+### HTTPRoute.RemoveResponseHeadersEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.L4MatchAttributes"/>
+
+### L4MatchAttributes
+L4 connection match attributes. Note that L4 connection matching support
+is incomplete.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| destination_subnet | [string](#string) |  | IPv4 or IPv6 ip address of destination with optional subnet. E.g., a.b.c.d/xx form or just a.b.c.d. This is only valid when the destination service has several IPs and the application explicitly specifies a particular IP. |
+| port | [uint32](#uint32) |  | Specifies the port on the host that is being addressed. Many services only expose a single port or label ports with the protocols they support, in these cases it is not required to explicitly select the port. |
+| source_subnet | [string](#string) |  | IPv4 or IPv6 ip address of source with optional subnet. E.g., a.b.c.d/xx form or just a.b.c.d |
+| source_labels | [L4MatchAttributes.SourceLabelsEntry](#istio.networking.v1alpha3.L4MatchAttributes.SourceLabelsEntry) | repeated | One or more labels that constrain the applicability of a rule to workloads with the given labels. If the VirtualService has a list of gateways specified at the top, it should include the reserved gateway `mesh` in order for this field to be applicable. |
+| gateways | [string](#string) | repeated | Names of gateways where the rule should be applied to. Gateway names at the top of the VirtualService (if any) are overridden. The gateway match is independent of sourceLabels. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.L4MatchAttributes.SourceLabelsEntry"/>
+
+### L4MatchAttributes.SourceLabelsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.PortSelector"/>
+
+### PortSelector
+PortSelector specifies the number of a port to be used for
+matching or selection for final routing.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| number | [uint32](#uint32) |  | Valid port number |
+| name | [string](#string) |  | $hide_from_docs |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.StringMatch"/>
+
+### StringMatch
+Describes how to match a given string in HTTP headers. Match is
+case-sensitive.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| exact | [string](#string) |  | exact string match |
+| prefix | [string](#string) |  | prefix-based match |
+| regex | [string](#string) |  | ECMAscript style regex-based match |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.TCPRoute"/>
+
+### TCPRoute
+Describes match conditions and actions for routing TCP traffic. The
+following routing rule forwards traffic arriving at port 27017 for
+mongo.prod.svc.cluster.local from 172.17.16.* subnet to another Mongo
+server on port 5555.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: bookinfo-Mongo
+spec:
+  hosts:
+  - mongo.prod.svc.cluster.local
+  tcp:
+  - match:
+    - port: 27017
+      sourceSubnet: &#34;172.17.16.0/24&#34;
+    route:
+    - destination:
+        host: mongo.backup.svc.cluster.local
+        port:
+          number: 5555
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| match | [L4MatchAttributes](#istio.networking.v1alpha3.L4MatchAttributes) | repeated | Match conditions to be satisfied for the rule to be activated. All conditions inside a single match block have AND semantics, while the list of match blocks have OR semantics. The rule is matched if any one of the match blocks succeed. |
+| route | [DestinationWeight](#istio.networking.v1alpha3.DestinationWeight) | repeated | The destination to which the connection should be forwarded to. Currently, only one destination is allowed for TCP services. When TCP weighted routing support is introduced in Envoy, multiple destinations with weights can be specified. |
+
+
+
+
+
+
+<a name="istio.networking.v1alpha3.VirtualService"/>
+
+### VirtualService
+A `VirtualService` defines a set of traffic routing rules to apply when a host is
+addressed. Each routing rule defines matching criteria for traffic of a specific
+protocol. If the traffic is matched, then it is sent to a named destination service
+(or subset/version of it) defined in the registry.
+
+The source of traffic can also be matched in a routing rule. This allows routing
+to be customized for specific client contexts.
+
+The following example on Kubernetes, routes all HTTP traffic by default to
+pods of the reviews service with label &#34;version: v1&#34;. In addition,
+HTTP requests containing /wpcatalog/, /consumercatalog/ url prefixes will
+be rewritten to /newcatalog and sent to pods with label &#34;version: v2&#34;.
+
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - match:
+    - uri:
+        prefix: &#34;/wpcatalog&#34;
+    - uri:
+        prefix: &#34;/consumercatalog&#34;
+    rewrite:
+      uri: &#34;/newcatalog&#34;
+    route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v2
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v1
+```
+
+A subset/version of a route destination is identified with a reference
+to a named service subset which must be declared in a corresponding
+`DestinationRule`.
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-destination
+spec:
+  host: reviews.prod.svc.cluster.local
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| hosts | [string](#string) | repeated | REQUIRED. The destination hosts to which traffic is being sent. Could be a DNS name with wildcard prefix or an IP address. Depending on the platform, short-names can also be used instead of a FQDN (i.e. has no dots in the name). In such a scenario, the FQDN of the host would be derived based on the underlying platform.  **A host name can be defined by only one VirtualService**. A single VirtualService can be used to describe traffic properties for multiple HTTP and TCP ports.  *Note for Kubernetes users*: When short names are used (e.g. &#34;reviews&#34; instead of &#34;reviews.default.svc.cluster.local&#34;), Istio will interpret the short name based on the namespace of the rule, not the service. A rule in the &#34;default&#34; namespace containing a host &#34;reviews will be interpreted as &#34;reviews.default.svc.cluster.local&#34;, irrespective of the actual namespace associated with the reviews service. _To avoid potential misconfigurations, it is recommended to always use fully qualified domain names over short names._  The hosts field applies to both HTTP and TCP services. Service inside the mesh, i.e., those found in the service registry, must always be referred to using their alphanumeric names. IP addresses are allowed only for services defined via the Gateway. |
+| gateways | [string](#string) | repeated | The names of gateways and sidecars that should apply these routes. A single VirtualService is used for sidecars inside the mesh as well as for one or more gateways. The selection condition imposed by this field can be overridden using the source field in the match conditions of HTTP/TCP routes. The reserved word `mesh` is used to imply all the sidecars in the mesh. When this field is omitted, the default gateway (`mesh`) will be used, which would apply the rule to all sidecars in the mesh. If a list of gateway names is provided, the rules will apply only to the gateways. To apply the rules to both gateways and sidecars, specify `mesh` as one of the gateway names. |
+| http | [HTTPRoute](#istio.networking.v1alpha3.HTTPRoute) | repeated | An ordered list of route rules for HTTP traffic. The first rule matching an incoming request is used. |
+| tcp | [TCPRoute](#istio.networking.v1alpha3.TCPRoute) | repeated | An ordered list of route rules for TCP traffic. The first rule matching an incoming request is used. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | Java Type | Python Type |
+| ----------- | ----- | -------- | --------- | ----------- |
+| <a name="double" /> double |  | double | double | float |
+| <a name="float" /> float |  | float | float | float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
+| <a name="bool" /> bool |  | bool | boolean | boolean |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+

--- a/policy/v1beta1/README.md
+++ b/policy/v1beta1/README.md
@@ -1,0 +1,549 @@
+# Protocol Documentation
+<a name="top"/>
+
+## Table of Contents
+
+- [policy/v1beta1/cfg.proto](#policy/v1beta1/cfg.proto)
+    - [Action](#istio.policy.v1beta1.Action)
+    - [AttributeManifest](#istio.policy.v1beta1.AttributeManifest)
+    - [AttributeManifest.AttributeInfo](#istio.policy.v1beta1.AttributeManifest.AttributeInfo)
+    - [AttributeManifest.AttributesEntry](#istio.policy.v1beta1.AttributeManifest.AttributesEntry)
+    - [Connection](#istio.policy.v1beta1.Connection)
+    - [Handler](#istio.policy.v1beta1.Handler)
+    - [Instance](#istio.policy.v1beta1.Instance)
+    - [Rule](#istio.policy.v1beta1.Rule)
+  
+  
+  
+  
+
+- [policy/v1beta1/type.proto](#policy/v1beta1/type.proto)
+    - [DNSName](#istio.policy.v1beta1.DNSName)
+    - [Duration](#istio.policy.v1beta1.Duration)
+    - [EmailAddress](#istio.policy.v1beta1.EmailAddress)
+    - [IPAddress](#istio.policy.v1beta1.IPAddress)
+    - [TimeStamp](#istio.policy.v1beta1.TimeStamp)
+    - [Uri](#istio.policy.v1beta1.Uri)
+    - [Value](#istio.policy.v1beta1.Value)
+  
+  
+  
+  
+
+- [policy/v1beta1/value_type.proto](#policy/v1beta1/value_type.proto)
+  
+    - [ValueType](#istio.policy.v1beta1.ValueType)
+  
+  
+  
+
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="policy/v1beta1/cfg.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## policy/v1beta1/cfg.proto
+
+
+
+<a name="istio.policy.v1beta1.Action"/>
+
+### Action
+Action describes which [Handler][istio.policy.v1beta1.Handler] to invoke and what data to pass to it for processing.
+
+The following example instructs Mixer to invoke &#39;prometheus-handler&#39; handler and pass it the object
+constructed using the instance &#39;RequestCountByService&#39;.
+
+```yaml
+  handler: prometheus-handler
+  instances:
+  - RequestCountByService
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| handler | [string](#string) |  | Required. Fully qualified name of the handler to invoke. Must match the `name` of a [Handler][istio.policy.v1beta1.Handler.name]. |
+| instances | [string](#string) | repeated | Required. Each value must match the fully qualified name of the [Instance][istio.policy.v1beta1.Instance.name]s. Referenced instances are evaluated by resolving the attributes/literals for all the fields. The constructed objects are then passed to the `handler` referenced within this action. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.AttributeManifest"/>
+
+### AttributeManifest
+AttributeManifest describes a set of Attributes produced by some component
+of an Istio deployment.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| revision | [string](#string) |  | Optional. The revision of this document. Assigned by server. |
+| name | [string](#string) |  | Required. Name of the component producing these attributes. This can be the proxy (with the canonical name &#34;istio-proxy&#34;) or the name of an `attributes` kind adapter in Mixer. |
+| attributes | [AttributeManifest.AttributesEntry](#istio.policy.v1beta1.AttributeManifest.AttributesEntry) | repeated | The set of attributes this Istio component will be responsible for producing at runtime. We map from attribute name to the attribute&#39;s specification. The name of an attribute, which is how attributes are referred to in aspect configuration, must conform to:   Name = IDENT { SEPARATOR IDENT };  Where `IDENT` must match the regular expression `[a-z][a-z0-9]&#43;` and `SEPARATOR` must match the regular expression `[\.-]`.  Attribute names must be unique within a single Istio deployment. The set of canonical attributes are described at https://istio.io/docs/reference/attribute-vocabulary.html. Attributes not in that list should be named with a component-specific suffix such as request.count-my.component. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.AttributeManifest.AttributeInfo"/>
+
+### AttributeManifest.AttributeInfo
+AttributeInfo describes the schema of an Istio `Attribute`.
+
+# Istio Attributes
+
+Istio uses `attributes` to describe runtime activities of Istio services.
+An Istio attribute carries a specific piece of information about an activity,
+such as the error code of an API request, the latency of an API request, or the
+original IP address of a TCP connection. The attributes are often generated
+and consumed by different services. For example, a frontend service can
+generate an authenticated user attribute and pass it to a backend service for
+access control purpose.
+
+To simplify the system and improve developer experience, Istio uses
+shared attribute definitions across all components. For example, the same
+authenticated user attribute will be used for logging, monitoring, analytics,
+billing, access control, auditing. Many Istio components provide their
+functionality by collecting, generating, and operating on attributes.
+For example, the proxy collects the error code attribute, and the logging
+stores it into a log.
+
+# Design
+
+Each Istio attribute must conform to an `AttributeInfo` in an
+`AttributeManifest` in the current Istio deployment at runtime. An
+[`AttributeInfo`][istio.policy.v1beta1] is used to define an attribute&#39;s
+metadata: the type of its value and a detailed description that explains
+the semantics of the attribute type. Each attribute&#39;s name is globally unique;
+in other words an attribute name can only appear once across all manifests.
+
+The runtime presentation of an attribute is intentionally left out of this
+specification, because passing attribute using JSON, XML, or Protocol Buffers
+does not change the semantics of the attribute. Different implementations
+can choose different representations based on their needs.
+
+# HTTP Mapping
+
+Because many systems already have REST APIs, it makes sense to define a
+standard HTTP mapping for Istio attributes that are compatible with typical
+REST APIs. The design is to map one attribute to one HTTP header, the
+attribute name and value becomes the HTTP header name and value. The actual
+encoding scheme will be decided later.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| description | [string](#string) |  | Optional. A human-readable description of the attribute&#39;s purpose. |
+| value_type | [ValueType](#istio.policy.v1beta1.ValueType) |  | Required. The type of data carried by this attribute. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.AttributeManifest.AttributesEntry"/>
+
+### AttributeManifest.AttributesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [AttributeManifest.AttributeInfo](#istio.policy.v1beta1.AttributeManifest.AttributeInfo) |  |  |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.Connection"/>
+
+### Connection
+Connection allows the operator to specify the endpoint for out-of-process infrastructure backend.
+Connection is part of the handler custom resource and is specified alongside adapter specific configuration.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| address | [string](#string) |  | The address of the backend. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.Handler"/>
+
+### Handler
+Handler allows the operator to configure a specific adapter implementation.
+Each adapter implementation defines its own `params` proto.
+
+In the following example we define a `metrics` handler for the `prometheus` adapter.
+The example is in the form of a kubernetes resource:
+* The `metadata.name` is the name of the handler
+* The `kind` refers to the adapter name
+* The `spec` block represents adapter-specific configuration as well as the connection information
+
+```yaml
+# Sample-1: No connection specified (for compiled in adapters)
+# Note: if connection information is not specified, the adapter configuration is directly inside
+# `spec` block. This is going to be DEPRECATED in favor of Sample-2
+apiVersion: &#34;config.istio.io/v1alpha2&#34;
+kind: prometheus
+metadata:
+  name: handler
+  namespace: istio-system
+spec:
+  metrics:
+  - name: request_count
+    instance_name: requestcount.metric.istio-system
+    kind: COUNTER
+    label_names:
+    - source_service
+    - source_version
+    - destination_service
+    - destination_version
+---
+# Sample-2: With connection information (for out-of-process adapters)
+# Note: Unlike sample-1, the adapter configuration is parallel to `connection` and is nested inside `param` block.
+apiVersion: &#34;config.istio.io/v1alpha2&#34;
+kind: prometheus
+metadata:
+  name: handler
+  namespace: istio-system
+spec:
+  param:
+    metrics:
+    - name: request_count
+      instance_name: requestcount.metric.istio-system
+      kind: COUNTER
+      label_names:
+      - source_service
+      - source_version
+      - destination_service
+      - destination_version
+  connection:
+    address: localhost:8090
+---
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | Required. Must be unique in the entire mixer configuration. Used by [Actions][istio.policy.v1beta1.Action.handler] to refer to this handler. |
+| compiled_adapter | [string](#string) |  | Required. The name of the compiled in adapter this handler instantiates. For referencing non compiled-in adapters, use the `adapter` field instead.  The value must match the name of the available adapter Mixer is built with. An adapter&#39;s name is typically a constant in its code. |
+| adapter | [string](#string) |  | Required. The name of a specific adapter implementation. For referencing compiled-in adapters, use the `compiled_adapter` field instead.  An adapter&#39;s implementation name is typically a constant in its code. |
+| params | [google.protobuf.Struct](#google.protobuf.Struct) |  | Optional. Depends on adapter implementation. Struct representation of a proto defined by the adapter implementation; this varies depending on the value of field `adapter`. |
+| connection | [Connection](#istio.policy.v1beta1.Connection) |  | Optional. Information on how to connect to the out-of-process adapter. This is used if the adapter is not compiled into Mixer binary and is running as a separate process. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.Instance"/>
+
+### Instance
+An Instance tells Mixer how to create instances for particular template.
+
+Instance is defined by the operator. Instance is defined relative to a known
+template. Their purpose is to tell Mixer how to use attributes or literals to produce
+instances of the specified template at runtime.
+
+The following example instructs Mixer to construct an instance associated with template
+&#39;istio.mixer.adapter.metric.Metric&#39;. It provides a mapping from the template&#39;s fields to expressions.
+Instances produced with this instance can be referenced by [Actions][istio.policy.v1beta1.Action] using name
+&#39;RequestCountByService&#39;
+
+```yaml
+- name: RequestCountByService
+  template: istio.mixer.adapter.metric.Metric
+  params:
+    value: 1
+    dimensions:
+      source: source.service
+      destination_ip: destination.ip
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | Required. The name of this instance  Must be unique amongst other Instances in scope. Used by [Action][istio.policy.v1beta1.Action] to refer to an instance produced by this instance. |
+| compiled_template | [string](#string) |  | Required. The name of the compiled in template this instance creates instances for. For referencing non compiled-in templates, use the `template` field instead.  The value must match the name of the available template Mixer is built with. |
+| template | [string](#string) |  | Required. The name of the template this instance creates instances for. For referencing compiled-in templates, use the `compiled_template` field instead.  The value must match the name of the available template in scope. |
+| params | [google.protobuf.Struct](#google.protobuf.Struct) |  | Required. Depends on referenced template. Struct representation of a proto defined by the template; this varies depending on the value of field `template`. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.Rule"/>
+
+### Rule
+A Rule is a selector and a set of intentions to be executed when the
+selector is `true`
+
+The following example instructs Mixer to invoke &#39;prometheus-handler&#39; handler for all services and pass it the
+instance constructed using the &#39;RequestCountByService&#39; instance.
+
+```yaml
+- match: destination.service == &#34;*&#34;
+  actions:
+  - handler: prometheus-handler
+    instances:
+    - RequestCountByService
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| match | [string](#string) |  | Required. Match is an attribute based predicate. When Mixer receives a request it evaluates the match expression and executes all the associated `actions` if the match evaluates to true.  A few example match:  * an empty match evaluates to `true` * `true`, a boolean literal; a rule with this match will always be executed * `destination.service == ratings*` selects any request targeting a service whose name starts with &#34;ratings&#34; * `attr1 == &#34;20&#34; &amp;&amp; attr2 == &#34;30&#34;` logical AND, OR, and NOT are also available |
+| actions | [Action](#istio.policy.v1beta1.Action) | repeated | Optional. The actions that will be executed when match evaluates to `true`. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="policy/v1beta1/type.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## policy/v1beta1/type.proto
+
+
+
+<a name="istio.policy.v1beta1.DNSName"/>
+
+### DNSName
+An instance field of type DNSName denotes that the expression for the field must evalaute to
+[ValueType.DNS_NAME][istio.policy.v1beta1.ValueType.DNS_NAME]
+
+Objects of type DNSName are also passed to the adapters during request-time for the instance fields of
+type DNSName
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [string](#string) |  | DNSName encoded as string. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.Duration"/>
+
+### Duration
+An instance field of type Duration denotes that the expression for the field must evalaute to
+[ValueType.DURATION][istio.policy.v1beta1.ValueType.DURATION]
+
+Objects of type Duration are also passed to the adapters during request-time for the instance fields of
+type Duration
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [google.protobuf.Duration](#google.protobuf.Duration) |  | Duration encoded as google.protobuf.Duration. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.EmailAddress"/>
+
+### EmailAddress
+DO NOT USE !! Under Development
+An instance field of type EmailAddress denotes that the expression for the field must evalaute to
+[ValueType.EMAIL_ADDRESS][istio.policy.v1beta1.ValueType.EMAIL_ADDRESS]
+
+Objects of type EmailAddress are also passed to the adapters during request-time for the instance fields of
+type EmailAddress
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [string](#string) |  | EmailAddress encoded as string. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.IPAddress"/>
+
+### IPAddress
+An instance field of type IPAddress denotes that the expression for the field must evalaute to
+[ValueType.IP_ADDRESS][istio.policy.v1beta1.ValueType.IP_ADDRESS]
+
+Objects of type IPAddress are also passed to the adapters during request-time for the instance fields of
+type IPAddress
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [bytes](#bytes) |  | IPAddress encoded as bytes. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.TimeStamp"/>
+
+### TimeStamp
+An instance field of type TimeStamp denotes that the expression for the field must evalaute to
+[ValueType.TIMESTAMP][istio.policy.v1beta1.ValueType.TIMESTAMP]
+
+Objects of type TimeStamp are also passed to the adapters during request-time for the instance fields of
+type TimeStamp
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | TimeStamp encoded as google.protobuf.Timestamp. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.Uri"/>
+
+### Uri
+DO NOT USE !! Under Development
+An instance field of type Uri denotes that the expression for the field must evalaute to
+[ValueType.URI][istio.policy.v1beta1.ValueType.URI]
+
+Objects of type Uri are also passed to the adapters during request-time for the instance fields of
+type Uri
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [string](#string) |  | Uri encoded as string. |
+
+
+
+
+
+
+<a name="istio.policy.v1beta1.Value"/>
+
+### Value
+An instance field of type Value denotes that the expression for the field is of dynamic type and can evalaute to any
+[ValueType][istio.policy.v1beta1.ValueType] enum values. For example, when
+authoring an instance configuration for a template that has a field `data` of type `istio.policy.v1beta1.Value`,
+both of the following expressions are valid `data: source.ip | ip(&#34;0.0.0.0&#34;)`, `data: request.id | &#34;&#34;`;
+the resulting type is either ValueType.IP_ADDRESS or ValueType.STRING for the two cases respectively.
+
+Objects of type Value are also passed to the adapters during request-time. There is a 1:1 mapping between
+oneof fields in `Value` and enum values inside `ValueType`. Depending on the expression&#39;s evaluated `ValueType`,
+the equivalent oneof field in `Value` is populated by Mixer and passed to the adapters.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| string_value | [string](#string) |  | Used for values of type STRING |
+| int64_value | [int64](#int64) |  | Used for values of type INT64 |
+| double_value | [double](#double) |  | Used for values of type DOUBLE |
+| bool_value | [bool](#bool) |  | Used for values of type BOOL |
+| ip_address_value | [IPAddress](#istio.policy.v1beta1.IPAddress) |  | Used for values of type IPAddress |
+| timestamp_value | [TimeStamp](#istio.policy.v1beta1.TimeStamp) |  | Used for values of type TIMESTAMP |
+| duration_value | [Duration](#istio.policy.v1beta1.Duration) |  | Used for values of type DURATION |
+| email_address_value | [EmailAddress](#istio.policy.v1beta1.EmailAddress) |  | Used for values of type EmailAddress |
+| dns_name_value | [DNSName](#istio.policy.v1beta1.DNSName) |  | Used for values of type DNSName |
+| uri_value | [Uri](#istio.policy.v1beta1.Uri) |  | Used for values of type Uri |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="policy/v1beta1/value_type.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## policy/v1beta1/value_type.proto
+
+
+ 
+
+
+<a name="istio.policy.v1beta1.ValueType"/>
+
+### ValueType
+ValueType describes the types that values in the Istio system can take. These
+are used to describe the type of Attributes at run time, describe the type of
+the result of evaluating an expression, and to describe the runtime type of
+fields of other descriptors.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| VALUE_TYPE_UNSPECIFIED | 0 | Invalid, default value. |
+| STRING | 1 | An undiscriminated variable-length string. |
+| INT64 | 2 | An undiscriminated 64-bit signed integer. |
+| DOUBLE | 3 | An undiscriminated 64-bit floating-point value. |
+| BOOL | 4 | An undiscriminated boolean value. |
+| TIMESTAMP | 5 | A point in time. |
+| IP_ADDRESS | 6 | An IP address. |
+| EMAIL_ADDRESS | 7 | An email address. |
+| URI | 8 | A URI. |
+| DNS_NAME | 9 | A DNS name. |
+| DURATION | 10 | A span between two points in time. |
+| STRING_MAP | 11 | A map string -&gt; string, typically used by headers. |
+
+
+ 
+
+ 
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | Java Type | Python Type |
+| ----------- | ----- | -------- | --------- | ----------- |
+| <a name="double" /> double |  | double | double | float |
+| <a name="float" /> float |  | float | float | float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
+| <a name="bool" /> bool |  | bool | boolean | boolean |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+

--- a/routing/v1alpha1/README.md
+++ b/routing/v1alpha1/README.md
@@ -1,0 +1,270 @@
+# Protocol Documentation
+<a name="top"/>
+
+## Table of Contents
+
+- [rbac/v1alpha1/rbac.proto](#rbac/v1alpha1/rbac.proto)
+    - [AccessRule](#istio.rbac.v1alpha1.AccessRule)
+    - [AccessRule.Constraint](#istio.rbac.v1alpha1.AccessRule.Constraint)
+    - [RbacConfig](#istio.rbac.v1alpha1.RbacConfig)
+    - [RbacConfig.Target](#istio.rbac.v1alpha1.RbacConfig.Target)
+    - [RoleRef](#istio.rbac.v1alpha1.RoleRef)
+    - [ServiceRole](#istio.rbac.v1alpha1.ServiceRole)
+    - [ServiceRoleBinding](#istio.rbac.v1alpha1.ServiceRoleBinding)
+    - [Subject](#istio.rbac.v1alpha1.Subject)
+    - [Subject.PropertiesEntry](#istio.rbac.v1alpha1.Subject.PropertiesEntry)
+  
+    - [EnforcementMode](#istio.rbac.v1alpha1.EnforcementMode)
+    - [RbacConfig.Mode](#istio.rbac.v1alpha1.RbacConfig.Mode)
+  
+  
+  
+
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="rbac/v1alpha1/rbac.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## rbac/v1alpha1/rbac.proto
+
+
+
+<a name="istio.rbac.v1alpha1.AccessRule"/>
+
+### AccessRule
+AccessRule defines a permission to access a list of services.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| services | [string](#string) | repeated | Required. A list of service names. Exact match, prefix match, and suffix match are supported for service names. For example, the service name &#34;bookstore.mtv.cluster.local&#34; matches &#34;bookstore.mtv.cluster.local&#34; (exact match), or &#34;bookstore*&#34; (prefix match), or &#34;*.mtv.cluster.local&#34; (suffix match). If set to [&#34;*&#34;], it refers to all services in the namespace. |
+| paths | [string](#string) | repeated | Optional. A list of HTTP paths or gRPC methods. gRPC methods must be presented as fully-qualified name in the form of packageName.serviceName/methodName. Exact match, prefix match, and suffix match are supported for paths. For example, the path &#34;/books/review&#34; matches &#34;/books/review&#34; (exact match), or &#34;/books/*&#34; (prefix match), or &#34;*/review&#34; (suffix match). If not specified, it applies to any path. |
+| methods | [string](#string) | repeated | Optional. A list of HTTP methods (e.g., &#34;GET&#34;, &#34;POST&#34;). It is ignored in gRPC case because the value is always &#34;POST&#34;. If set to [&#34;*&#34;] or not specified, it applies to any method. |
+| constraints | [AccessRule.Constraint](#istio.rbac.v1alpha1.AccessRule.Constraint) | repeated | Optional. Extra constraints in the ServiceRole specification. The above ServiceRole examples shows an example of constraint &#34;version&#34;. |
+
+
+
+
+
+
+<a name="istio.rbac.v1alpha1.AccessRule.Constraint"/>
+
+### AccessRule.Constraint
+Definition of a custom constraint. The key of a custom constraint must match
+one of the &#34;properties&#34; in the &#34;action&#34; part of the &#34;authorization&#34; template
+(https://github.com/istio/istio/blob/master/mixer/template/authorization/template.proto).
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  | Key of the constraint. |
+| values | [string](#string) | repeated | List of valid values for the constraint. Exact match, prefix match, and suffix match are supported for constraint values. For example, the value &#34;v1alpha2&#34; matches &#34;v1alpha2&#34; (exact match), or &#34;v1*&#34; (prefix match), or &#34;*alpha2&#34; (suffix match). |
+
+
+
+
+
+
+<a name="istio.rbac.v1alpha1.RbacConfig"/>
+
+### RbacConfig
+RbacConfig defines the global config to control Istio RBAC behavior.
+This Custom Resource is a singleton where only one Custom Resource should be created globally in
+the mesh and the namespace should be the same to other Istio components, which usually is istio-system.
+Note: This is enforced in both istioctl and server side, new Custom Resource will be rejected if found any
+existing one, the user should either delete the existing one or change the existing one directly.
+
+Below is an example of RbacConfig object &#34;istio-rbac-config&#34; which enables Istio RBAC for all
+services in the default namespace.
+
+```yaml
+apiVersion: &#34;config.istio.io/v1alpha1&#34;
+kind: RbacConfig
+metadata:
+  name: istio-rbac-config
+  namespace: istio-system
+spec:
+  mode: ON_WITH_INCLUSION
+  inclusion:
+    namespaces: [ &#34;default&#34; ]
+```
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| mode | [RbacConfig.Mode](#istio.rbac.v1alpha1.RbacConfig.Mode) |  | Istio RBAC mode. |
+| inclusion | [RbacConfig.Target](#istio.rbac.v1alpha1.RbacConfig.Target) |  | A list of services or namespaces that should be enforced by Istio RBAC policies. Note: This field have effect only when mode is ON_WITH_INCLUSION and will be ignored for any other modes. |
+| exclusion | [RbacConfig.Target](#istio.rbac.v1alpha1.RbacConfig.Target) |  | A list of services or namespaces that should not be enforced by Istio RBAC policies. Note: This field have effect only when mode is ON_WITH_EXCLUSION and will be ignored for any other modes. |
+
+
+
+
+
+
+<a name="istio.rbac.v1alpha1.RbacConfig.Target"/>
+
+### RbacConfig.Target
+Target defines a list of services or namespaces.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| services | [string](#string) | repeated | A list of services. |
+| namespaces | [string](#string) | repeated | A list of namespaces. |
+
+
+
+
+
+
+<a name="istio.rbac.v1alpha1.RoleRef"/>
+
+### RoleRef
+RoleRef refers to a role object.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| kind | [string](#string) |  | Required. The type of the role being referenced. Currently, &#34;ServiceRole&#34; is the only supported value for &#34;kind&#34;. |
+| name | [string](#string) |  | Required. The name of the ServiceRole object being referenced. The ServiceRole object must be in the same namespace as the ServiceRoleBinding object. |
+
+
+
+
+
+
+<a name="istio.rbac.v1alpha1.ServiceRole"/>
+
+### ServiceRole
+ServiceRole specification contains a list of access rules (permissions).
+This represent the &#34;Spec&#34; part of the ServiceRole object. The name and namespace
+of the ServiceRole is specified in &#34;metadata&#34; section of the ServiceRole object.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| rules | [AccessRule](#istio.rbac.v1alpha1.AccessRule) | repeated | Required. The set of access rules (permissions) that the role has. |
+| mode | [EnforcementMode](#istio.rbac.v1alpha1.EnforcementMode) |  | $hide_from_docs Indicates enforcement mode of the ServiceRole config. If ServiceRole is in PERMISSIVE mode, all ServiceRoleBindings that refers to it will be treated as PERMISSIVE mode. If ServiceRole is in ENFORCED mode, ServiceRoleBindings that refers to it will decide their own enforcement modes. |
+
+
+
+
+
+
+<a name="istio.rbac.v1alpha1.ServiceRoleBinding"/>
+
+### ServiceRoleBinding
+ServiceRoleBinding assigns a ServiceRole to a list of subjects.
+This represents the &#34;Spec&#34; part of the ServiceRoleBinding object. The name and namespace
+of the ServiceRoleBinding is specified in &#34;metadata&#34; section of the ServiceRoleBinding
+object.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| subjects | [Subject](#istio.rbac.v1alpha1.Subject) | repeated | Required. List of subjects that are assigned the ServiceRole object. |
+| roleRef | [RoleRef](#istio.rbac.v1alpha1.RoleRef) |  | Required. Reference to the ServiceRole object. |
+| mode | [EnforcementMode](#istio.rbac.v1alpha1.EnforcementMode) |  | $hide_from_docs Indicates enforcement mode of the ServiceRoleBinding config. If RoleRef it refers to is in PERMISSIVE mode, the ServiceRoleBinding will be treated as PERMISSIVE mode regardless this mode field. If RoleRef it refers to is in ENFORCED mode, the ServiceRoleBinding will decide its own enforcement mode from this mode field. |
+
+
+
+
+
+
+<a name="istio.rbac.v1alpha1.Subject"/>
+
+### Subject
+Subject defines an identity or a group of identities. The identity is either a user or
+a group or identified by a set of &#34;properties&#34;. The name of the &#34;properties&#34; must match
+the &#34;properties&#34; in the &#34;subject&#34; part of the &#34;authorization&#34; template
+(https://github.com/istio/istio/blob/master/mixer/template/authorization/template.proto).
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| user | [string](#string) |  | Optional. The user name/ID that the subject represents. |
+| group | [string](#string) |  | Optional. The group that the subject belongs to. |
+| properties | [Subject.PropertiesEntry](#istio.rbac.v1alpha1.Subject.PropertiesEntry) | repeated | Optional. The set of properties that identify the subject. In the above ServiceRoleBinding example, the second subject has two properties: service: &#34;reviews&#34; namespace: &#34;abc&#34; |
+
+
+
+
+
+
+<a name="istio.rbac.v1alpha1.Subject.PropertiesEntry"/>
+
+### Subject.PropertiesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+
+<a name="istio.rbac.v1alpha1.EnforcementMode"/>
+
+### EnforcementMode
+$hide_from_docs
+RBAC config enforcement mode, used to verify new ServiceRole/ServiceBinding configs
+work as expected before rolling to prod. RBAC engine only logs results from
+ServiceRole/ServiceBinding configs that are in permissive mode, and discards result
+before returning to the user.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| ENFORCED | 0 | Policy in ENFORCED mode has impact on user experience. Policy is in ENFORCED mode by default. |
+| PERMISSIVE | 1 | Policy in PERMISSIVE doesn&#39;t impact on user experience. RBAC engine run policies in PERMISSIVE and logs decision. |
+
+
+
+<a name="istio.rbac.v1alpha1.RbacConfig.Mode"/>
+
+### RbacConfig.Mode
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| OFF | 0 | Disable Istio RBAC completely, any other config in RbacConfig will be ignored and Istio RBAC policies will not be enforced. |
+| ON | 1 | Enable Istio RBAC for all services and namespaces. |
+| ON_WITH_INCLUSION | 2 | Enable Istio RBAC only for services and namespaces specified in the inclusion field. Any other services and namespaces not in the inclusion field will not be enforced by Istio RBAC policies. |
+| ON_WITH_EXCLUSION | 3 | Enable Istio RBAC for all services and namespaces except those specified in the exclusion field. Any other services and namespaces not in the exclusion field will be enforced by Istio RBAC policies. |
+
+
+ 
+
+ 
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | Java Type | Python Type |
+| ----------- | ----- | -------- | --------- | ----------- |
+| <a name="double" /> double |  | double | double | float |
+| <a name="float" /> float |  | float | float | float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
+| <a name="bool" /> bool |  | bool | boolean | boolean |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+


### PR DESCRIPTION
This PR is a proposal for generating a `README.md` file for each package in the api repo. The idea behind this PR is to make it easier to browse through the proto files from the github web UI and from preview windows in IDEs. These docs are intended only for quick reference when browsing the repo.

A few notes about the tool used:
- The tool used is a fork (in my personal space) of an existing `proto-gen-doc` tool. I had to fork it because it did not properly account for new lines in field descriptions, leading to broken tables.
- It uses html templates as the basis for the markdown conversion. This leads to some problematic conversions in some places, especially related to character escaping. This might be acceptable -- especially as a first pass.
- If this is generally useful, we can add markdown capabilities to the existing istio docgen tool.