### PR TITLE
update comment

### DIFF
--- a/mesh/v1alpha1/config.pb.go
+++ b/mesh/v1alpha1/config.pb.go
@@ -410,7 +410,7 @@ func (m *MeshConfig_OutboundTrafficPolicy) GetMode() MeshConfig_OutboundTrafficP
 type ConfigSource struct {
 	// Address of the server implementing the Istio Mesh Configuration
 	// protocol (MCP). Can be IP address or a fully qualified DNS name.
-	// Use file:/// to specify a file-based backend with absolute path to the directory.
+	// Use fs:/// to specify a file-based backend with absolute path to the directory.
 	Address string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	// Use the tls_settings to specify the tls mode to use. If the MCP server
 	// uses Istio MTLS and shares the root CA with Pilot, specify the TLS

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -192,7 +192,7 @@ message MeshConfig {
 message ConfigSource {
   // Address of the server implementing the Istio Mesh Configuration
   // protocol (MCP). Can be IP address or a fully qualified DNS name.
-  // Use file:/// to specify a file-based backend with absolute path to the directory.
+  // Use fs:/// to specify a file-based backend with absolute path to the directory.
   string address = 1;
 
   // Use the tls_settings to specify the tls mode to use. If the MCP server

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -67,7 +67,7 @@ sources.</p>
 <td>
 <p>Address of the server implementing the Istio Mesh Configuration
 protocol (MCP). Can be IP address or a fully qualified DNS name.
-Use file:/// to specify a file-based backend with absolute path to the directory.</p>
+Use fs:/// to specify a file-based backend with absolute path to the directory.</p>
 
 </td>
 </tr>


### PR DESCRIPTION
use `fs:///` to indicate a file directory instead of `file:///` which may confuse users.