### PR TITLE
For Sidecar captureMode NONE, bind inbound listener to instance IP in…

### DIFF
--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -103,7 +103,7 @@
 //       app: productpage
 //   ingress:
 //   - port:
-//       number: 9080 # binds to 0.0.0.0:9080
+//       number: 9080 # binds to proxy_instance_ip:9080 (0.0.0.0:9080, if no unicast IP is available for the instance)
 //       protocol: HTTP
 //       name: somename
 //     defaultEndpoint: 127.0.0.1:8080

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -105,7 +105,7 @@ spec:
       app: productpage
   ingress:
   - port:
-      number: 9080 # binds to 0.0.0.0:9080
+      number: 9080 # binds to proxy_instance_ip:9080 (0.0.0.0:9080, if no unicast IP is available for the instance)
       protocol: HTTP
       name: somename
     defaultEndpoint: 127.0.0.1:8080

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -122,7 +122,7 @@ import "networking/v1alpha3/gateway.proto";
 //       app: productpage
 //   ingress:
 //   - port:
-//       number: 9080 # binds to 0.0.0.0:9080
+//       number: 9080 # binds to proxy_instance_ip:9080 (0.0.0.0:9080, if no unicast IP is available for the instance)
 //       protocol: HTTP
 //       name: somename
 //     defaultEndpoint: 127.0.0.1:8080


### PR DESCRIPTION
…stead of wildcard.

Signed-off-by: Shakti <shaktiprakash.das@salesforce.com>

API changes for Issue #14693