### PR TITLE
Simplify protogen container builder

### DIFF
--- a/tools/protoc/Dockerfile
+++ b/tools/protoc/Dockerfile
@@ -1,14 +1,8 @@
-# Based on: https://github.com/znly/docker-protobuf/blob/master/Dockerfile
-# Modified to slim down the image and adjust for Istio
-
 FROM golang:1.12 as build-env
 
 RUN mkdir -p /out_build_env/usr/bin
-# tools repo should pull these deps in automagically, time will tell once its working
-#RUN go get -u -v github.com/golang/protobuf/proto
-#RUN go get -u -v gopkg.in/russross/blackfriday.v2
-RUN ls -lR ${GOPATH}
 RUN go get -u -v -ldflags '-w -s' github.com/golang/protobuf/protoc-gen-go
+# this repo 404s...
 #RUN go get -u -v -ldflags '-w -s' github.com/golang/protobuf/protoc-gen-gofast
 RUN go get -u -v -ldflags '-w -s' github.com/gogo/protobuf/protoc-gen-gogo
 RUN go get -u -v -ldflags '-w -s' github.com/gogo/protobuf/protoc-gen-gogofaster
@@ -16,16 +10,16 @@ RUN go get -u -v -ldflags '-w -s' github.com/gogo/protobuf/protoc-gen-gogoslick
 RUN go get -u -v -ldflags '-w -s' istio.io/tools/protoc-gen-docs
 RUN cp -aR ${GOPATH}/bin/protoc-gen* /out_build_env/usr/bin/
 
-FROM znly/upx as packer
-COPY --from=protoc_builder /out_packer/ /out_packer/
-RUN upx --lzma \
-        /out_packer/usr/bin/protoc \
-        /out_packer/usr/bin/grpc_* \
-        /out_packer/usr/bin/protoc-gen-*
+#FROM znly/upx as packer
+#COPY --from=protoc_builder /out_packer/ /out_packer/
+#RUN upx --lzma \
+#        /out_packer/usr/bin/protoc \
+#        /out_packer/usr/bin/grpc_* \
+#        /out_packer/usr/bin/protoc-gen-*
 
 FROM gcr.io/distroless/cc
 
-COPY --from=packer /out_packer/ /
+#COPY --from=packer /out_packer/ /
 COPY --from=build-env /out_build_env/ /
 
 ENTRYPOINT ["/usr/bin/protoc", "-I/protobuf"]

--- a/tools/protoc/Dockerfile
+++ b/tools/protoc/Dockerfile
@@ -1,64 +1,31 @@
 # Based on: https://github.com/znly/docker-protobuf/blob/master/Dockerfile
 # Modified to slim down the image and adjust for Istio
 
-FROM alpine:3.7 as protoc_builder
-RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev
+FROM golang:1.12 as build-env
 
