### PR TITLE
adding DestinationRule

### DIFF
--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -196,6 +196,7 @@
 //     route:
 //     - destination:
 //         host: istio-egressgateway.istio-system.svc.cluster.local
+//         subset: httpbin
 //   - match:
 //     - port: 80
 //       gateways:
@@ -203,6 +204,23 @@
 //     route:
 //     - destination:
 //         host: httpbin.com
+// ```
+//
+// Lastly, the associated DestinationRule, to define policies that apply to
+// traffic intended for the gateway service (istio-egressgateway.istio-system.svc.cluster.local)
+// after routing defined in the above VirtualService has occurred.
+//
+// ```yaml
+// apiVersion: networking.istio.io/v1alpha3
+// kind: DestinationRule
+// metadata:
+//   name: egressgateway-for-httpbin
+// spec:
+//   host: istio-egressgateway.istio-system.svc.cluster.local
+//   subsets:
+//   - name: httpbin
+//     labels:
+//       istio: egressgateway
 // ```
 //
 // The following example demonstrates the use of wildcards in the hosts for

--- a/networking/v1alpha3/service_entry.pb.html
+++ b/networking/v1alpha3/service_entry.pb.html
@@ -193,6 +193,7 @@ spec:
     route:
     - destination:
         host: istio-egressgateway.istio-system.svc.cluster.local
+        subset: httpbin
   - match:
     - port: 80
       gateways:
@@ -200,6 +201,22 @@ spec:
     route:
     - destination:
         host: httpbin.com
+</code></pre>
+
+<p>Lastly, the associated DestinationRule, to define policies that apply to
+traffic intended for the gateway service (istio-egressgateway.istio-system.svc.cluster.local)
+after routing defined in the above VirtualService has occurred.</p>
+
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: egressgateway-for-httpbin
+spec:
+  host: istio-egressgateway.istio-system.svc.cluster.local
+  subsets:
+  - name: httpbin
+    labels:
+      istio: egressgateway
 </code></pre>
 
 <p>The following example demonstrates the use of wildcards in the hosts for

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -215,6 +215,7 @@ import "networking/v1alpha3/gateway.proto";
 //     route:
 //     - destination:
 //         host: istio-egressgateway.istio-system.svc.cluster.local
+//         subset: httpbin
 //   - match:
 //     - port: 80
 //       gateways:
@@ -222,6 +223,23 @@ import "networking/v1alpha3/gateway.proto";
 //     route:
 //     - destination:
 //         host: httpbin.com
+// ```
+//
+// Lastly, the associated DestinationRule, to define policies that apply to
+// traffic intended for the gateway service (istio-egressgateway.istio-system.svc.cluster.local)
+// after routing defined in the above VirtualService has occurred.
+//
+// ```yaml
+// apiVersion: networking.istio.io/v1alpha3
+// kind: DestinationRule
+// metadata:
+//   name: egressgateway-for-httpbin
+// spec:
+//   host: istio-egressgateway.istio-system.svc.cluster.local
+//   subsets:
+//   - name: httpbin
+//     labels:
+//       istio: egressgateway
 // ```
 //
 // The following example demonstrates the use of wildcards in the hosts for


### PR DESCRIPTION
Adding DestinationRule to the section of the page, which describes the use of "dedicated egress gateway through which all external service traffic is forwarded". Without the DestinationRule the example results in Status Code 503.