### PR TITLE
Document default behavior for maxRequestsPerConnection

### DIFF
--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1278,7 +1278,8 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	// Maximum number of requests to a backend. Default 1024.
 	Http2MaxRequests int32 `protobuf:"varint,2,opt,name=http2_max_requests,json=http2MaxRequests,proto3" json:"http2_max_requests,omitempty"`
 	// Maximum number of requests per connection to a backend. Setting this
-	// parameter to 1 disables keep alive.
+	// parameter to 1 disables keep alive. Default 0, meaning "unlimited",
+	// up to 2^29.
 	MaxRequestsPerConnection int32 `protobuf:"varint,3,opt,name=max_requests_per_connection,json=maxRequestsPerConnection,proto3" json:"max_requests_per_connection,omitempty"`
 	// Maximum number of retries that can be outstanding to all hosts in a
 	// cluster at a given time. Defaults to 1024.

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -163,7 +163,8 @@ spec:
 <td><code>int32</code></td>
 <td>
 <p>Maximum number of requests per connection to a backend. Setting this
-parameter to 1 disables keep alive.</p>
+parameter to 1 disables keep alive. Default 0, meaning &ldquo;unlimited&rdquo;,
+up to 2^29.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -419,7 +419,8 @@ message ConnectionPoolSettings {
     int32 http2_max_requests = 2;
 
     // Maximum number of requests per connection to a backend. Setting this
-    // parameter to 1 disables keep alive.
+    // parameter to 1 disables keep alive. Default 0, meaning "unlimited",
+    // up to 2^29.
     int32 max_requests_per_connection = 3;
 
     // Maximum number of retries that can be outstanding to all hosts in a


### PR DESCRIPTION
The default on envoy is to use MAX_STREAMS, defined internally
to be 2²⁹ connections.

This is one of the few properties missing an explanation for its default value.