### PR TITLE
route directive: ignore empty header values

### DIFF
--- a/policy/v1beta1/cfg.pb.go
+++ b/policy/v1beta1/cfg.pb.go
@@ -346,12 +346,17 @@ func (m *Rule) GetSampling() *Sampling {
 // that may reference action outputs by name. For example, if an action `x` produces an output
 // with a field `f`, then the header value expressions may use attribute `x.output.f` to reference
 // the field value:
+//
 // ```yaml
 // request_header_operations:
 // - name: x-istio-header
 //   values:
 //   - x.output.f
 // ```
+//
+// If the header value expression evaluates to an empty string, and the operation is to either replace
+// or append a header, then the operation is not applied. This permits conditional behavior on behalf of the
+// adapter to optionally modify the headers.
 type Rule_HeaderOperationTemplate struct {
 	// Required. Header name literal value.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`

--- a/policy/v1beta1/cfg.proto
+++ b/policy/v1beta1/cfg.proto
@@ -131,12 +131,17 @@ message Rule {
   // that may reference action outputs by name. For example, if an action `x` produces an output
   // with a field `f`, then the header value expressions may use attribute `x.output.f` to reference
   // the field value:
+  //
   // ```yaml
   // request_header_operations:
   // - name: x-istio-header
   //   values:
   //   - x.output.f
   // ```
+  //
+  // If the header value expression evaluates to an empty string, and the operation is to either replace
+  // or append a header, then the operation is not applied. This permits conditional behavior on behalf of the
+  // adapter to optionally modify the headers.
   message HeaderOperationTemplate {
 
     // Required. Header name literal value.

--- a/policy/v1beta1/istio.policy.v1beta1.pb.html
+++ b/policy/v1beta1/istio.policy.v1beta1.pb.html
@@ -809,6 +809,10 @@ the field value:</p>
   - x.output.f
 </code></pre>
 
+<p>If the header value expression evaluates to an empty string, and the operation is to either replace
+or append a header, then the operation is not applied. This permits conditional behavior on behalf of the
+adapter to optionally modify the headers.</p>
+
 <table class="message-fields">
 <thead>
 <tr>


### PR DESCRIPTION
Per https://github.com/istio/istio/issues/10801, empty header values are rarely desirable. We can use the empty value as a special conditional value.

/assign @geeknoid 

Signed-off-by: Kuat Yessenov <kuat@google.com>