### PR TITLE
Follow a comment about the default value of `min_health_percent`.

### DIFF
--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1458,7 +1458,9 @@ type OutlierDetection struct {
 	// pool has at least min_health_percent hosts in healthy mode. When the
 	// percentage of healthy hosts in the load balancing pool drops below this
 	// threshold, outlier detection will be disabled and the proxy will load balance
-	// across all hosts in the pool (healthy and unhealthy).  The default is 50%.
+	// across all hosts in the pool (healthy and unhealthy). the threshold can be
+	// disabled by setting it to 0%. The default is 0% as it's not typically
+	// applicable in k8s environments with few pods per service.
 	MinHealthPercent     int32    `protobuf:"varint,5,opt,name=min_health_percent,json=minHealthPercent,proto3" json:"min_health_percent,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1458,7 +1458,7 @@ type OutlierDetection struct {
 	// pool has at least min_health_percent hosts in healthy mode. When the
 	// percentage of healthy hosts in the load balancing pool drops below this
 	// threshold, outlier detection will be disabled and the proxy will load balance
-	// across all hosts in the pool (healthy and unhealthy). the threshold can be
+	// across all hosts in the pool (healthy and unhealthy). The threshold can be
 	// disabled by setting it to 0%. The default is 0% as it's not typically
 	// applicable in k8s environments with few pods per service.
 	MinHealthPercent     int32    `protobuf:"varint,5,opt,name=min_health_percent,json=minHealthPercent,proto3" json:"min_health_percent,omitempty"`

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -710,7 +710,7 @@ service that can be ejected. Defaults to 10%.</p>
 pool has at least min<em>health</em>percent hosts in healthy mode. When the
 percentage of healthy hosts in the load balancing pool drops below this
 threshold, outlier detection will be disabled and the proxy will load balance
-across all hosts in the pool (healthy and unhealthy). the threshold can be
+across all hosts in the pool (healthy and unhealthy). The threshold can be
 disabled by setting it to 0%. The default is 0% as it&rsquo;s not typically
 applicable in k8s environments with few pods per service.</p>
 

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -710,7 +710,9 @@ service that can be ejected. Defaults to 10%.</p>
 pool has at least min<em>health</em>percent hosts in healthy mode. When the
 percentage of healthy hosts in the load balancing pool drops below this
 threshold, outlier detection will be disabled and the proxy will load balance
-across all hosts in the pool (healthy and unhealthy).  The default is 50%.</p>
+across all hosts in the pool (healthy and unhealthy). the threshold can be
+disabled by setting it to 0%. The default is 0% as it&rsquo;s not typically
+applicable in k8s environments with few pods per service.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -511,7 +511,7 @@ message OutlierDetection {
   // pool has at least min_health_percent hosts in healthy mode. When the
   // percentage of healthy hosts in the load balancing pool drops below this
   // threshold, outlier detection will be disabled and the proxy will load balance
-  // across all hosts in the pool (healthy and unhealthy). the threshold can be 
+  // across all hosts in the pool (healthy and unhealthy). The threshold can be 
   // disabled by setting it to 0%. The default is 0% as it's not typically 
   // applicable in k8s environments with few pods per service.
   int32 min_health_percent = 5;

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -511,7 +511,9 @@ message OutlierDetection {
   // pool has at least min_health_percent hosts in healthy mode. When the
   // percentage of healthy hosts in the load balancing pool drops below this
   // threshold, outlier detection will be disabled and the proxy will load balance
-  // across all hosts in the pool (healthy and unhealthy).  The default is 50%.
+  // across all hosts in the pool (healthy and unhealthy). the threshold can be 
+  // disabled by setting it to 0%. The default is 0% as it's not typically 
+  // applicable in k8s environments with few pods per service.
   int32 min_health_percent = 5;
 }
 


### PR DESCRIPTION
Related to https://github.com/istio/istio/pull/15609 .

By the PR,  the default value of `min_health_percent` was changed to `0%` from `50%`.