### PR TITLE
improve code snippet style of MeshNetworks

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -618,8 +618,9 @@ there are no services or ServiceEntries for the destination port</p>
 <p>MeshNetworks (config map) provides information about the set of networks
 inside a mesh and how to route to endpoints in each network. For example</p>
 
-<p>MeshNetworks(file/config map):
-networks:
+<p>MeshNetworks(file/config map):</p>
+
+<pre><code class="language-yaml">networks:
   network1:
   - endpoints:
     - fromRegistry: registry1 #must match secret name in Kubernetes
@@ -630,7 +631,8 @@ networks:
       locality: us-east-1a
     - address: 192.168.100.1
       port: 15443
-      locality: us-east-1a</p>
+      locality: us-east-1a
+</code></pre>
 
 <table class="message-fields">
 <thead>

--- a/mesh/v1alpha1/network.pb.go
+++ b/mesh/v1alpha1/network.pb.go
@@ -422,6 +422,8 @@ func _Network_IstioNetworkGateway_OneofSizer(msg proto.Message) (n int) {
 // inside a mesh and how to route to endpoints in each network. For example
 //
 // MeshNetworks(file/config map):
+//
+// ```yaml
 // networks:
 //   network1:
 //   - endpoints:
@@ -434,6 +436,8 @@ func _Network_IstioNetworkGateway_OneofSizer(msg proto.Message) (n int) {
 //     - address: 192.168.100.1
 //       port: 15443
 //       locality: us-east-1a
+// ```
+//
 type MeshNetworks struct {
 	// REQUIRED: The set of networks inside this mesh. Each network should
 	// have a unique name and information about how to infer the endpoints in

--- a/mesh/v1alpha1/network.proto
+++ b/mesh/v1alpha1/network.proto
@@ -96,6 +96,8 @@ message Network {
 // inside a mesh and how to route to endpoints in each network. For example
 //
 // MeshNetworks(file/config map):
+//
+// ```yaml
 // networks:
 //   network1:
 //   - endpoints:
@@ -108,6 +110,8 @@ message Network {
 //     - address: 192.168.100.1
 //       port: 15443
 //       locality: us-east-1a
+// ```
+//
 message MeshNetworks {
   // REQUIRED: The set of networks inside this mesh. Each network should
   // have a unique name and information about how to infer the endpoints in


### PR DESCRIPTION
currently, MeshNetworks  code snippet  is inline
![image](https://user-images.githubusercontent.com/463772/57305828-37258080-7114-11e9-9d38-53fd8db0fc87.png)

improved it using yaml block
![image](https://user-images.githubusercontent.com/463772/57305969-84a1ed80-7114-11e9-82c5-92e89b29a144.png)
