### PR TITLE
Minor correction to avoid confusion in ServiceEntry reference doc

### DIFF
--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -2959,7 +2959,7 @@ spec:
   location: MESH_EXTERNAL
   ports:
   - number: 80
-    name: https
+    name: http
     protocol: HTTP
   resolution: DNS
   endpoints:

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -343,7 +343,7 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 //   location: MESH_EXTERNAL
 //   ports:
 //   - number: 80
-//     name: https
+//     name: http
 //     protocol: HTTP
 //   resolution: DNS
 //   endpoints:

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -264,7 +264,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //   location: MESH_EXTERNAL
 //   ports:
 //   - number: 80
-//     name: https
+//     name: http
 //     protocol: HTTP
 //   resolution: DNS
 //   endpoints:


### PR DESCRIPTION
This is a minor correction to prevent user confusion in the istio.io reference doc for ServiceEntry.