### PR TITLE
fix RbacConfig comments and do not hide in documents

### DIFF
--- a/authentication/v1alpha1/istio.authentication.v1alpha1.pb.html
+++ b/authentication/v1alpha1/istio.authentication.v1alpha1.pb.html
@@ -4,6 +4,7 @@ description: Authentication policy for Istio services.
 location: https://istio.io/docs/reference/config/istio.authentication.v1alpha1.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
+weight: 29
 number_of_entries: 11
 ---
 <p>This package defines user-facing authentication policy.</p>

--- a/authentication/v1alpha1/policy.proto
+++ b/authentication/v1alpha1/policy.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 // $title: Authentication Policy
 // $description: Authentication policy for Istio services.
 // $location: https://istio.io/docs/reference/config/istio.authentication.v1alpha1.html
+// $weight: 29
 
 // This package defines user-facing authentication policy.
 package istio.authentication.v1alpha1;

--- a/rbac/v1alpha1/istio.rbac.v1alpha1.pb.html
+++ b/rbac/v1alpha1/istio.rbac.v1alpha1.pb.html
@@ -4,7 +4,7 @@ description: Configuration for Role Based Access Control.
 location: https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
-number_of_entries: 8
+number_of_entries: 9
 ---
 <p>Istio RBAC (Role Based Access Control) defines ServiceRole and ServiceRoleBinding
 objects.</p>
