### PR TITLE
Fix typo in gateway.proto

### DIFF
--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -104,7 +104,7 @@ func (Server_TLSOptions_TLSProtocol) EnumDescriptor() ([]byte, []int) {
 //   name: my-gateway
 // spec:
 //   selector:
-//     app: my-gatweway-controller
+//     app: my-gateway-controller
 //   servers:
 //   - port:
 //       number: 80

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -38,7 +38,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //   name: my-gateway
 // spec:
 //   selector:
-//     app: my-gatweway-controller
+//     app: my-gateway-controller
 //   servers:
 //   - port:
 //       number: 80

--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -989,7 +989,7 @@ metadata:
   name: my-gateway
 spec:
   selector:
-    app: my-gatweway-controller
+    app: my-gateway-controller
   servers:
   - port:
       number: 80


### PR DESCRIPTION
`s/gatweway/gateway`

Modified `gateway.proto` then generated the 2 other files.