### PR TITLE
add connection.requested_server_name attribute (SNI)

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -183,10 +183,10 @@
 - connection.id
 - connection.received.bytes
 - connection.received.bytes_total
-- connection.received.requested_server_name
 - connection.sent.bytes
 - connection.sent.bytes_total
 - connection.duration
+- connection.requested_server_name
 
 # context attributes
 - context.protocol

--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -186,7 +186,6 @@
 - connection.sent.bytes
 - connection.sent.bytes_total
 - connection.duration
-- connection.requested_server_name
 
 # context attributes
 - context.protocol
@@ -287,3 +286,6 @@
 
 - context.reporter.type
 - context.reporter.kind
+
+# SNI, for TLS connections
+- connection.requested_server_name

--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -186,6 +186,7 @@
 - connection.sent.bytes
 - connection.sent.bytes_total
 - connection.duration
+- connection.requested_server_name
 
 # context attributes
 - context.protocol

--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -183,10 +183,10 @@
 - connection.id
 - connection.received.bytes
 - connection.received.bytes_total
+- connection.received.requested_server_name
 - connection.sent.bytes
 - connection.sent.bytes_total
 - connection.duration
-- connection.requested_server_name
 
 # context attributes
 - context.protocol


### PR DESCRIPTION
Will use Envoy's Network::Connection::requestedServerName() method