### PR TITLE
add default max connections to docs

### DIFF
--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1129,7 +1129,7 @@ func (m *ConnectionPoolSettings) GetHttp() *ConnectionPoolSettings_HTTPSettings 
 
 // Settings common to both HTTP and TCP upstream connections.
 type ConnectionPoolSettings_TCPSettings struct {
-	// Maximum number of HTTP1 /TCP connections to a destination host.
+	// Maximum number of HTTP1 /TCP connections to a destination host. Default 1024.
 	MaxConnections int32 `protobuf:"varint,1,opt,name=max_connections,json=maxConnections,proto3" json:"max_connections,omitempty"`
 	// TCP connection timeout.
 	ConnectTimeout *types.Duration `protobuf:"bytes,2,opt,name=connect_timeout,json=connectTimeout,proto3" json:"connect_timeout,omitempty"`

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -206,7 +206,7 @@ Note that request based timeouts mean that HTTP/2 PINGs will not keep the connec
 <td><code>maxConnections</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of HTTP1 /TCP connections to a destination host.</p>
+<p>Maximum number of HTTP1 /TCP connections to a destination host. Default 1024.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -400,7 +400,7 @@ message ConnectionPoolSettings {
       google.protobuf.Duration interval = 3;
     };
 
-    // Maximum number of HTTP1 /TCP connections to a destination host.
+    // Maximum number of HTTP1 /TCP connections to a destination host. Default 1024.
     int32 max_connections = 1;
 
     // TCP connection timeout.


### PR DESCRIPTION
Simple change to add the default number of max connections to the docs.

ref: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cluster/circuit_breaker.proto#cluster-circuitbreakers-thresholds

cc: @Stono