### PR TITLE
uri should be under http.match rather than under http.match.headers according to the spec of HTTPMatchRequest.

### DIFF
--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -1352,8 +1352,8 @@ spec:
     - headers:
         cookie:
           regex: &quot;^(.*?;)?(user=jason)(;.*)?&quot;
-        uri:
-          prefix: &quot;/ratings/v2/&quot;
+      uri:
+        prefix: &quot;/ratings/v2/&quot;
     route:
     - destination:
         host: ratings.prod.svc.cluster.local

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -549,8 +549,8 @@ func (m *TCPRoute) GetRoute() []*DestinationWeight {
 //     - headers:
 //         cookie:
 //           regex: "^(.*?;)?(user=jason)(;.*)?"
-//         uri:
-//           prefix: "/ratings/v2/"
+//       uri:
+//         prefix: "/ratings/v2/"
 //     route:
 //     - destination:
 //         host: ratings.prod.svc.cluster.local

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -436,8 +436,8 @@ message TCPRoute {
 //     - headers:
 //         cookie:
 //           regex: "^(.*?;)?(user=jason)(;.*)?"
-//         uri:
-//           prefix: "/ratings/v2/"
+//       uri:
+//         prefix: "/ratings/v2/"
 //     route:
 //     - destination:
 //         host: ratings.prod.svc.cluster.local


### PR DESCRIPTION
In [HTTPMatchRequest ] (https://preliminary.istio.io/docs/reference/config/istio.networking.v1alpha3/#HTTPMatchRequest) , a http match can be described by  _uri(StringMatch), schema(StringMatch), headers map<string, StringMatch>(StringMatch)_ ... . **uri** is a brother filed of http.match.**headers** , not a key of headers map. It is a little confusing to use uri as a key of headers map, even though syntax is ok. 