### PR TITLE
Fix ISTIO_META_USER_SDS styling in docs

### DIFF
--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -551,7 +551,7 @@ type Server_TLSOptions struct {
 	// server expects the credentialName to match the name of the
 	// Kubernetes secret that holds the server certificate, the private
 	// key, and the CA certificate (if using mutual TLS). Set the
-	// ISTIO_META_USER_SDS metadata variable in the gateway's proxy to
+	// `ISTIO_META_USER_SDS` metadata variable in the gateway's proxy to
 	// enable the dynamic credential fetching feature.
 	CredentialName string `protobuf:"bytes,10,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`
 	// A list of alternate names to verify the subject identity in the

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -459,7 +459,7 @@ dependent.  In Kubernetes, the default Istio supplied credential
 server expects the credentialName to match the name of the
 Kubernetes secret that holds the server certificate, the private
 key, and the CA certificate (if using mutual TLS). Set the
-ISTIO<em>META</em>USER_SDS metadata variable in the gateway&rsquo;s proxy to
+<code>ISTIO_META_USER_SDS</code> metadata variable in the gateway&rsquo;s proxy to
 enable the dynamic credential fetching feature.</p>
 
 </td>

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -368,7 +368,7 @@ message Server {
     // server expects the credentialName to match the name of the
     // Kubernetes secret that holds the server certificate, the private
     // key, and the CA certificate (if using mutual TLS). Set the
-    // ISTIO_META_USER_SDS metadata variable in the gateway's proxy to
+    // `ISTIO_META_USER_SDS` metadata variable in the gateway's proxy to
     // enable the dynamic credential fetching feature.
     string credential_name = 10;
 


### PR DESCRIPTION
This fixes a minor styling issue with the `ISTIO_META_USER_SDS` variable in the `Gateway` docs.

Fixes #880.

/cc @esnible 