### PR TITLE
Update comment for credentialName

### DIFF
--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -426,7 +426,7 @@ type Server_TLSOptions struct {
 	// using the file system paths specified above. If using mutual TLS,
 	// gateway workloads will retrieve the CaCertificates using
 	// credentialName-cacert. The semantics of the name are platform dependent.
-	// In Kubernetes, the default Istio supplied credentail server expects the
+	// In Kubernetes, the default Istio supplied credential server expects the
 	// credentialName to match the name of the Kubernetes secret that holds the
 	// server certificate, the private key, and the CA certificate
 	// (if using mutual TLS).

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -418,15 +418,18 @@ type Server_TLSOptions struct {
 	// client side certificate.
 	CaCertificates string `protobuf:"bytes,5,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// The credentialName stands for a unique identifier that can be used
-	// to identify the serverCertificate, the privateKey and the
-	// CaCertificates associated with this server. Gateway workloads
-	// capable of fetching credentials from a remote credential store will
-	// be configured to retrive the credentials using this name, instead of
-	// using the file system paths specified above. The semantics of the
-	// name are platform dependent. In Kubernetes, the default Istio
-	// supplied credentail server expects the credentialName to match the
-	// name of the Kubernetes secret that holds the server certificate, the
-	// private key, and the CA certificate (if using mutual TLS).
+	// to identify the serverCertificate and the privateKey. The credentialName
+	// appended with suffix "-cacert" is used to identify the CaCertificates
+	// associated with this server. Gateway workloads capable of fetching
+	// credentials from a remote credential store will be configured to retrieve
+	// the serverCertificate and the privateKey using credentialName, instead of
+	// using the file system paths specified above. If using mutual TLS,
+	// gateway workloads will retrieve the CaCertificates using
+	// credentialName-cacert. The semantics of the name are platform dependent.
+	// In Kubernetes, the default Istio supplied credentail server expects the
+	// credentialName to match the name of the Kubernetes secret that holds the
+	// server certificate, the private key, and the CA certificate
+	// (if using mutual TLS).
 	CredentialName string `protobuf:"bytes,10,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`
 	// A list of alternate names to verify the subject identity in the
 	// certificate presented by the client.

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -305,15 +305,18 @@ message Server {
     string ca_certificates = 5;
 
     // The credentialName stands for a unique identifier that can be used
-    // to identify the serverCertificate, the privateKey and the
-    // CaCertificates associated with this server. Gateway workloads
-    // capable of fetching credentials from a remote credential store will
-    // be configured to retrive the credentials using this name, instead of
-    // using the file system paths specified above. The semantics of the
-    // name are platform dependent. In Kubernetes, the default Istio
-    // supplied credentail server expects the credentialName to match the
-    // name of the Kubernetes secret that holds the server certificate, the
-    // private key, and the CA certificate (if using mutual TLS).
+    // to identify the serverCertificate and the privateKey. The credentialName
+    // appended with suffix "-cacert" is used to identify the CaCertificates
+    // associated with this server. Gateway workloads capable of fetching
+    // credentials from a remote credential store will be configured to retrieve
+    // the serverCertificate and the privateKey using credentialName, instead of
+    // using the file system paths specified above. If using mutual TLS,
+    // gateway workloads will retrieve the CaCertificates using
+    // credentialName-cacert. The semantics of the name are platform dependent.
+    // In Kubernetes, the default Istio supplied credentail server expects the
+    // credentialName to match the name of the Kubernetes secret that holds the
+    // server certificate, the private key, and the CA certificate
+    // (if using mutual TLS).
     string credential_name = 10;
 
     // A list of alternate names to verify the subject identity in the

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -313,7 +313,7 @@ message Server {
     // using the file system paths specified above. If using mutual TLS,
     // gateway workloads will retrieve the CaCertificates using
     // credentialName-cacert. The semantics of the name are platform dependent.
-    // In Kubernetes, the default Istio supplied credentail server expects the
+    // In Kubernetes, the default Istio supplied credential server expects the
     // credentialName to match the name of the Kubernetes secret that holds the
     // server certificate, the private key, and the CA certificate
     // (if using mutual TLS).

--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -2969,7 +2969,7 @@ the serverCertificate and the privateKey using credentialName, instead of
 using the file system paths specified above. If using mutual TLS,
 gateway workloads will retrieve the CaCertificates using
 credentialName-cacert. The semantics of the name are platform dependent.
-In Kubernetes, the default Istio supplied credentail server expects the
+In Kubernetes, the default Istio supplied credential server expects the
 credentialName to match the name of the Kubernetes secret that holds the
 server certificate, the private key, and the CA certificate
 (if using mutual TLS).</p>

--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -2961,15 +2961,18 @@ client side certificate.</p>
 <td><code>string</code></td>
 <td>
 <p>The credentialName stands for a unique identifier that can be used
-to identify the serverCertificate, the privateKey and the
-CaCertificates associated with this server. Gateway workloads
-capable of fetching credentials from a remote credential store will
-be configured to retrive the credentials using this name, instead of
-using the file system paths specified above. The semantics of the
-name are platform dependent. In Kubernetes, the default Istio
-supplied credentail server expects the credentialName to match the
-name of the Kubernetes secret that holds the server certificate, the
-private key, and the CA certificate (if using mutual TLS).</p>
+to identify the serverCertificate and the privateKey. The credentialName
+appended with suffix &ldquo;-cacert&rdquo; is used to identify the CaCertificates
+associated with this server. Gateway workloads capable of fetching
+credentials from a remote credential store will be configured to retrieve
+the serverCertificate and the privateKey using credentialName, instead of
+using the file system paths specified above. If using mutual TLS,
+gateway workloads will retrieve the CaCertificates using
+credentialName-cacert. The semantics of the name are platform dependent.
+In Kubernetes, the default Istio supplied credentail server expects the
+credentialName to match the name of the Kubernetes secret that holds the
+server certificate, the private key, and the CA certificate
+(if using mutual TLS).</p>
 
 </td>
 </tr>


### PR DESCRIPTION
Update comment for credentialName.
When customer specifies credentialName (e.g. "foo.credential"), and use MUTUAL TLS.
Gateway workloads will send SDS requests with resource name "foo.credential" to retrieve serverCertificate and privateKey, and send SDS requests with resource name "foo.credential-cacert" to retrieve CaCertificates. In Kubernetes, customer needs to create a Kubernetes secret named "foo.credential", which contains server certificate, the private key, and the CA certificate.
If customer specifies credentialName (e.g. "foo.credential"), and use SIMPLE TLS. Gateway workload will only send SDS requests with resource name "foo.credential" to retrieve serverCertificate and privateKey. And the Kubernetes secret named "foo.credential" only contains server certificate and private key.