### PR TITLE
correct default values in the destination rule

### DIFF
--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1273,15 +1273,15 @@ func (m *ConnectionPoolSettings_TCPSettings_TcpKeepalive) GetInterval() *types.D
 
 // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
 type ConnectionPoolSettings_HTTPSettings struct {
-	// Maximum number of pending HTTP requests to a destination. Default 1024.
+	// Maximum number of pending HTTP requests to a destination.
 	Http1MaxPendingRequests int32 `protobuf:"varint,1,opt,name=http1_max_pending_requests,json=http1MaxPendingRequests,proto3" json:"http1_max_pending_requests,omitempty"`
-	// Maximum number of requests to a backend. Default 1024.
+	// Maximum number of requests to a backend.
 	Http2MaxRequests int32 `protobuf:"varint,2,opt,name=http2_max_requests,json=http2MaxRequests,proto3" json:"http2_max_requests,omitempty"`
 	// Maximum number of requests per connection to a backend. Setting this
 	// parameter to 1 disables keep alive.
 	MaxRequestsPerConnection int32 `protobuf:"varint,3,opt,name=max_requests_per_connection,json=maxRequestsPerConnection,proto3" json:"max_requests_per_connection,omitempty"`
 	// Maximum number of retries that can be outstanding to all hosts in a
-	// cluster at a given time. Defaults to 3.
+	// cluster at a given time. Defaults to 1024.
 	MaxRetries int32 `protobuf:"varint,4,opt,name=max_retries,json=maxRetries,proto3" json:"max_retries,omitempty"`
 	// The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests.
 	// If not set, there is no idle timeout. When the idle timeout is reached the connection will be closed.

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1273,9 +1273,9 @@ func (m *ConnectionPoolSettings_TCPSettings_TcpKeepalive) GetInterval() *types.D
 
 // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
 type ConnectionPoolSettings_HTTPSettings struct {
-	// Maximum number of pending HTTP requests to a destination.
+	// Maximum number of pending HTTP requests to a destination. Default 1024.
 	Http1MaxPendingRequests int32 `protobuf:"varint,1,opt,name=http1_max_pending_requests,json=http1MaxPendingRequests,proto3" json:"http1_max_pending_requests,omitempty"`
-	// Maximum number of requests to a backend.
+	// Maximum number of requests to a backend. Default 1024.
 	Http2MaxRequests int32 `protobuf:"varint,2,opt,name=http2_max_requests,json=http2MaxRequests,proto3" json:"http2_max_requests,omitempty"`
 	// Maximum number of requests per connection to a backend. Setting this
 	// parameter to 1 disables keep alive.

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -146,7 +146,7 @@ spec:
 <td><code>http1MaxPendingRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of pending HTTP requests to a destination. Default 1024.</p>
+<p>Maximum number of pending HTTP requests to a destination.</p>
 
 </td>
 </tr>
@@ -154,7 +154,7 @@ spec:
 <td><code>http2MaxRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of requests to a backend. Default 1024.</p>
+<p>Maximum number of requests to a backend.</p>
 
 </td>
 </tr>
@@ -172,7 +172,7 @@ parameter to 1 disables keep alive.</p>
 <td><code>int32</code></td>
 <td>
 <p>Maximum number of retries that can be outstanding to all hosts in a
-cluster at a given time. Defaults to 3.</p>
+cluster at a given time. Defaults to 1024.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -146,7 +146,7 @@ spec:
 <td><code>http1MaxPendingRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of pending HTTP requests to a destination.</p>
+<p>Maximum number of pending HTTP requests to a destination. Default 1024.</p>
 
 </td>
 </tr>
@@ -154,7 +154,7 @@ spec:
 <td><code>http2MaxRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of requests to a backend.</p>
+<p>Maximum number of requests to a backend. Default 1024.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -412,10 +412,10 @@ message ConnectionPoolSettings {
 
   // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
   message HTTPSettings {
-    // Maximum number of pending HTTP requests to a destination. Default 1024.
+    // Maximum number of pending HTTP requests to a destination.
     int32 http1_max_pending_requests = 1;
 
-    // Maximum number of requests to a backend. Default 1024.
+    // Maximum number of requests to a backend.
     int32 http2_max_requests = 2;
 
     // Maximum number of requests per connection to a backend. Setting this
@@ -423,7 +423,7 @@ message ConnectionPoolSettings {
     int32 max_requests_per_connection = 3;
 
     // Maximum number of retries that can be outstanding to all hosts in a
-    // cluster at a given time. Defaults to 3.
+    // cluster at a given time. Defaults to 1024.
     int32 max_retries = 4;
 
     // The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests.

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -412,10 +412,10 @@ message ConnectionPoolSettings {
 
   // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
   message HTTPSettings {
-    // Maximum number of pending HTTP requests to a destination.
+    // Maximum number of pending HTTP requests to a destination. Default 1024.
     int32 http1_max_pending_requests = 1;
 
-    // Maximum number of requests to a backend.
+    // Maximum number of requests to a backend. Default 1024.
     int32 http2_max_requests = 2;
 
     // Maximum number of requests per connection to a backend. Setting this


### PR DESCRIPTION
The destination rule proto default values for `max_retries` ,  `http1_max_pending_requests` and `http2_max_requests` is not as per the current [implemementation](https://github.com/istio/istio/blob/7d61672e25a28b0fa49ef2091f5b49703307572f/pilot/pkg/networking/core/v1alpha3/cluster.go). This PR corrects the docs.