### PR TITLE
attributes: define context.reporter.type

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -283,3 +283,5 @@
 # gRPC trailer return status support
 - response.grpc_status
 - response.grpc_message
+
+- context.reporter.type


### PR DESCRIPTION
Values are "inbound" and "outbound". This is a replacement for context.reporter.local.

/assign @douglas-reid @geeknoid 

Signed-off-by: Kuat Yessenov <kuat@google.com>