### PR TITLE
Fix documentation of supported protocols for Port.protocol

### DIFF
--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -677,7 +677,7 @@ type Port struct {
 	// REQUIRED: A valid non-negative integer port number.
 	Number uint32 `protobuf:"varint,1,opt,name=number,proto3" json:"number,omitempty"`
 	// REQUIRED: The protocol exposed on the port.
-	// MUST BE one of HTTP|HTTPS|GRPC|HTTP2|MONGO|TCP|TLS.
+	// MUST BE one of HTTP|HTTPS|GRPC|HTTP2|MONGO|REDIS|MYSQL|TCP|TLS|UDP.
 	// TLS implies the connection will be routed based on the SNI header to
 	// the destination without terminating the TLS connection.
 	Protocol string `protobuf:"bytes,2,opt,name=protocol,proto3" json:"protocol,omitempty"`

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -233,7 +233,7 @@ reside in the same namespace as the gateway workload instance.</p>
 <td><code>string</code></td>
 <td>
 <p>REQUIRED: The protocol exposed on the port.
-MUST BE one of HTTP|HTTPS|GRPC|HTTP2|MONGO|TCP|TLS.
+MUST BE one of HTTP|HTTPS|GRPC|HTTP2|MONGO|REDIS|MYSQL|TCP|TLS|UDP.
 TLS implies the connection will be routed based on the SNI header to
 the destination without terminating the TLS connection.</p>
 

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -422,7 +422,7 @@ message Port {
   uint32 number = 1;
 
   // REQUIRED: The protocol exposed on the port.
-  // MUST BE one of HTTP|HTTPS|GRPC|HTTP2|MONGO|TCP|TLS.
+  // MUST BE one of HTTP|HTTPS|GRPC|HTTP2|MONGO|REDIS|MYSQL|TCP|TLS|UDP.
   // TLS implies the connection will be routed based on the SNI header to
   // the destination without terminating the TLS connection.
   string protocol = 2;


### PR DESCRIPTION
This PR updates the documentation of Gateway.port.protocol so that it matches the list of supported values in Istio 1.2.0.
Right now the documentation is missing the values `REDIS`, `MYSQL` and `UDP`.