### PR TITLE
attributes: rename attribute type to kind

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -285,3 +285,4 @@
 - response.grpc_message
 
 - context.reporter.type
+- context.reporter.kind


### PR DESCRIPTION
Due to collision with a go keyword.
Signed-off-by: Kuat Yessenov <kuat@google.com>