### PR TITLE
fix proxy build broken by global_dictionary.yaml

### DIFF
--- a/mixer/v1/global_dictionary.yaml
+++ b/mixer/v1/global_dictionary.yaml
@@ -313,7 +313,7 @@
 - DI
 - FI
 - RL
-- "-"
+- -
 
 - inbound
 - outbound


### PR DESCRIPTION
I made a comment in https://github.com/istio/api/pull/605/files but think it's faster to send out a PR directly.

@mandarjog 
Line 316 `- "-"` break the proxy build as [create_global_dictionary.py](https://github.com/istio/proxy/blob/4865583db000db91be0469a7f1756cc98fea9992/src/istio/mixerclient/create_global_dictionary.py#L65) parse it to: `    ""-"",` which is invalid in `.cc` file.

Could you suggest the proper way to fix this? Should we just remove the `"` or make it `\"-\"` or even update the script?