### PR TITLE
bazel: Allow to distdir all dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,13 +3,17 @@ workspace(name = "io_istio_api")
 load("//:check_bazel_version.bzl", "check_version")
 check_version()
 
-git_repository(
+# Oct 12, 2017 (Add `build_external` option to `go_repository`)
+RULES_GO_SHA = "9cf23e2aab101f86e4f51d8c5e0f14c012c2161c"
+RULES_GO_SHA256 = "76133849005134eceba9080ee28cef03316fd29f64a0a8a3ae09cd8862531d15"
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
     name = "io_bazel_rules_go",
-    commit = "9cf23e2aab101f86e4f51d8c5e0f14c012c2161c",  # Oct 12, 2017 (Add `build_external` option to `go_repository`)
-    remote = "https://github.com/bazelbuild/rules_go.git",
+    strip_prefix = "rules_go-" + RULES_GO_SHA,
+    url = "https://github.com/bazelbuild/rules_go/archive/" + RULES_GO_SHA + ".tar.gz",
+    sha256 = RULES_GO_SHA256,
 )
 
 load("//:api_dependencies.bzl", "mixer_api_dependencies")
 mixer_api_dependencies()
-
-

--- a/scripts/check-repositories
+++ b/scripts/check-repositories
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright 2018 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+set -eu
+
+# Check whether any git repositories are defined.
+# Git repository definition contains `commit` and `remote` fields.
+if git --no-pager grep -E "commit =|remote =" -- 'WORKSPACE' '*.bzl'; then
+  echo "Using git repositories is not allowed."
+  echo "To ensure that all dependencies can be stored offline in distdir, only HTTP repositories are allowed."
+  exit 1
+fi
+
+# Check whether number of defined `url =` and `sha256 =` kwargs in repository
+# definitions is equal.
+urls_count=$(git --no-pager grep -E "url =" -- 'WORKSPACE' '*.bzl' | wc -l)
+sha256sums_count=$(git --no-pager grep -E "sha256 =" -- 'WORKSPACE' '*.bzl' | wc -l)
+
+if [[ $urls_count != $sha256sums_count ]]; then
+  echo "Found more defined repository URLs than SHA256 sums, which means that there are some repositories without sums."
+  echo "Dependencies without SHA256 sums cannot be stored in distdir."
+  echo "Please ensure that every repository has a SHA256 sum."
+  echo "Repositories are defined in the WORKSPACE file."
+  exit 1
+fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -38,4 +38,7 @@ if [ $BRANCH_NAME != '(no branch)' ]; then
 
   echo "Checking lint"
   make lint
+
+  echo "Checking repositories definitions"
+  scripts/check-repositories
 fi


### PR DESCRIPTION
To use --distdir option of Bazel (which allows to use previously
fetched tarballs instead of downloading dependencies during
build), all dependencies should use http instead of git and need
to have sha256 sums specified.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>