### PR TITLE
rename gateway to gateways

### DIFF
--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -210,7 +210,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //         host: istio-egressgateway.istio-system.svc.cluster.local
 //   - match:
 //     - port: 80
-//       gateway:
+//       gateways:
 //       - istio-egressgateway
 //     route:
 //     - destination:


### PR DESCRIPTION
Renaming gateway to "gateways". Without these changes the yaml wouldn't be applied successfully.