### PR TITLE
Fix OpenAPI dependency tracking.

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -95,7 +95,7 @@ mcp_v1alpha1_path := mcp/v1alpha1
 mcp_v1alpha1_protos := $(wildcard $(mcp_v1alpha1_path)/*.proto)
 mcp_v1alpha1_pb_gos := $(mcp_v1alpha1_protos:.proto=.pb.go)
 mcp_v1alpha1_pb_pythons := $(patsubst $(mcp_v1alpha1_path)/%.proto,$(python_output_path)/$(mcp_v1alpha1_path)/%_pb2.py,$(mcp_v1alpha1_protos))
-config_mcp_openapi := $(config_mcp_path)/istio.mcp.v1alpha1.json
+mcp_v1alpha1_openapi := $(mcp_v1alpha1_path)/istio.mcp.v1alpha1.json
 
 $(mcp_v1alpha1_pb_gos) $(mcp_v1alpha1_pb_pythons): $(mcp_v1alpha1_protos)
 	@$(protolock) status
@@ -104,7 +104,7 @@ $(mcp_v1alpha1_pb_gos) $(mcp_v1alpha1_pb_pythons): $(mcp_v1alpha1_protos)
 generate-mcp: $(mcp_v1alpha1_pb_gos) $(mcp_v1alpha1_pb_doc) $(mcp_v1alpha1_pb_pythons)
 
 clean-mcp:
-	@rm -fr $(mcp_v1alpha1_pb_gos) $(mcp_v1alpha1_pb_pythons) $(config_mcp_openapi)
+	@rm -fr $(mcp_v1alpha1_pb_gos) $(mcp_v1alpha1_pb_pythons)
 
 #####################
 # mesh/...
@@ -115,7 +115,7 @@ mesh_v1alpha1_protos := $(wildcard $(mesh_v1alpha1_path)/*.proto)
 mesh_v1alpha1_pb_gos := $(mesh_v1alpha1_protos:.proto=.pb.go)
 mesh_v1alpha1_pb_pythons := $(patsubst $(mesh_v1alpha1_path)/%.proto,$(python_output_path)/$(mesh_v1alpha1_path)/%_pb2.py,$(mesh_v1alpha1_protos))
 mesh_v1alpha1_pb_doc := $(mesh_v1alpha1_path)/istio.mesh.v1alpha1.pb.html
-mesh_openapi := $(mesh_path)/istio.mesh.v1alpha1.json
+mesh_v1alpha1_openapi := $(mesh_v1alpha1_path)/istio.mesh.v1alpha1.json
 
 $(mesh_v1alpha1_pb_gos) $(mesh_v1alpha1_pb_doc) $(mesh_v1alpha1_pb_pythons): $(mesh_v1alpha1_protos)
 	@$(protolock) status
@@ -124,7 +124,7 @@ $(mesh_v1alpha1_pb_gos) $(mesh_v1alpha1_pb_doc) $(mesh_v1alpha1_pb_pythons): $(m
 generate-mesh: $(mesh_v1alpha1_pb_gos) $(mesh_v1alpha1_pb_doc) $(mesh_v1alpha1_pb_pythons)
 
 clean-mesh:
-	@rm -fr $(mesh_v1alpha1_pb_gos) $(mesh_v1alpha1_pb_doc) $(mesh_v1alpha1_pb_pythons) $(mesh_openapi)
+	@rm -fr $(mesh_v1alpha1_pb_gos) $(mesh_v1alpha1_pb_doc) $(mesh_v1alpha1_pb_pythons)
 
 #####################
 # policy/...
@@ -144,7 +144,7 @@ $(policy_v1beta1_pb_gos) $(policy_v1beta1_pb_doc) $(policy_v1beta1_pb_pythons): 
 generate-policy: $(policy_v1beta1_pb_gos) $(policy_v1beta1_pb_doc) $(policy_v1beta1_pb_pythons)
 
 clean-policy:
-	@rm -fr $(policy_v1beta1_pb_gos) policy/v1beta1/fixed_cfg.pb.go $(policy_v1beta1_pb_doc) $(policy_v1beta1_pb_pythons) $(policy_v1beta1_openapi)
+	@rm -fr $(policy_v1beta1_pb_gos) policy/v1beta1/fixed_cfg.pb.go $(policy_v1beta1_pb_doc) $(policy_v1beta1_pb_pythons)
 
 #####################
 # mixer/...
@@ -166,7 +166,7 @@ mixer_config_client_openapi := $(mixer_config_client_path)/istio.mixer.v1.config
 mixer_adapter_model_v1beta1_path := mixer/adapter/model/v1beta1
 mixer_adapter_model_v1beta1_protos := $(wildcard $(mixer_adapter_model_v1beta1_path)/*.proto)
 mixer_adapter_model_v1beta1_pb_gos := $(mixer_adapter_model_v1beta1_protos:.proto=.pb.go)
-mixer_adapter_model_pb_pythons := $(patsubst $(mixer_adapter_model_path)/%.proto,$(python_output_path)/$(mixer_adapter_model_path)/%_pb2.py,$(mixer_adapter_model_protos))
+mixer_adapter_model_v1beta1_pb_pythons := $(patsubst $(mixer_adapter_model_v1beta1_path)/%.proto,$(python_output_path)/$(mixer_client_config_path)/%_pb2.py,$(mixer_client_config_protos))
 mixer_adapter_model_v1beta1_openapi := $(mixer_adapter_model_v1beta1_path)/istio.mixer.adapter.model.v1beta1.json
 
 $(mixer_v1_pb_gos) $(mixer_v1_pb_pythons): $(mixer_v1_protos)
@@ -187,9 +187,9 @@ generate-mixer: \
 	$(mixer_adapter_model_v1beta1_pb_gos) $(mixer_adapter_model_v1beta1_pb_pythons)
 
 clean-mixer:
-	@rm -fr $(mixer_v1_pb_gos) $(mixer_v1_pb_pythons) $(mixer_v1_openapi)
-	@rm -fr $(mixer_config_client_pb_gos) $(mixer_config_client_pb_doc) $(mixer_config_client_pb_pythons) $(mixer_config_client_openapi)
-	@rm -fr $(mixer_adapter_model_v1beta1_pb_gos) $(mixer_adapter_model_v1beta1_pb_pythons) $(mixer_adapter_model_v1beta1_openapi)
+	@rm -fr $(mixer_v1_pb_gos) $(mixer_v1_pb_pythons)
+	@rm -fr $(mixer_config_client_pb_gos) $(mixer_config_client_pb_doc) $(mixer_config_client_pb_pythons)
+	@rm -fr $(mixer_adapter_model_v1beta1_pb_gos) $(mixer_adapter_model_v1beta1_pb_pythons)
 
 #####################
 # networking/...
@@ -209,7 +209,7 @@ $(networking_v1alpha3_pb_gos) $(networking_v1alpha3_pb_docs) $(networking_v1alph
 generate-networking: $(networking_v1alpha3_pb_gos) $(networking_v1alpha3_pb_docs) $(networking_v1alpha3_pb_pythons)
 
 clean-networking:
-	@rm -fr $(networking_v1alpha3_pb_gos) $(networking_v1alpha3_pb_docs) $(networking_v1alpha3_pb_pythons) $(networking_v1alpha3_openapi)
+	@rm -fr $(networking_v1alpha3_pb_gos) $(networking_v1alpha3_pb_docs) $(networking_v1alpha3_pb_pythons)
 
 #####################
 # rbac/...
@@ -229,7 +229,7 @@ $(rbac_v1alpha1_pb_gos) $(rbac_v1alpha1_pb_doc) $(rbac_v1alpha1_pb_pythons): $(r
 generate-rbac: $(rbac_v1alpha1_pb_gos) $(rbac_v1alpha1_pb_doc) $(rbac_v1alpha1_protos)
 
 clean-rbac:
-	@rm -fr $(rbac_v1alpha1_pb_gos) $(rbac_v1alpha1_pb_doc) $(rbac_v1alpha1_pb_pythons) $(rbac_v1alpha1_openapi)
+	@rm -fr $(rbac_v1alpha1_pb_gos) $(rbac_v1alpha1_pb_doc) $(rbac_v1alpha1_pb_pythons)
 
 #####################
 # authentication/...
@@ -249,7 +249,7 @@ $(authn_v1alpha1_pb_gos) $(authn_v1alpha1_pb_doc) $(authn_v1alpha1_pb_pythons): 
 generate-authn: $(authn_v1alpha1_pb_gos) $(authn_v1alpha1_pb_doc) $(authn_v1alpha1_pb_pythons)
 
 clean-authn:
-	@rm -fr $(authn_v1alpha1_pb_gos) $(authn_v1alpha1_pb_doc) $(authn_v1alpha1_pb_pythons) $(authn_v1alpha1_openapi)
+	@rm -fr $(authn_v1alpha1_pb_gos) $(authn_v1alpha1_pb_doc) $(authn_v1alpha1_pb_pythons)
 
 #####################
 # envoy/...
@@ -318,8 +318,35 @@ lint:
 # OpenAPI Schema
 #####################
 
-generate-openapi-schema:
+all_protos := \
+	$(mcp_v1alpha1_protos) \
+	$(mesh_v1alpha1_protos) \
+	$(policy_v1beta1_protos) \
+	$(mixer_v1_protos) \
+	$(mixer_config_client_protos) \
+	$(mixer_adapter_model_v1beta1_protos) \
+	$(networking_v1alpha3_protos) \
+	$(rbac_v1alpha1_protos) \
+	$(authn_v1alpha1_protos)
+
+all_openapi := \
+	$(mcp_v1alpha1_openapi) \
+	$(mesh_v1alpha1_openapi) \
+	$(policy_v1beta1_openapi) \
+	$(mixer_v1_openapi) \
+	$(mixer_config_client_openapi) \
+	$(mixer_adapter_model_v1beta1_openapi) \
+	$(networking_v1alpha3_openapi) \
+	$(rbac_v1alpha1_openapi) \
+	$(authn_v1alpha1_openapi)
+
+$(all_openapi): $(all_protos)
 	@$(cue) -f=$(repo_dir)/cue.yaml
+
+generate-openapi-schema: $(all_openapi)
+
+clean-openapi-schema:
+	@rm $(all_openapi)
 
 #####################
 # Cleanup
@@ -334,6 +361,7 @@ clean: \
 	clean-authn \
 	clean-envoy \
 	clean-policy \
-	clean-annotations
+	clean-annotations \
+	clean-openapi-schema
 
 include Makefile.common.mk


### PR DESCRIPTION
Typing "make" twice would run cue twice because dependencies from *.proto files to *.json files weren't being tracked. Now with the right dependency tracking in place, the second time you run "make" nothing happens because all targets are up to date.