-ENV GRPC_VERSION=1.8.3 \
-    PROTOBUF_VERSION=3.5.1 \
-    OUTDIR=/out
-RUN mkdir -p /protobuf && \
-    curl -L https://github.com/google/protobuf/archive/v${PROTOBUF_VERSION}.tar.gz | tar xvz --strip-components=1 -C /protobuf
-RUN git clone --depth 1 --recursive -b v${GRPC_VERSION} https://github.com/grpc/grpc.git /grpc && \
-    rm -rf grpc/third_party/protobuf && \
-    ln -s /protobuf /grpc/third_party/protobuf
-RUN cd /protobuf && \
-    autoreconf -f -i -Wall,no-obsolete && \
-    ./configure --prefix=/usr --enable-static=no && \
-    make -j2 && make install
-RUN cd grpc && \
-    make -j2 plugins
-RUN cd /protobuf && \
-    make install DESTDIR=${OUTDIR}
-RUN cd /grpc && \
-    make install-plugins prefix=${OUTDIR}/usr
-RUN find ${OUTDIR} -name "*.a" -delete -or -name "*.la" -delete
-RUN apk update
-RUN apk add --no-cache go>1.10
-ENV GOPATH=/go \
-    PATH=/go/bin/:$PATH
-RUN go get -u -v -ldflags '-w -s' \
-        github.com/golang/protobuf/protoc-gen-go \
-        github.com/gogo/protobuf/protoc-gen-gofast \
-        github.com/gogo/protobuf/protoc-gen-gogo \
-        github.com/gogo/protobuf/protoc-gen-gogofast \
-        github.com/gogo/protobuf/protoc-gen-gogofaster \
-        github.com/gogo/protobuf/protoc-gen-gogoslick \
-        github.com/istio/tools/protoc-gen-docs \
-        && install -c ${GOPATH}/bin/protoc-gen* ${OUTDIR}/usr/bin/
+RUN mkdir -p /out_build_env/usr/bin
+# tools repo should pull these deps in automagically, time will tell once its working
+#RUN go get -u -v github.com/golang/protobuf/proto
+#RUN go get -u -v gopkg.in/russross/blackfriday.v2
+RUN ls -lR ${GOPATH}
+RUN go get -u -v -ldflags '-w -s' github.com/golang/protobuf/protoc-gen-go
+#RUN go get -u -v -ldflags '-w -s' github.com/golang/protobuf/protoc-gen-gofast
+RUN go get -u -v -ldflags '-w -s' github.com/gogo/protobuf/protoc-gen-gogo
+RUN go get -u -v -ldflags '-w -s' github.com/gogo/protobuf/protoc-gen-gogofaster
+RUN go get -u -v -ldflags '-w -s' github.com/gogo/protobuf/protoc-gen-gogoslick
+RUN go get -u -v -ldflags '-w -s' istio.io/tools/protoc-gen-docs
+RUN cp -aR ${GOPATH}/bin/protoc-gen* /out_build_env/usr/bin/
 
 FROM znly/upx as packer
-COPY --from=protoc_builder /out/ /out/
+COPY --from=protoc_builder /out_packer/ /out_packer/
 RUN upx --lzma \
-        /out/usr/bin/protoc \
-        /out/usr/bin/grpc_* \
-        /out/usr/bin/protoc-gen-*
+        /out_packer/usr/bin/protoc \
+        /out_packer/usr/bin/grpc_* \
+        /out_packer/usr/bin/protoc-gen-*
 
-FROM alpine:3.7
-RUN apk add --update --no-cache libstdc++ make bash git openssh
-COPY --from=packer /out/ /
+FROM gcr.io/distroless/cc
 
-RUN apk add --no-cache curl && \
-    mkdir -p /protobuf/google/protobuf && \
-        for f in any duration descriptor empty struct timestamp wrappers; do \
-            curl -L -o /protobuf/google/protobuf/${f}.proto https://raw.githubusercontent.com/google/protobuf/master/src/google/protobuf/${f}.proto; \
-        done && \
-    mkdir -p /protobuf/google/rpc && \
-        for f in code error_details status http; do \
-            curl -L -o /protobuf/google/rpc/${f}.proto https://raw.githubusercontent.com/istio/gogo-genproto/master/googleapis/google/rpc/${f}.proto; \
-        done && \
-    mkdir -p /protobuf/gogoproto && \
-        curl -L -o /protobuf/gogoproto/gogo.proto https://raw.githubusercontent.com/gogo/protobuf/master/gogoproto/gogo.proto && \
-   apk del curl
+COPY --from=packer /out_packer/ /
+COPY --from=build-env /out_build_env/ /
 
 ENTRYPOINT ["/usr/bin/protoc", "-I/protobuf"]

--- a/tools/protoc/Dockerfile
+++ b/tools/protoc/Dockerfile
@@ -1,25 +1,43 @@
-FROM golang:1.12 as build-env
+FROM golang:1.12 as golang-build-env
 
