### PR TITLE
Fix Invalid Example Manifests in Policy Proto

### DIFF
--- a/authentication/v1alpha1/istio.authentication.v1alpha1.pb.html
+++ b/authentication/v1alpha1/istio.authentication.v1alpha1.pb.html
@@ -340,7 +340,7 @@ or origin) should be used as principal. By default, it uses peer.</p>
 <pre><code class="language-yaml">apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: mTLS_enable
+  name: mtls-enable
   namespace: frod
 spec:
   peers:
@@ -352,7 +352,7 @@ spec:
 <pre><code class="language-yaml">apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: mTLS_disable
+  name: mtls-disable
   namespace: frod
 spec:
   targets:
@@ -365,7 +365,7 @@ for productpage:9000 except the path &lsquo;/health_check&rsquo; . Principal is 
 <pre><code class="language-yaml">apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: mTLS_enable
+  name: mtls-enable
   namespace: frod
 spec:
   targets:

--- a/authentication/v1alpha1/policy.pb.go
+++ b/authentication/v1alpha1/policy.pb.go
@@ -646,7 +646,7 @@ func (m *OriginAuthenticationMethod) GetJwt() *Jwt {
 // apiVersion: authentication.istio.io/v1alpha1
 // kind: Policy
 // metadata:
-//   name: mTLS_enable
+//   name: mtls-enable
 //   namespace: frod
 // spec:
 //   peers:
@@ -658,7 +658,7 @@ func (m *OriginAuthenticationMethod) GetJwt() *Jwt {
 // apiVersion: authentication.istio.io/v1alpha1
 // kind: Policy
 // metadata:
-//   name: mTLS_disable
+//   name: mtls-disable
 //   namespace: frod
 // spec:
 //   targets:
@@ -671,7 +671,7 @@ func (m *OriginAuthenticationMethod) GetJwt() *Jwt {
 // apiVersion: authentication.istio.io/v1alpha1
 // kind: Policy
 // metadata:
-//   name: mTLS_enable
+//   name: mtls-enable
 //   namespace: frod
 // spec:
 //   targets:

--- a/authentication/v1alpha1/policy.proto
+++ b/authentication/v1alpha1/policy.proto
@@ -261,7 +261,7 @@ enum PrincipalBinding {
 // apiVersion: authentication.istio.io/v1alpha1
 // kind: Policy
 // metadata:
-//   name: mTLS_enable
+//   name: mtls-enable
 //   namespace: frod
 // spec:
 //   peers:
@@ -273,7 +273,7 @@ enum PrincipalBinding {
 // apiVersion: authentication.istio.io/v1alpha1
 // kind: Policy
 // metadata:
-//   name: mTLS_disable
+//   name: mtls-disable
 //   namespace: frod
 // spec:
 //   targets:
@@ -286,7 +286,7 @@ enum PrincipalBinding {
 // apiVersion: authentication.istio.io/v1alpha1
 // kind: Policy
 // metadata:
-//   name: mTLS_enable
+//   name: mtls-enable
 //   namespace: frod
 // spec:
 //   targets:


### PR DESCRIPTION
Some examples in [authentication/v1alpha1/policy.proto](https://github.com/istio/api/blob/master/authentication/v1alpha1/policy.proto) include invalid **Name** fields that contain underscores and capital letters. Kubernetes will reject these examples if you attempt to apply them.

Signed-off-by: Jacob Boykin <Boykinmusic@gmail.com>