### PR TITLE
Update documentation related to weighted routes

### DIFF
--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -2402,9 +2402,8 @@ to which the request/connection should be forwarded to.</p>
 <td><code>int32</code></td>
 <td>
 <p>REQUIRED. The proportion of traffic to be forwarded to the service
-version. (0-100). Sum of weights across destinations SHOULD BE == 100.
-If there is only one destination in a rule, the weight value is assumed to
-be 100.</p>
+version. If there is only one destination in a rule, all traffic will be
+routed to it irrespective of the weight.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -934,9 +934,8 @@ type RouteDestination struct {
 	// to which the request/connection should be forwarded to.
 	Destination *Destination `protobuf:"bytes,1,opt,name=destination" json:"destination,omitempty"`
 	// REQUIRED. The proportion of traffic to be forwarded to the service
-	// version. (0-100). Sum of weights across destinations SHOULD BE == 100.
-	// If there is only one destination in a rule, the weight value is assumed to
-	// be 100.
+	// version. If there is only one destination in a rule, all traffic will be
+	// routed to it irrespective of the weight.
 	Weight int32 `protobuf:"varint,2,opt,name=weight,proto3" json:"weight,omitempty"`
 }
 

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -682,9 +682,8 @@ message RouteDestination {
   Destination destination = 1;
 
   // REQUIRED. The proportion of traffic to be forwarded to the service
-  // version. (0-100). Sum of weights across destinations SHOULD BE == 100.
-  // If there is only one destination in a rule, the weight value is assumed to
-  // be 100.
+  // version. If there is only one destination in a rule, all traffic will be
+  // routed to it irrespective of the weight.
   int32 weight = 2;
 }
 


### PR DESCRIPTION
Envoy doesn't need that the total weight of all routes be equal to 100. This PR updates the documentation related to the same. Refer to [this comment](https://github.com/istio/istio/pull/9112#discussion_r222797735) in istio/istio#9112 for more information.