### PR TITLE
Remove reference for name since it fails validation

### DIFF
--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -416,13 +416,9 @@ func (m *TrafficPolicy) GetPortLevelSettings() []*TrafficPolicy_PortTrafficPolic
 
 // Traffic policies that apply to specific ports of the service
 type TrafficPolicy_PortTrafficPolicy struct {
-	// Specifies the port name or number of a port on the destination service
+	// Specifies the port number of a port on the destination service
 	// on which this policy is being applied.
 	//
-	// Names must comply with DNS label syntax (rfc1035) and therefore cannot
-	// collide with numbers. If there are multiple ports on a service with
-	// the same protocol the names should be of the form <protocol-name>-<DNS
-	// label>.
 	Port *PortSelector `protobuf:"bytes,1,opt,name=port,proto3" json:"port,omitempty"`
 	// Settings controlling the load balancer algorithms.
 	LoadBalancer *LoadBalancerSettings `protobuf:"bytes,2,opt,name=load_balancer,json=loadBalancer,proto3" json:"load_balancer,omitempty"`

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -416,7 +416,7 @@ func (m *TrafficPolicy) GetPortLevelSettings() []*TrafficPolicy_PortTrafficPolic
 
 // Traffic policies that apply to specific ports of the service
 type TrafficPolicy_PortTrafficPolicy struct {
-	// Specifies the port number of a port on the destination service
+	// Specifies the number of a port on the destination service
 	// on which this policy is being applied.
 	//
 	Port *PortSelector `protobuf:"bytes,1,opt,name=port,proto3" json:"port,omitempty"`

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1045,13 +1045,8 @@ to fields omitted in port-level traffic policies.</p>
 <td><code>port</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service.html#PortSelector">PortSelector</a></code></td>
 <td>
-<p>Specifies the port name or number of a port on the destination service
+<p>Specifies the port number of a port on the destination service
 on which this policy is being applied.</p>
-
-<p>Names must comply with DNS label syntax (rfc1035) and therefore cannot
-collide with numbers. If there are multiple ports on a service with
-the same protocol the names should be of the form &lt;protocol-name&gt;-&lt;DNS
-label&gt;.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1045,7 +1045,7 @@ to fields omitted in port-level traffic policies.</p>
 <td><code>port</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service.html#PortSelector">PortSelector</a></code></td>
 <td>
-<p>Specifies the port number of a port on the destination service
+<p>Specifies the number of a port on the destination service
 on which this policy is being applied.</p>
 
 </td>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -159,13 +159,9 @@ message TrafficPolicy {
 
   // Traffic policies that apply to specific ports of the service
   message PortTrafficPolicy {
-    // Specifies the port name or number of a port on the destination service
+    // Specifies the port number of a port on the destination service
     // on which this policy is being applied.
     //
-    // Names must comply with DNS label syntax (rfc1035) and therefore cannot
-    // collide with numbers. If there are multiple ports on a service with
-    // the same protocol the names should be of the form <protocol-name>-<DNS
-    // label>.
     PortSelector port = 1;
 
     // Settings controlling the load balancer algorithms.

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -159,7 +159,7 @@ message TrafficPolicy {
 
   // Traffic policies that apply to specific ports of the service
   message PortTrafficPolicy {
-    // Specifies the port number of a port on the destination service
+    // Specifies the number of a port on the destination service
     // on which this policy is being applied.
     //
     PortSelector port = 1;


### PR DESCRIPTION
Name is still documented in destination rules for the port, but the field is not documented in portSelector. Attempts to use the field hit (https://github.com/istio/istio/blob/870877a1e3d01f6a2c285f67ed1f709a9f993095/pilot/pkg/model/validation.go#L2257) "Port.name HTTP is no longer supported for destination".

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure