### PR TITLE
Changing "gateway" to "gateways"

### DIFF
--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -3313,7 +3313,7 @@ spec:
         host: istio-egressgateway.istio-system.svc.cluster.local
   - match:
     - port: 80
-      gateway:
+      gateways:
       - istio-egressgateway
     route:
     - destination:

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -289,7 +289,7 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 //         host: istio-egressgateway.istio-system.svc.cluster.local
 //   - match:
 //     - port: 80
-//       gateway:
+//       gateways:
 //       - istio-egressgateway
 //     route:
 //     - destination:

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -210,7 +210,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //         host: istio-egressgateway.istio-system.svc.cluster.local
 //   - match:
 //     - port: 80
-//       gateway:
+//       gateways:
 //       - istio-egressgateway
 //     route:
 //     - destination:


### PR DESCRIPTION
Correcting gateway as gateways. If not changed, the yaml would not apply successfully.