### PR TITLE
Fix incorrect indentation of `redirect` in `HTTPRedirect` docs

### DIFF
--- a/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -1605,9 +1605,9 @@ spec:
   - match:
     - uri:
         exact: /v1/getProductRatings
-  redirect:
-    uri: /v1/bookRatings
-    authority: newratings.default.svc.cluster.local
+    redirect:
+      uri: /v1/bookRatings
+      authority: newratings.default.svc.cluster.local
   ...
 </code></pre>
 

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -1641,9 +1641,9 @@ func (m *TLSMatchAttributes) GetGateways() []string {
 //   - match:
 //     - uri:
 //         exact: /v1/getProductRatings
-//   redirect:
-//     uri: /v1/bookRatings
-//     authority: newratings.default.svc.cluster.local
+//     redirect:
+//       uri: /v1/bookRatings
+//       authority: newratings.default.svc.cluster.local
 //   ...
 // ```
 type HTTPRedirect struct {

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -735,9 +735,9 @@ spec:
   - match:
     - uri:
         exact: /v1/getProductRatings
-  redirect:
-    uri: /v1/bookRatings
-    authority: newratings.default.svc.cluster.local
+    redirect:
+      uri: /v1/bookRatings
+      authority: newratings.default.svc.cluster.local
   ...
 </code></pre>
 

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -814,9 +814,9 @@ message TLSMatchAttributes {
 //   - match:
 //     - uri:
 //         exact: /v1/getProductRatings
-//   redirect:
-//     uri: /v1/bookRatings
-//     authority: newratings.default.svc.cluster.local
+//     redirect:
+//       uri: /v1/bookRatings
+//       authority: newratings.default.svc.cluster.local
 //   ...
 // ```
 message HTTPRedirect {


### PR DESCRIPTION
I believe there is a typo in the docs
https://istio.io/docs/reference/config/istio.networking.v1alpha3/#HTTPRedirect

```diff
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: ratings-route
spec:
  hosts:
  - ratings.prod.svc.cluster.local
  http:
  - match:
    - uri:
        exact: /v1/getProductRatings
-  redirect:
-    uri: /v1/bookRatings
-    authority: newratings.default.svc.cluster.local
+    redirect:
+      uri: /v1/bookRatings
+      authority: newratings.default.svc.cluster.local
  ...
```

See also istio/istio.io#3651