@@ -173,6 +173,64 @@ or &ldquo;v1<em>&rdquo; (prefix match), or &ldquo;</em>alpha2&rdquo; (suffix mat
 </tbody>
 </table>
 </section>
+<h2 id="RbacConfig">RbacConfig</h2>
+<section>
+<p>RbacConfig implements the ClusterRbaConfig Custom Resource Definition for controlling Istio RBAC behavior.
+The ClusterRbaConfig Custom Resource is a singleton where only one ClusterRbaConfig should be created
+globally in the mesh and the namespace should be the same to other Istio components, which usually is <code>istio-system</code>.</p>
+
+<p>Below is an example of an <code>ClusterRbacConfig</code> resource called <code>istio-rbac-config</code> which enables Istio RBAC for all
+services in the default namespace.</p>
+
+<pre><code class="language-yaml">apiVersion: &quot;rbac.istio.io/v1alpha1&quot;
+kind: ClusterRbacConfig
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  mode: ON_WITH_INCLUSION
+  inclusion:
+    namespaces: [ &quot;default&quot; ]
+</code></pre>
+
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="RbacConfig-mode">
+<td><code>mode</code></td>
+<td><code><a href="#RbacConfig-Mode">RbacConfig.Mode</a></code></td>
+<td>
+<p>Istio RBAC mode.</p>
+
+</td>
+</tr>
+<tr id="RbacConfig-inclusion">
+<td><code>inclusion</code></td>
+<td><code><a href="#RbacConfig-Target">RbacConfig.Target</a></code></td>
+<td>
+<p>A list of services or namespaces that should be enforced by Istio RBAC policies. Note: This field have
+effect only when mode is ON<em>WITH</em>INCLUSION and will be ignored for any other modes.</p>
+
+</td>
+</tr>
+<tr id="RbacConfig-exclusion">
+<td><code>exclusion</code></td>
+<td><code><a href="#RbacConfig-Target">RbacConfig.Target</a></code></td>
+<td>
+<p>A list of services or namespaces that should not be enforced by Istio RBAC policies. Note: This field have
+effect only when mode is ON<em>WITH</em>EXCLUSION and will be ignored for any other modes.</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>
 <h2 id="RbacConfig-Mode">RbacConfig.Mode</h2>
 <section>
 <table class="enum-values">
@@ -186,15 +244,15 @@ or &ldquo;v1<em>&rdquo; (prefix match), or &ldquo;</em>alpha2&rdquo; (suffix mat
 <tr id="RbacConfig-Mode-OFF">
 <td><code>OFF</code></td>
 <td>
-<p>Disable Istio RBAC completely, any other config in RbacConfig will be ignored and Istio RBAC policies
-will not be enforced.</p>
+<p>Disable Istio RBAC completely, Istio RBAC policies will not be enforced.</p>
 
 </td>
 </tr>
 <tr id="RbacConfig-Mode-ON">
 <td><code>ON</code></td>
 <td>
-<p>Enable Istio RBAC for all services and namespaces.</p>
+<p>Enable Istio RBAC for all services and namespaces. Note Istio RBAC is deny-by-default
+which means all requests will be denied if it&rsquo;s not allowed by RBAC rules.</p>
 
 </td>
 </tr>

--- a/rbac/v1alpha1/rbac.pb.go
+++ b/rbac/v1alpha1/rbac.pb.go
@@ -123,10 +123,10 @@ func (EnforcementMode) EnumDescriptor() ([]byte, []int) {
 type RbacConfig_Mode int32
 
 const (
-	// Disable Istio RBAC completely, any other config in RbacConfig will be ignored and Istio RBAC policies
-	// will not be enforced.
+	// Disable Istio RBAC completely, Istio RBAC policies will not be enforced.
 	RbacConfig_OFF RbacConfig_Mode = 0
-	// Enable Istio RBAC for all services and namespaces.
+	// Enable Istio RBAC for all services and namespaces. Note Istio RBAC is deny-by-default
+	// which means all requests will be denied if it's not allowed by RBAC rules.
 	RbacConfig_ON RbacConfig_Mode = 1
 	// Enable Istio RBAC only for services and namespaces specified in the inclusion field. Any other
 	// services and namespaces not in the inclusion field will not be enforced by Istio RBAC policies.
@@ -891,19 +891,16 @@ func (m *RoleRef) GetName() string {
 	return ""
 }
 
-// $hide_from_docs
-// RbacConfig is deprecated.  RbacConfig defined the global config to control Istio RBAC behavior.
-// This Custom Resource is a singleton where only one Custom Resource should be created globally in
-// the mesh and the namespace should be the same to other Istio components, which usually is `istio-system`.
-// Note: This is enforced in both `istioctl` and server side, new Custom Resource will be rejected if found any
-// existing one, the user should either delete the existing one or change the existing one directly.
+// RbacConfig implements the ClusterRbaConfig Custom Resource Definition for controlling Istio RBAC behavior.
+// The ClusterRbaConfig Custom Resource is a singleton where only one ClusterRbaConfig should be created
+// globally in the mesh and the namespace should be the same to other Istio components, which usually is `istio-system`.
 //
-// Below is an example of an `RbacConfig` resource called `istio-rbac-config` which enables Istio RBAC for all
+// Below is an example of an `ClusterRbacConfig` resource called `istio-rbac-config` which enables Istio RBAC for all
 // services in the default namespace.
 //
 // ```yaml
 // apiVersion: "rbac.istio.io/v1alpha1"
-// kind: RbacConfig
+// kind: ClusterRbacConfig
 // metadata:
 //   name: default
 //   namespace: istio-system

--- a/rbac/v1alpha1/rbac.proto
+++ b/rbac/v1alpha1/rbac.proto
@@ -339,19 +339,16 @@ message RoleRef {
   string name = 2;
 }
 
-// $hide_from_docs
-// RbacConfig is deprecated.  RbacConfig defined the global config to control Istio RBAC behavior.
-// This Custom Resource is a singleton where only one Custom Resource should be created globally in
-// the mesh and the namespace should be the same to other Istio components, which usually is `istio-system`.
-// Note: This is enforced in both `istioctl` and server side, new Custom Resource will be rejected if found any
-// existing one, the user should either delete the existing one or change the existing one directly.
+// RbacConfig implements the ClusterRbaConfig Custom Resource Definition for controlling Istio RBAC behavior.
+// The ClusterRbaConfig Custom Resource is a singleton where only one ClusterRbaConfig should be created
+// globally in the mesh and the namespace should be the same to other Istio components, which usually is `istio-system`.
 //
-// Below is an example of an `RbacConfig` resource called `istio-rbac-config` which enables Istio RBAC for all
+// Below is an example of an `ClusterRbacConfig` resource called `istio-rbac-config` which enables Istio RBAC for all
 // services in the default namespace.
 //
 // ```yaml
 // apiVersion: "rbac.istio.io/v1alpha1"
-// kind: RbacConfig
+// kind: ClusterRbacConfig
 // metadata:
 //   name: default
 //   namespace: istio-system
@@ -362,10 +359,10 @@ message RoleRef {
 // ```
 message RbacConfig {
   enum Mode {
-    // Disable Istio RBAC completely, any other config in RbacConfig will be ignored and Istio RBAC policies
-    // will not be enforced.
+    // Disable Istio RBAC completely, Istio RBAC policies will not be enforced.
     OFF = 0;
-    // Enable Istio RBAC for all services and namespaces.
+    // Enable Istio RBAC for all services and namespaces. Note Istio RBAC is deny-by-default
+    // which means all requests will be denied if it's not allowed by RBAC rules.
     ON = 1;
     // Enable Istio RBAC only for services and namespaces specified in the inclusion field. Any other
     // services and namespaces not in the inclusion field will not be enforced by Istio RBAC policies.


### PR DESCRIPTION
The `RbacConfig` is wrongly hidden from the doc. Also fixed the comments. This PR also puts the authentication page to be right above authorization page.