### PR TITLE
Correct percentage value to match 1 out of 1000 docs value

### DIFF
--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -2285,7 +2285,7 @@ func (m *HTTPFaultInjection) GetAbort() *HTTPFaultInjection_Abort {
 //     fault:
 //       delay:
 //         percentage:
-//           value: 0.001
+//           value: 0.1
 //         fixedDelay: 5s
 // ```
 //
@@ -2487,7 +2487,7 @@ func _HTTPFaultInjection_Delay_OneofSizer(msg proto.Message) (n int) {
 //     fault:
 //       abort:
 //         percentage:
-//           value: 0.001
+//           value: 0.1
 //         httpStatus: 400
 // ```
 //

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -435,7 +435,7 @@ spec:
     fault:
       abort:
         percentage:
-          value: 0.001
+          value: 0.1
         httpStatus: 400
 </code></pre>
 
@@ -507,7 +507,7 @@ spec:
     fault:
       delay:
         percentage:
-          value: 0.001
+          value: 0.1
         fixedDelay: 5s
 </code></pre>
 

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -1023,7 +1023,7 @@ message HTTPFaultInjection {
   //     fault:
   //       delay:
   //         percentage:
-  //           value: 0.001
+  //           value: 0.1
   //         fixedDelay: 5s
   // ```
   //
@@ -1069,7 +1069,7 @@ message HTTPFaultInjection {
   //     fault:
   //       abort:
   //         percentage:
-  //           value: 0.001
+  //           value: 0.1
   //         httpStatus: 400
   // ```
   //


### PR DESCRIPTION
Both for HTTPFaultInjection.Abort and HTTPFaultInjection.Delay, the docs give an example for a "1 out of every 1000 requests".

The value given in the example to the 'percentage' field is '0.001', but the field 'percentage' is a type 'Percent' which goes from 0 to 100, so '0.001' would mean "1 out of 100000"

I've corrected the value from '0.001' to '0.1' to match "1 out of 1000", was either that or changing the docs to "1 out of 100000", but seemed like a too big number to me ;)