### PR TITLE
Fix some spelling errors

### DIFF
--- a/mesh/v1alpha1/config.pb.go
+++ b/mesh/v1alpha1/config.pb.go
@@ -290,7 +290,7 @@ type MeshConfig struct {
 	// The default service dependency setting associated with every workload
 	// in the mesh.  Pilot will program the routes in the sidecars and
 	// gateways accordingly. If omitted, sidecars will be configured to reach
-	// every service in the mesh. The default scope can be overriden by
+	// every service in the mesh. The default scope can be overridden by
 	// supplying a ServiceDependency resource per namespace.
 	DefaultServiceDependency *MeshConfig_DefaultServiceDependency `protobuf:"bytes,29,opt,name=default_service_dependency,json=defaultServiceDependency" json:"default_service_dependency,omitempty"`
 }

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -238,7 +238,7 @@ message MeshConfig {
   // The default service dependency setting associated with every workload
   // in the mesh.  Pilot will program the routes in the sidecars and
   // gateways accordingly. If omitted, sidecars will be configured to reach
-  // every service in the mesh. The default scope can be overriden by
+  // every service in the mesh. The default scope can be overridden by
   // supplying a ServiceDependency resource per namespace.
   DefaultServiceDependency default_service_dependency = 29;
 

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -312,7 +312,7 @@ Fallback to old identity format(without trust domain) if not set.</p>
 <p>The default service dependency setting associated with every workload
 in the mesh.  Pilot will program the routes in the sidecars and
 gateways accordingly. If omitted, sidecars will be configured to reach
-every service in the mesh. The default scope can be overriden by
+every service in the mesh. The default scope can be overridden by
 supplying a ServiceDependency resource per namespace.</p>
 
 </td>
@@ -656,7 +656,7 @@ adding ISTIO<em>META</em>NETWORK environment variable to the sidecar.</p></li>
 </ol>
 
 <p>a. By matching the registry name with one of the &ldquo;from<em>registries&rdquo;
-   in the mesh config. A &ldquo;from</em>registry&rdquo; can only be assinged to a
+   in the mesh config. A &ldquo;from</em>registry&rdquo; can only be assigned to a
    single network.</p>
 
 <p>b. By matching the IP against one of the CIDR ranges in a mesh

--- a/mesh/v1alpha1/network.pb.go
+++ b/mesh/v1alpha1/network.pb.go
@@ -59,7 +59,7 @@ func (m *Network) GetGateways() []*Network_IstioNetworkGateway {
 // 2. Explicitly:
 //
 //    a. By matching the registry name with one of the "from_registries"
-//    in the mesh config. A "from_registry" can only be assinged to a
+//    in the mesh config. A "from_registry" can only be assigned to a
 //    single network.
 //
 //    b. By matching the IP against one of the CIDR ranges in a mesh

--- a/mesh/v1alpha1/network.proto
+++ b/mesh/v1alpha1/network.proto
@@ -36,7 +36,7 @@ message Network {
   // 2. Explicitly:
   //
   //    a. By matching the registry name with one of the "from_registries"
-  //    in the mesh config. A "from_registry" can only be assinged to a
+  //    in the mesh config. A "from_registry" can only be assigned to a
   //    single network.
   //
   //    b. By matching the IP against one of the CIDR ranges in a mesh


### PR DESCRIPTION
Fix some spelling errors:
1. "overriden" to "overridden".
2. "assinged" to "assigned".