### PR TITLE
Fix incorrect doc statement about HTTPS redirect.

### DIFF
--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -76,7 +76,7 @@ func (Server_TLSOptions_TLSmode) EnumDescriptor() ([]byte, []int) {
 //     - uk.bookinfo.com
 //     - eu.bookinfo.com
 //     tls:
-//       httpsRedirect: true # sends 302 redirect for http requests
+//       httpsRedirect: true # sends 301 redirect for http requests
 //   - port:
 //       number: 443
 //       name: https
@@ -320,7 +320,7 @@ func (m *Server) GetTls() *Server_TLSOptions {
 }
 
 type Server_TLSOptions struct {
-	// If set to true, the load balancer will send a 302 redirect for all
+	// If set to true, the load balancer will send a 301 redirect for all
 	// http connections, asking the clients to use HTTPS.
 	HttpsRedirect bool `protobuf:"varint,1,opt,name=https_redirect,json=httpsRedirect,proto3" json:"https_redirect,omitempty"`
 	// Optional: Indicates whether connections to this port should be

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -48,7 +48,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //     - uk.bookinfo.com
 //     - eu.bookinfo.com
 //     tls:
-//       httpsRedirect: true # sends 302 redirect for http requests
+//       httpsRedirect: true # sends 301 redirect for http requests
 //   - port:
 //       number: 443
 //       name: https
@@ -244,7 +244,7 @@ message Server {
   repeated string hosts = 2;
 
   message TLSOptions {
-    // If set to true, the load balancer will send a 302 redirect for all
+    // If set to true, the load balancer will send a 301 redirect for all
     // http connections, asking the clients to use HTTPS.
     bool https_redirect = 1;
 

--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -1039,7 +1039,7 @@ spec:
     - uk.bookinfo.com
     - eu.bookinfo.com
     tls:
-      httpsRedirect: true # sends 302 redirect for http requests
+      httpsRedirect: true # sends 301 redirect for http requests
   - port:
       number: 443
       name: https
@@ -2316,7 +2316,7 @@ https, and the TLS modes to use.</p>
 <td><code>httpsRedirect</code></td>
 <td><code>bool</code></td>
 <td>
-<p>If set to true, the load balancer will send a 302 redirect for all
+<p>If set to true, the load balancer will send a 301 redirect for all
 http connections, asking the clients to use HTTPS.</p>
 
 </td>


### PR DESCRIPTION
As seen [in envoy doc](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#enum-route-virtualhost-tlsrequirementtype) and [istio usage](https://github.com/istio/istio/blob/f3c0f5f9f86b80dc67af5e91622532516ecddc71/pilot/pkg/networking/core/v1alpha3/gateway.go#L348).