### PR TITLE
Fix example Sidecar structure

### DIFF
--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -68,14 +68,14 @@
 //       name: somename
 //     defaultEndpoint: unix:///var/run/someuds.sock
 //   egress:
-//   - hosts:
-//     - "istio-system/*"
-//     port:
+//   - port:
 //       number: 9080
 //       protocol: HTTP
 //       name: egresshttp
-//   - hosts:
+//     hosts:
 //     - "prod-us1/*"
+//   - hosts:
+//     - "istio-system/*"
 // ```
 //
 // If the workload is deployed without IP tables based traffic capture, the

--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -70,11 +70,11 @@
 //   egress:
 //   - hosts:
 //     - "istio-system/*"
-//   - port:
+//     port:
 //       number: 9080
 //       protocol: HTTP
 //       name: egresshttp
-//     hosts:
+//   - hosts:
 //     - "prod-us1/*"
 // ```
 //

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -73,11 +73,11 @@ spec:
   egress:
   - hosts:
     - &quot;istio-system/*&quot;
-  - port:
+    port:
       number: 9080
       protocol: HTTP
       name: egresshttp
-    hosts:
+  - hosts:
     - &quot;prod-us1/*&quot;
 </code></pre>
 

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -71,14 +71,14 @@ spec:
       name: somename
     defaultEndpoint: unix:///var/run/someuds.sock
   egress:
-  - hosts:
-    - &quot;istio-system/*&quot;
-    port:
+  - port:
       number: 9080
       protocol: HTTP
       name: egresshttp
-  - hosts:
+    hosts:
     - &quot;prod-us1/*&quot;
+  - hosts:
+    - &quot;istio-system/*&quot;
 </code></pre>
 
 <p>If the workload is deployed without IP tables based traffic capture, the

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -87,14 +87,14 @@ import "networking/v1alpha3/gateway.proto";
 //       name: somename
 //     defaultEndpoint: unix:///var/run/someuds.sock
 //   egress:
-//   - hosts:
-//     - "istio-system/*"
-//     port:
+//   - port:
 //       number: 9080
 //       protocol: HTTP
 //       name: egresshttp
-//   - hosts:
+//     hosts:
 //     - "prod-us1/*"
+//   - hosts:
+//     - "istio-system/*"
 // ```
 //
 // If the workload is deployed without IP tables based traffic capture, the

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -89,11 +89,11 @@ import "networking/v1alpha3/gateway.proto";
 //   egress:
 //   - hosts:
 //     - "istio-system/*"
-//   - port:
+//     port:
 //       number: 9080
 //       protocol: HTTP
 //       name: egresshttp
-//     hosts:
+//   - hosts:
 //     - "prod-us1/*"
 // ```
 //


### PR DESCRIPTION
Resolves https://github.com/istio/api/issues/847

An example Sidecar CRD in networking/v1alpha3/sidecar.proto is invalid.

It's the example that starts at line 77. It is generated into https://preliminary.istio.io/docs/reference/config/networking/v1alpha3/sidecar/ . If I take that example and use istioctl validate -f the error response is

```
* error validating resource (networking.istio.io/v1alpha3, Kind=Sidecar Name=default Namespace=): sidecar: the egress listener with empty port should be the last listener in the list
```