-RUN mkdir -p /out_build_env/usr/bin
-RUN go get -u -v -ldflags '-w -s' github.com/golang/protobuf/protoc-gen-go
-# this repo 404s...
-#RUN go get -u -v -ldflags '-w -s' github.com/golang/protobuf/protoc-gen-gofast
-RUN go get -u -v -ldflags '-w -s' github.com/gogo/protobuf/protoc-gen-gogo
+# Build gRPC from source
+RUN apt-get update
+RUN apt-get install -y build-essential unzip autoconf libtool zlibc zlib1g-dev libc-ares-dev libssl-dev
+
+# Install protoc
+RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.9.0/protobuf-all-3.9.0.tar.gz
+run tar -xzvf protobuf-all-3.9.0.tar.gz
+WORKDIR protobuf-3.9.0
+RUN aclocal
+RUN automake
+RUN ./autogen.sh
+RUN ./configure --prefix=/usr
+RUN make
+RUN make install
+
+# Install gRPC
+RUN curl -LO https://github.com/grpc/grpc/archive/v1.22.0.tar.gz
+RUN tar -xzvf v1.22.0.tar.gz
+WORKDIR grpc-1.22.0
+RUN make install
+
+# Curl mysterious protobuf files
+RUN mkdir -p /protobuf/google/protobuf
+RUN mkdir -p /protobuf/google/rpc
+RUN mkdir -p /protobuf/gogoproto
+RUN for f in any duration descriptor empty struct timestamp wrappers; do \
+            curl -L -o /protobuf/google/protobuf/${f}.proto https://raw.githubusercontent.com/google/protobuf/master/src/google/protobuf/${f}.proto; \
+        done
+RUN for f in code error_details status http; do \
+            curl -L -o /protobuf/google/rpc/${f}.proto https://raw.githubusercontent.com/istio/gogo-genproto/master/googleapis/google/rpc/${f}.proto; \
+        done
+RUN curl -L -o /protobuf/gogoproto/gogo.proto https://raw.githubusercontent.com/gogo/protobuf/master/gogoproto/gogo.proto
+
+# Install protoc plugins
+RUN go get -u -v -ldflags '-w -s' github.com/gogo/protobuf/protoc-gen-gogofast
 RUN go get -u -v -ldflags '-w -s' github.com/gogo/protobuf/protoc-gen-gogofaster
 RUN go get -u -v -ldflags '-w -s' github.com/gogo/protobuf/protoc-gen-gogoslick
 RUN go get -u -v -ldflags '-w -s' istio.io/tools/protoc-gen-docs
-RUN cp -aR ${GOPATH}/bin/protoc-gen* /out_build_env/usr/bin/
-
-#FROM znly/upx as packer
-#COPY --from=protoc_builder /out_packer/ /out_packer/
-#RUN upx --lzma \
-#        /out_packer/usr/bin/protoc \
-#        /out_packer/usr/bin/grpc_* \
-#        /out_packer/usr/bin/protoc-gen-*
-
-FROM gcr.io/distroless/cc
-
-#COPY --from=packer /out_packer/ /
-COPY --from=build-env /out_build_env/ /
+RUN go get -u -v -ldflags '-w -s' istio.io/tools/cmd/annotations_prep
 
 ENTRYPOINT ["/usr/bin/protoc", "-I/protobuf"]


### PR DESCRIPTION
The old continer builder was based on Golang 1.9 (according to
@geeknoid; I couldn't actually get it to build).  The container
could use some serious simplificaiton.  If we don't need to pin gRPC
and protobuf, it is better practice to let the experts in golang
distribute their own container (golang:1.12) and work from that.

I have assumed in this PR that they have the correct versions of
gRPC and protobuf, which may be a bad assumption.

Also this PR does not yet build (so don't merge) because of a
dependency problem in the tools repo.  Further, this PR likely
won't build and certainly isn't tested yet, until the tools
repo build problem is sorted out.

Depends-On: https://github.com/istio/tools/pull/222