### PR TITLE
Refine RBAC API usage for TCP and gRPC services.  (#942)

### DIFF
--- a/rbac/v1alpha1/istio.rbac.v1alpha1.pb.html
+++ b/rbac/v1alpha1/istio.rbac.v1alpha1.pb.html
@@ -14,7 +14,9 @@ the following standard fields:</p>
 
 <ul>
 <li>services: a list of services.</li>
-<li>methods: HTTP methods. In the case of gRPC, this field is ignored because the value is always &ldquo;POST&rdquo;.</li>
+<li>methods: A list of HTTP methods. You can set the value to <code>*</code> to include all HTTP methods.
+         This field should not be set for TCP services. The policy will be ignored.
+         For gRPC services, only <code>POST</code> is allowed; other methods will result in denying services.</li>
 <li>paths: HTTP paths or gRPC methods. Note that gRPC methods should be
 presented in the form of &ldquo;/packageName.serviceName/methodName&rdquo; and are case sensitive.</li>
 </ul>
@@ -109,7 +111,8 @@ gRPC methods must be presented as fully-qualified name in the form of
 Exact match, prefix match, and suffix match are supported. For example,
 the path &ldquo;/books/review&rdquo; matches &ldquo;/books/review&rdquo; (exact match),
 or &ldquo;/books/<em>&rdquo; (prefix match), or &ldquo;</em>/review&rdquo; (suffix match).
-If not specified, it matches to any path.</p>
+If not specified, it matches to any path.
+This field should not be set for TCP services. The policy will be ignored.</p>
 
 </td>
 </tr>
@@ -118,8 +121,9 @@ If not specified, it matches to any path.</p>
 <td><code>string[]</code></td>
 <td>
 <p>Optional. A list of HTTP methods (e.g., &ldquo;GET&rdquo;, &ldquo;POST&rdquo;).
-It is ignored in gRPC case because the value is always &ldquo;POST&rdquo;.
-If not specified, it matches to any methods.</p>
+If not specified or specified as &ldquo;*&rdquo;, it matches to any methods.
+This field should not be set for TCP services. The policy will be ignored.
+For gRPC services, only <code>POST</code> is allowed; other methods will result in denying services.</p>
 
 </td>
 </tr>

--- a/rbac/v1alpha1/rbac.pb.go
+++ b/rbac/v1alpha1/rbac.pb.go
@@ -8,7 +8,9 @@
 // the following standard fields:
 //
 //   * services: a list of services.
-//   * methods: HTTP methods. In the case of gRPC, this field is ignored because the value is always "POST".
+//   * methods: A list of HTTP methods. You can set the value to `*` to include all HTTP methods.
+//              This field should not be set for TCP services. The policy will be ignored.
+//              For gRPC services, only `POST` is allowed; other methods will result in denying services.
 //   * paths: HTTP paths or gRPC methods. Note that gRPC methods should be
 //     presented in the form of "/packageName.serviceName/methodName" and are case sensitive.
 //
@@ -347,6 +349,7 @@ type AccessRule struct {
 	// For example, the host "test.abc.com" matches "test.abc.com" (exact match),
 	// or "*.abc.com" (prefix match), or "test.abc.*" (suffix match).
 	// If not specified, it matches to any host.
+	// This field should not be set for TCP services. The policy will be ignored.
 	Hosts []string `protobuf:"bytes,5,rep,name=hosts,proto3" json:"hosts,omitempty"`
 	// $hide_from_docs
 	// Optional. A list of HTTP hosts that must not be matched.
@@ -358,13 +361,15 @@ type AccessRule struct {
 	// the path "/books/review" matches "/books/review" (exact match),
 	// or "/books/*" (prefix match), or "*/review" (suffix match).
 	// If not specified, it matches to any path.
+	// This field should not be set for TCP services. The policy will be ignored.
 	Paths []string `protobuf:"bytes,2,rep,name=paths,proto3" json:"paths,omitempty"`
 	// $hide_from_docs
 	// Optional. A list of HTTP paths or gRPC methods that must not be matched.
 	NotPaths []string `protobuf:"bytes,7,rep,name=not_paths,json=notPaths,proto3" json:"not_paths,omitempty"`
 	// Optional. A list of HTTP methods (e.g., "GET", "POST").
-	// It is ignored in gRPC case because the value is always "POST".
-	// If not specified, it matches to any methods.
+	// If not specified or specified as "*", it matches to any methods.
+	// This field should not be set for TCP services. The policy will be ignored.
+	// For gRPC services, only `POST` is allowed; other methods will result in denying services.
 	Methods []string `protobuf:"bytes,3,rep,name=methods,proto3" json:"methods,omitempty"`
 	// $hide_from_docs
 	// Optional. A list of HTTP methods that must not be matched.

--- a/rbac/v1alpha1/rbac.proto
+++ b/rbac/v1alpha1/rbac.proto
@@ -25,7 +25,9 @@ syntax = "proto3";
 // the following standard fields:
 //
 //   * services: a list of services.
-//   * methods: HTTP methods. In the case of gRPC, this field is ignored because the value is always "POST".
+//   * methods: A list of HTTP methods. You can set the value to `*` to include all HTTP methods.
+//              This field should not be set for TCP services. The policy will be ignored.
+//              For gRPC services, only `POST` is allowed; other methods will result in denying services.
 //   * paths: HTTP paths or gRPC methods. Note that gRPC methods should be
 //     presented in the form of "/packageName.serviceName/methodName" and are case sensitive.
 //
@@ -141,6 +143,7 @@ message AccessRule {
   // For example, the host "test.abc.com" matches "test.abc.com" (exact match),
   // or "*.abc.com" (prefix match), or "test.abc.*" (suffix match).
   // If not specified, it matches to any host.
+  // This field should not be set for TCP services. The policy will be ignored.
   repeated string hosts = 5;
 
   // $hide_from_docs
@@ -154,6 +157,7 @@ message AccessRule {
   // the path "/books/review" matches "/books/review" (exact match),
   // or "/books/*" (prefix match), or "*/review" (suffix match).
   // If not specified, it matches to any path.
+  // This field should not be set for TCP services. The policy will be ignored.
   repeated string paths = 2;
 
   // $hide_from_docs
@@ -161,8 +165,9 @@ message AccessRule {
   repeated string not_paths = 7;
 
   // Optional. A list of HTTP methods (e.g., "GET", "POST").
-  // It is ignored in gRPC case because the value is always "POST".
-  // If not specified, it matches to any methods.
+  // If not specified or specified as "*", it matches to any methods.
+  // This field should not be set for TCP services. The policy will be ignored.
+  // For gRPC services, only `POST` is allowed; other methods will result in denying services.
   repeated string methods = 3;
 
   // $hide_from_docs


### PR DESCRIPTION
* Correct gRPC usage for RBAC methods field
* Refine TCP and gRPC usage for RBAC

This is a cherry-picking for release-1.2