### PR TITLE
remove the out-dated authorization policy

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -6853,35 +6853,6 @@
         ],
         "messages": [
           {
-            "name": "WorkloadSelector",
-            "maps": [
-              {
-                "key_type": "string",
-                "field": {
-                  "id": 1,
-                  "name": "labels",
-                  "type": "string"
-                }
-              }
-            ]
-          },
-          {
-            "name": "AuthorizationPolicy",
-            "fields": [
-              {
-                "id": 1,
-                "name": "workload_selector",
-                "type": "WorkloadSelector"
-              },
-              {
-                "id": 2,
-                "name": "allow",
-                "type": "ServiceRoleBinding",
-                "is_repeated": true
-              }
-            ]
-          },
-          {
             "name": "ServiceRole",
             "fields": [
               {
@@ -7133,12 +7104,6 @@
                     "id": 1,
                     "name": "services",
                     "type": "string",
-                    "is_repeated": true
-                  },
-                  {
-                    "id": 3,
-                    "name": "workload_selectors",
-                    "type": "WorkloadSelector",
                     "is_repeated": true
                   },
                   {

--- a/python/istio_api/rbac/v1alpha1/rbac_pb2.py
+++ b/python/istio_api/rbac/v1alpha1/rbac_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='istio.rbac.v1alpha1',
   syntax='proto3',
   serialized_options=_b('Z\032istio.io/api/rbac/v1alpha1'),
-  serialized_pb=_b('\n\x18rbac/v1alpha1/rbac.proto\x12\x13istio.rbac.v1alpha1\"\x84\x01\n\x10WorkloadSelector\x12\x41\n\x06labels\x18\x01 \x03(\x0b\x32\x31.istio.rbac.v1alpha1.WorkloadSelector.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x8f\x01\n\x13\x41uthorizationPolicy\x12@\n\x11workload_selector\x18\x01 \x01(\x0b\x32%.istio.rbac.v1alpha1.WorkloadSelector\x12\x36\n\x05\x61llow\x18\x02 \x03(\x0b\x32\'.istio.rbac.v1alpha1.ServiceRoleBinding\"=\n\x0bServiceRole\x12.\n\x05rules\x18\x01 \x03(\x0b\x32\x1f.istio.rbac.v1alpha1.AccessRule\"\x96\x02\n\nAccessRule\x12\x10\n\x08services\x18\x01 \x03(\t\x12\r\n\x05hosts\x18\x05 \x03(\t\x12\x11\n\tnot_hosts\x18\x06 \x03(\t\x12\r\n\x05paths\x18\x02 \x03(\t\x12\x11\n\tnot_paths\x18\x07 \x03(\t\x12\x0f\n\x07methods\x18\x03 \x03(\t\x12\x13\n\x0bnot_methods\x18\x08 \x03(\t\x12\r\n\x05ports\x18\t \x03(\x05\x12\x11\n\tnot_ports\x18\n \x03(\x05\x12?\n\x0b\x63onstraints\x18\x04 \x03(\x0b\x32*.istio.rbac.v1alpha1.AccessRule.Constraint\x1a)\n\nConstraint\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x0e\n\x06values\x18\x02 \x03(\t\"\xe7\x01\n\x12ServiceRoleBinding\x12.\n\x08subjects\x18\x01 \x03(\x0b\x32\x1c.istio.rbac.v1alpha1.Subject\x12-\n\x07roleRef\x18\x02 \x01(\x0b\x32\x1c.istio.rbac.v1alpha1.RoleRef\x12\x32\n\x04mode\x18\x03 \x01(\x0e\x32$.istio.rbac.v1alpha1.EnforcementMode\x12\x30\n\x07\x61\x63tions\x18\x04 \x03(\x0b\x32\x1f.istio.rbac.v1alpha1.AccessRule\x12\x0c\n\x04role\x18\x05 \x01(\t\"\xaf\x02\n\x07Subject\x12\x0c\n\x04user\x18\x01 \x01(\t\x12\r\n\x05names\x18\x04 \x03(\t\x12\x11\n\tnot_names\x18\x05 \x03(\t\x12\x11\n\x05group\x18\x02 \x01(\tB\x02\x18\x01\x12\x0e\n\x06groups\x18\x06 \x03(\t\x12\x12\n\nnot_groups\x18\x07 \x03(\t\x12\x12\n\nnamespaces\x18\x08 \x03(\t\x12\x16\n\x0enot_namespaces\x18\t \x03(\t\x12\x0b\n\x03ips\x18\n \x03(\t\x12\x0f\n\x07not_ips\x18\x0b \x03(\t\x12@\n\nproperties\x18\x03 \x03(\x0b\x32,.istio.rbac.v1alpha1.Subject.PropertiesEntry\x1a\x31\n\x0fPropertiesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"%\n\x07RoleRef\x12\x0c\n\x04kind\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\"\xb0\x03\n\nRbacConfig\x12\x32\n\x04mode\x18\x01 \x01(\x0e\x32$.istio.rbac.v1alpha1.RbacConfig.Mode\x12\x39\n\tinclusion\x18\x02 \x01(\x0b\x32&.istio.rbac.v1alpha1.RbacConfig.Target\x12\x39\n\texclusion\x18\x03 \x01(\x0b\x32&.istio.rbac.v1alpha1.RbacConfig.Target\x12>\n\x10\x65nforcement_mode\x18\x04 \x01(\x0e\x32$.istio.rbac.v1alpha1.EnforcementMode\x1aq\n\x06Target\x12\x10\n\x08services\x18\x01 \x03(\t\x12\x41\n\x12workload_selectors\x18\x03 \x03(\x0b\x32%.istio.rbac.v1alpha1.WorkloadSelector\x12\x12\n\nnamespaces\x18\x02 \x03(\t\"E\n\x04Mode\x12\x07\n\x03OFF\x10\x00\x12\x06\n\x02ON\x10\x01\x12\x15\n\x11ON_WITH_INCLUSION\x10\x02\x12\x15\n\x11ON_WITH_EXCLUSION\x10\x03*/\n\x0f\x45nforcementMode\x12\x0c\n\x08\x45NFORCED\x10\x00\x12\x0e\n\nPERMISSIVE\x10\x01\x42\x1cZ\x1aistio.io/api/rbac/v1alpha1b\x06proto3')
+  serialized_pb=_b('\n\x18rbac/v1alpha1/rbac.proto\x12\x13istio.rbac.v1alpha1\"=\n\x0bServiceRole\x12.\n\x05rules\x18\x01 \x03(\x0b\x32\x1f.istio.rbac.v1alpha1.AccessRule\"\x96\x02\n\nAccessRule\x12\x10\n\x08services\x18\x01 \x03(\t\x12\r\n\x05hosts\x18\x05 \x03(\t\x12\x11\n\tnot_hosts\x18\x06 \x03(\t\x12\r\n\x05paths\x18\x02 \x03(\t\x12\x11\n\tnot_paths\x18\x07 \x03(\t\x12\x0f\n\x07methods\x18\x03 \x03(\t\x12\x13\n\x0bnot_methods\x18\x08 \x03(\t\x12\r\n\x05ports\x18\t \x03(\x05\x12\x11\n\tnot_ports\x18\n \x03(\x05\x12?\n\x0b\x63onstraints\x18\x04 \x03(\x0b\x32*.istio.rbac.v1alpha1.AccessRule.Constraint\x1a)\n\nConstraint\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x0e\n\x06values\x18\x02 \x03(\t\"\xe7\x01\n\x12ServiceRoleBinding\x12.\n\x08subjects\x18\x01 \x03(\x0b\x32\x1c.istio.rbac.v1alpha1.Subject\x12-\n\x07roleRef\x18\x02 \x01(\x0b\x32\x1c.istio.rbac.v1alpha1.RoleRef\x12\x32\n\x04mode\x18\x03 \x01(\x0e\x32$.istio.rbac.v1alpha1.EnforcementMode\x12\x30\n\x07\x61\x63tions\x18\x04 \x03(\x0b\x32\x1f.istio.rbac.v1alpha1.AccessRule\x12\x0c\n\x04role\x18\x05 \x01(\t\"\xaf\x02\n\x07Subject\x12\x0c\n\x04user\x18\x01 \x01(\t\x12\r\n\x05names\x18\x04 \x03(\t\x12\x11\n\tnot_names\x18\x05 \x03(\t\x12\x11\n\x05group\x18\x02 \x01(\tB\x02\x18\x01\x12\x0e\n\x06groups\x18\x06 \x03(\t\x12\x12\n\nnot_groups\x18\x07 \x03(\t\x12\x12\n\nnamespaces\x18\x08 \x03(\t\x12\x16\n\x0enot_namespaces\x18\t \x03(\t\x12\x0b\n\x03ips\x18\n \x03(\t\x12\x0f\n\x07not_ips\x18\x0b \x03(\t\x12@\n\nproperties\x18\x03 \x03(\x0b\x32,.istio.rbac.v1alpha1.Subject.PropertiesEntry\x1a\x31\n\x0fPropertiesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"%\n\x07RoleRef\x12\x0c\n\x04kind\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\"\xed\x02\n\nRbacConfig\x12\x32\n\x04mode\x18\x01 \x01(\x0e\x32$.istio.rbac.v1alpha1.RbacConfig.Mode\x12\x39\n\tinclusion\x18\x02 \x01(\x0b\x32&.istio.rbac.v1alpha1.RbacConfig.Target\x12\x39\n\texclusion\x18\x03 \x01(\x0b\x32&.istio.rbac.v1alpha1.RbacConfig.Target\x12>\n\x10\x65nforcement_mode\x18\x04 \x01(\x0e\x32$.istio.rbac.v1alpha1.EnforcementMode\x1a.\n\x06Target\x12\x10\n\x08services\x18\x01 \x03(\t\x12\x12\n\nnamespaces\x18\x02 \x03(\t\"E\n\x04Mode\x12\x07\n\x03OFF\x10\x00\x12\x06\n\x02ON\x10\x01\x12\x15\n\x11ON_WITH_INCLUSION\x10\x02\x12\x15\n\x11ON_WITH_EXCLUSION\x10\x03*/\n\x0f\x45nforcementMode\x12\x0c\n\x08\x45NFORCED\x10\x00\x12\x0e\n\nPERMISSIVE\x10\x01\x42\x1cZ\x1aistio.io/api/rbac/v1alpha1b\x06proto3')
 )
 
 _ENFORCEMENTMODE = _descriptor.EnumDescriptor(
@@ -40,8 +40,8 @@ _ENFORCEMENTMODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1688,
-  serialized_end=1735,
+  serialized_start=1340,
+  serialized_end=1387,
 )
 _sym_db.RegisterEnumDescriptor(_ENFORCEMENTMODE)
 
@@ -75,116 +75,10 @@ _RBACCONFIG_MODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1617,
-  serialized_end=1686,
+  serialized_start=1269,
+  serialized_end=1338,
 )
 _sym_db.RegisterEnumDescriptor(_RBACCONFIG_MODE)
-
-
-_WORKLOADSELECTOR_LABELSENTRY = _descriptor.Descriptor(
-  name='LabelsEntry',
-  full_name='istio.rbac.v1alpha1.WorkloadSelector.LabelsEntry',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='istio.rbac.v1alpha1.WorkloadSelector.LabelsEntry.key', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='istio.rbac.v1alpha1.WorkloadSelector.LabelsEntry.value', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=_b('8\001'),
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=137,
-  serialized_end=182,
-)
-
-_WORKLOADSELECTOR = _descriptor.Descriptor(
-  name='WorkloadSelector',
-  full_name='istio.rbac.v1alpha1.WorkloadSelector',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='labels', full_name='istio.rbac.v1alpha1.WorkloadSelector.labels', index=0,
-      number=1, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[_WORKLOADSELECTOR_LABELSENTRY, ],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=50,
-  serialized_end=182,
-)
-
-
-_AUTHORIZATIONPOLICY = _descriptor.Descriptor(
-  name='AuthorizationPolicy',
-  full_name='istio.rbac.v1alpha1.AuthorizationPolicy',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='workload_selector', full_name='istio.rbac.v1alpha1.AuthorizationPolicy.workload_selector', index=0,
-      number=1, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='allow', full_name='istio.rbac.v1alpha1.AuthorizationPolicy.allow', index=1,
-      number=2, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=185,
-  serialized_end=328,
-)
 
 
 _SERVICEROLE = _descriptor.Descriptor(
@@ -213,8 +107,8 @@ _SERVICEROLE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=330,
-  serialized_end=391,
+  serialized_start=49,
+  serialized_end=110,
 )
 
 
@@ -251,8 +145,8 @@ _ACCESSRULE_CONSTRAINT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=631,
-  serialized_end=672,
+  serialized_start=350,
+  serialized_end=391,
 )
 
 _ACCESSRULE = _descriptor.Descriptor(
@@ -344,8 +238,8 @@ _ACCESSRULE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=394,
-  serialized_end=672,
+  serialized_start=113,
+  serialized_end=391,
 )
 
 
@@ -403,8 +297,8 @@ _SERVICEROLEBINDING = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=675,
-  serialized_end=906,
+  serialized_start=394,
+  serialized_end=625,
 )
 
 
@@ -441,8 +335,8 @@ _SUBJECT_PROPERTIESENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1163,
-  serialized_end=1212,
+  serialized_start=882,
+  serialized_end=931,
 )
 
 _SUBJECT = _descriptor.Descriptor(
@@ -541,8 +435,8 @@ _SUBJECT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=909,
-  serialized_end=1212,
+  serialized_start=628,
+  serialized_end=931,
 )
 
 
@@ -579,8 +473,8 @@ _ROLEREF = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1214,
-  serialized_end=1251,
+  serialized_start=933,
+  serialized_end=970,
 )
 
 
@@ -599,14 +493,7 @@ _RBACCONFIG_TARGET = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='workload_selectors', full_name='istio.rbac.v1alpha1.RbacConfig.Target.workload_selectors', index=1,
-      number=3, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='namespaces', full_name='istio.rbac.v1alpha1.RbacConfig.Target.namespaces', index=2,
+      name='namespaces', full_name='istio.rbac.v1alpha1.RbacConfig.Target.namespaces', index=1,
       number=2, type=9, cpp_type=9, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -624,8 +511,8 @@ _RBACCONFIG_TARGET = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1502,
-  serialized_end=1615,
+  serialized_start=1221,
+  serialized_end=1267,
 )
 
 _RBACCONFIG = _descriptor.Descriptor(
@@ -676,14 +563,10 @@ _RBACCONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1254,
-  serialized_end=1686,
+  serialized_start=973,
+  serialized_end=1338,
 )
 
-_WORKLOADSELECTOR_LABELSENTRY.containing_type = _WORKLOADSELECTOR
-_WORKLOADSELECTOR.fields_by_name['labels'].message_type = _WORKLOADSELECTOR_LABELSENTRY
-_AUTHORIZATIONPOLICY.fields_by_name['workload_selector'].message_type = _WORKLOADSELECTOR
-_AUTHORIZATIONPOLICY.fields_by_name['allow'].message_type = _SERVICEROLEBINDING
 _SERVICEROLE.fields_by_name['rules'].message_type = _ACCESSRULE
 _ACCESSRULE_CONSTRAINT.containing_type = _ACCESSRULE
 _ACCESSRULE.fields_by_name['constraints'].message_type = _ACCESSRULE_CONSTRAINT
@@ -693,15 +576,12 @@ _SERVICEROLEBINDING.fields_by_name['mode'].enum_type = _ENFORCEMENTMODE
 _SERVICEROLEBINDING.fields_by_name['actions'].message_type = _ACCESSRULE
 _SUBJECT_PROPERTIESENTRY.containing_type = _SUBJECT
 _SUBJECT.fields_by_name['properties'].message_type = _SUBJECT_PROPERTIESENTRY
-_RBACCONFIG_TARGET.fields_by_name['workload_selectors'].message_type = _WORKLOADSELECTOR
 _RBACCONFIG_TARGET.containing_type = _RBACCONFIG
 _RBACCONFIG.fields_by_name['mode'].enum_type = _RBACCONFIG_MODE
 _RBACCONFIG.fields_by_name['inclusion'].message_type = _RBACCONFIG_TARGET
 _RBACCONFIG.fields_by_name['exclusion'].message_type = _RBACCONFIG_TARGET
 _RBACCONFIG.fields_by_name['enforcement_mode'].enum_type = _ENFORCEMENTMODE
 _RBACCONFIG_MODE.containing_type = _RBACCONFIG
-DESCRIPTOR.message_types_by_name['WorkloadSelector'] = _WORKLOADSELECTOR
-DESCRIPTOR.message_types_by_name['AuthorizationPolicy'] = _AUTHORIZATIONPOLICY
 DESCRIPTOR.message_types_by_name['ServiceRole'] = _SERVICEROLE
 DESCRIPTOR.message_types_by_name['AccessRule'] = _ACCESSRULE
 DESCRIPTOR.message_types_by_name['ServiceRoleBinding'] = _SERVICEROLEBINDING
@@ -710,28 +590,6 @@ DESCRIPTOR.message_types_by_name['RoleRef'] = _ROLEREF
 DESCRIPTOR.message_types_by_name['RbacConfig'] = _RBACCONFIG
 DESCRIPTOR.enum_types_by_name['EnforcementMode'] = _ENFORCEMENTMODE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
-
-WorkloadSelector = _reflection.GeneratedProtocolMessageType('WorkloadSelector', (_message.Message,), dict(
-
-  LabelsEntry = _reflection.GeneratedProtocolMessageType('LabelsEntry', (_message.Message,), dict(
-    DESCRIPTOR = _WORKLOADSELECTOR_LABELSENTRY,
-    __module__ = 'rbac.v1alpha1.rbac_pb2'
-    # @@protoc_insertion_point(class_scope:istio.rbac.v1alpha1.WorkloadSelector.LabelsEntry)
-    ))
-  ,
-  DESCRIPTOR = _WORKLOADSELECTOR,
-  __module__ = 'rbac.v1alpha1.rbac_pb2'
-  # @@protoc_insertion_point(class_scope:istio.rbac.v1alpha1.WorkloadSelector)
-  ))
-_sym_db.RegisterMessage(WorkloadSelector)
-_sym_db.RegisterMessage(WorkloadSelector.LabelsEntry)
-
-AuthorizationPolicy = _reflection.GeneratedProtocolMessageType('AuthorizationPolicy', (_message.Message,), dict(
-  DESCRIPTOR = _AUTHORIZATIONPOLICY,
-  __module__ = 'rbac.v1alpha1.rbac_pb2'
-  # @@protoc_insertion_point(class_scope:istio.rbac.v1alpha1.AuthorizationPolicy)
-  ))
-_sym_db.RegisterMessage(AuthorizationPolicy)
 
 ServiceRole = _reflection.GeneratedProtocolMessageType('ServiceRole', (_message.Message,), dict(
   DESCRIPTOR = _SERVICEROLE,
@@ -801,7 +659,6 @@ _sym_db.RegisterMessage(RbacConfig.Target)
 
 
 DESCRIPTOR._options = None
-_WORKLOADSELECTOR_LABELSENTRY._options = None
 _SUBJECT_PROPERTIESENTRY._options = None
 _SUBJECT.fields_by_name['group']._options = None
 # @@protoc_insertion_point(module_scope)

--- a/rbac/v1alpha1/istio.rbac.v1alpha1.json
+++ b/rbac/v1alpha1/istio.rbac.v1alpha1.json
@@ -6,70 +6,6 @@
   },
   "components": {
     "schemas": {
-      "istio.rbac.v1alpha1.WorkloadSelector": {
-        "description": "This is forked from the networking/v1alpha3/sidecar.proto to avoid a direct dependency from the rbac API on networking API. TODO: Move the WorkloadSelector to a common place to be shared by other packages. WorkloadSelector specifies the criteria used to determine if the Gateway or Sidecar resource can be applied to a proxy. The matching criteria includes the metadata associated with a proxy, workload instance info such as labels attached to the pod/VM, or any other info that the proxy provides to Istio during the initial handshake. If multiple conditions are specified, all conditions need to match in order for the workload instance to be selected. Currently, only label based selection mechanism is supported.",
-        "type": "object",
-        "required": [
-          "labels"
-        ],
-        "properties": {
-          "labels": {
-            "description": "One or more labels that indicate a specific set of pods/VMs on which this sidecar configuration should be applied. The scope of label search is restricted to the configuration namespace in which the the resource is present.",
-            "type": "object",
-            "additionalProperties": {
-              "type": "string",
-              "format": "string"
-            }
-          }
-        }
-      },
-      "istio.rbac.v1alpha1.AuthorizationPolicy": {
-        "description": "AuthorizationPolicy to enforce access control on a selected workload instance.",
-        "type": "object",
-        "properties": {
-          "workloadSelector": {
-            "$ref": "#/components/schemas/istio.rbac.v1alpha1.WorkloadSelector"
-          },
-          "allow": {
-            "description": "A list of bindings that specify the subjects and permissions to the selected workload instance.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/istio.rbac.v1alpha1.ServiceRoleBinding"
-            }
-          }
-        }
-      },
-      "istio.rbac.v1alpha1.ServiceRoleBinding": {
-        "description": "ServiceRoleBinding assigns a ServiceRole to a list of subjects.",
-        "type": "object",
-        "properties": {
-          "subjects": {
-            "description": "Required. List of subjects that are assigned the ServiceRole object.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/istio.rbac.v1alpha1.Subject"
-            }
-          },
-          "roleRef": {
-            "$ref": "#/components/schemas/istio.rbac.v1alpha1.RoleRef"
-          },
-          "mode": {
-            "$ref": "#/components/schemas/istio.rbac.v1alpha1.EnforcementMode"
-          },
-          "actions": {
-            "description": "Inline role definition. An inline role is a role that is defined inside an authorization policy, instead of explicitly defined in a ServiceRole object. Inline roles can be used for the role definitions that are not intended to be reused in other bindings, while explicit roles are reusable. Both inline roles (defined in \"actions\" field) and explicit roles (defined in ServiceRole) are supported. Users should use only one of them in a single binding. For example, the following “product-frontend” AuthorizationPolicy allows “frontend” service to view “product” service on “/info” path. ```yaml apiVersion: \"rbac.istio.io/v1alpha1\" kind: AuthorizationPolicy metadata: name: product-frontend namespace: ns1 spec: selector: labels: app: product allow: - subjects: - names: [\"cluster.local/ns/default/sa/frontend\"] actions: - paths: [\"/info\"] methods: [\"GET\"] Required. The set of access rules (permissions) that the role has.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/istio.rbac.v1alpha1.AccessRule"
-            }
-          },
-          "role": {
-            "description": "A `role` inside a ServiceRoleBinding refers to the ServiceRole that this ServiceRoleBinding binds to. A ServiceRoleBinding can bind to a ServiceRole in the same namespace or the root namespace. A ServiceRole in the root namespace represents a mesh global ServiceRole. The value of `role` is the name of the ServiceRole, and it can start with or without a forward slash (\"/\"). When a `role` starts with \"/\", e.g. \"/service-viewer\", it means that this ServiceRoleBinding refers to the ServiceRole in the configurable Istio root namespace. When a `role` starts without \"/\", this ServiceRoleBinding refers to the ServiceRole in the same namespace as the AuthorizationPolicy's, which contains said ServiceRoleBinding.",
-            "type": "string",
-            "format": "string"
-          }
-        }
-      },
       "istio.rbac.v1alpha1.ServiceRole": {
         "description": "ServiceRole specification contains a list of access rules (permissions).",
         "type": "object",
@@ -194,6 +130,37 @@
           "PERMISSIVE"
         ],
         "default": "ENFORCED"
+      },
+      "istio.rbac.v1alpha1.ServiceRoleBinding": {
+        "description": "ServiceRoleBinding assigns a ServiceRole to a list of subjects.",
+        "type": "object",
+        "properties": {
+          "subjects": {
+            "description": "Required. List of subjects that are assigned the ServiceRole object.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/istio.rbac.v1alpha1.Subject"
+            }
+          },
+          "roleRef": {
+            "$ref": "#/components/schemas/istio.rbac.v1alpha1.RoleRef"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/istio.rbac.v1alpha1.EnforcementMode"
+          },
+          "actions": {
+            "description": "Inline role definition. An inline role is a role that is defined inside an authorization policy, instead of explicitly defined in a ServiceRole object. Inline roles can be used for the role definitions that are not intended to be reused in other bindings, while explicit roles are reusable. Both inline roles (defined in \"actions\" field) and explicit roles (defined in ServiceRole) are supported. Users should use only one of them in a single binding. For example, the following “product-frontend” AuthorizationPolicy allows “frontend” service to view “product” service on “/info” path. ```yaml apiVersion: \"rbac.istio.io/v1alpha1\" kind: AuthorizationPolicy metadata: name: product-frontend namespace: ns1 spec: selector: labels: app: product allow: - subjects: - names: [\"cluster.local/ns/default/sa/frontend\"] actions: - paths: [\"/info\"] methods: [\"GET\"] Required. The set of access rules (permissions) that the role has.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/istio.rbac.v1alpha1.AccessRule"
+            }
+          },
+          "role": {
+            "description": "A `role` inside a ServiceRoleBinding refers to the ServiceRole that this ServiceRoleBinding binds to. A ServiceRoleBinding can bind to a ServiceRole in the same namespace or the root namespace. A ServiceRole in the root namespace represents a mesh global ServiceRole. The value of `role` is the name of the ServiceRole, and it can start with or without a forward slash (\"/\"). When a `role` starts with \"/\", e.g. \"/service-viewer\", it means that this ServiceRoleBinding refers to the ServiceRole in the configurable Istio root namespace. When a `role` starts without \"/\", this ServiceRoleBinding refers to the ServiceRole in the same namespace as the AuthorizationPolicy's, which contains said ServiceRoleBinding.",
+            "type": "string",
+            "format": "string"
+          }
+        }
       },
       "istio.rbac.v1alpha1.Subject": {
         "description": "Subject defines an identity. The identity is either a user or identified by a set of `properties`. The supported keys in `properties` are listed in \"constraint and properties\" page.",
@@ -347,13 +314,6 @@
             "items": {
               "type": "string",
               "format": "string"
-            }
-          },
-          "workloadSelectors": {
-            "description": "A list of workload instances.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/istio.rbac.v1alpha1.WorkloadSelector"
             }
           }
         }

--- a/rbac/v1alpha1/rbac.pb.go
+++ b/rbac/v1alpha1/rbac.pb.go
@@ -156,134 +156,7 @@ func (x RbacConfig_Mode) String() string {
 }
 
 func (RbacConfig_Mode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_3462954d26c055c0, []int{7, 0}
-}
-
-// $hide_from_docs
-// This is forked from the networking/v1alpha3/sidecar.proto to avoid a direct
-// dependency from the rbac API on networking API.
-// TODO: Move the WorkloadSelector to a common place to be shared by other packages.
-// WorkloadSelector specifies the criteria used to determine if the Gateway
-// or Sidecar resource can be applied to a proxy. The matching criteria
-// includes the metadata associated with a proxy, workload instance info such as
-// labels attached to the pod/VM, or any other info that the proxy provides
-// to Istio during the initial handshake. If multiple conditions are
-// specified, all conditions need to match in order for the workload instance to be
-// selected. Currently, only label based selection mechanism is supported.
-type WorkloadSelector struct {
-	// One or more labels that indicate a specific set of pods/VMs on which
-	// this sidecar configuration should be applied. The scope of label
-	// search is restricted to the configuration namespace in which the the
-	// resource is present.
-	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
-}
-
-func (m *WorkloadSelector) Reset()         { *m = WorkloadSelector{} }
-func (m *WorkloadSelector) String() string { return proto.CompactTextString(m) }
-func (*WorkloadSelector) ProtoMessage()    {}
-func (*WorkloadSelector) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3462954d26c055c0, []int{0}
-}
-func (m *WorkloadSelector) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *WorkloadSelector) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_WorkloadSelector.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *WorkloadSelector) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_WorkloadSelector.Merge(m, src)
-}
-func (m *WorkloadSelector) XXX_Size() int {
-	return m.Size()
-}
-func (m *WorkloadSelector) XXX_DiscardUnknown() {
-	xxx_messageInfo_WorkloadSelector.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_WorkloadSelector proto.InternalMessageInfo
-
-func (m *WorkloadSelector) GetLabels() map[string]string {
-	if m != nil {
-		return m.Labels
-	}
-	return nil
-}
-
-// $hide_from_docs
-// AuthorizationPolicy to enforce access control on a selected workload instance.
-type AuthorizationPolicy struct {
-	// $hide_from_docs
-	// Optional. One or more labels that indicate a specific set of pods/VMs
-	// on which this authorization policy should be applied. Leave this empty to
-	// select all pods/VMs.
-	// The scope of label search is platform dependent. On Kubernetes, for example,
-	// the scope includes pods running in the same namespace as the authorization policy itself.
-	WorkloadSelector *WorkloadSelector `protobuf:"bytes,1,opt,name=workload_selector,json=workloadSelector,proto3" json:"workload_selector,omitempty"`
-	// $hide_from_docs
-	// A list of bindings that specify the subjects and permissions to the selected workload instance.
-	Allow                []*ServiceRoleBinding `protobuf:"bytes,2,rep,name=allow,proto3" json:"allow,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
-	XXX_unrecognized     []byte                `json:"-"`
-	XXX_sizecache        int32                 `json:"-"`
-}
-
-func (m *AuthorizationPolicy) Reset()         { *m = AuthorizationPolicy{} }
-func (m *AuthorizationPolicy) String() string { return proto.CompactTextString(m) }
-func (*AuthorizationPolicy) ProtoMessage()    {}
-func (*AuthorizationPolicy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3462954d26c055c0, []int{1}
-}
-func (m *AuthorizationPolicy) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *AuthorizationPolicy) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_AuthorizationPolicy.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *AuthorizationPolicy) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AuthorizationPolicy.Merge(m, src)
-}
-func (m *AuthorizationPolicy) XXX_Size() int {
-	return m.Size()
-}
-func (m *AuthorizationPolicy) XXX_DiscardUnknown() {
-	xxx_messageInfo_AuthorizationPolicy.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_AuthorizationPolicy proto.InternalMessageInfo
-
-func (m *AuthorizationPolicy) GetWorkloadSelector() *WorkloadSelector {
-	if m != nil {
-		return m.WorkloadSelector
-	}
-	return nil
-}
-
-func (m *AuthorizationPolicy) GetAllow() []*ServiceRoleBinding {
-	if m != nil {
-		return m.Allow
-	}
-	return nil
+	return fileDescriptor_3462954d26c055c0, []int{5, 0}
 }
 
 // ServiceRole specification contains a list of access rules (permissions).
@@ -299,7 +172,7 @@ func (m *ServiceRole) Reset()         { *m = ServiceRole{} }
 func (m *ServiceRole) String() string { return proto.CompactTextString(m) }
 func (*ServiceRole) ProtoMessage()    {}
 func (*ServiceRole) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3462954d26c055c0, []int{2}
+	return fileDescriptor_3462954d26c055c0, []int{0}
 }
 func (m *ServiceRole) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -396,7 +269,7 @@ func (m *AccessRule) Reset()         { *m = AccessRule{} }
 func (m *AccessRule) String() string { return proto.CompactTextString(m) }
 func (*AccessRule) ProtoMessage()    {}
 func (*AccessRule) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3462954d26c055c0, []int{3}
+	return fileDescriptor_3462954d26c055c0, []int{1}
 }
 func (m *AccessRule) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -513,7 +386,7 @@ func (m *AccessRule_Constraint) Reset()         { *m = AccessRule_Constraint{} }
 func (m *AccessRule_Constraint) String() string { return proto.CompactTextString(m) }
 func (*AccessRule_Constraint) ProtoMessage()    {}
 func (*AccessRule_Constraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3462954d26c055c0, []int{3, 0}
+	return fileDescriptor_3462954d26c055c0, []int{1, 0}
 }
 func (m *AccessRule_Constraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -612,7 +485,7 @@ func (m *ServiceRoleBinding) Reset()         { *m = ServiceRoleBinding{} }
 func (m *ServiceRoleBinding) String() string { return proto.CompactTextString(m) }
 func (*ServiceRoleBinding) ProtoMessage()    {}
 func (*ServiceRoleBinding) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3462954d26c055c0, []int{4}
+	return fileDescriptor_3462954d26c055c0, []int{2}
 }
 func (m *ServiceRoleBinding) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -725,7 +598,7 @@ func (m *Subject) Reset()         { *m = Subject{} }
 func (m *Subject) String() string { return proto.CompactTextString(m) }
 func (*Subject) ProtoMessage()    {}
 func (*Subject) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3462954d26c055c0, []int{5}
+	return fileDescriptor_3462954d26c055c0, []int{3}
 }
 func (m *Subject) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -849,7 +722,7 @@ func (m *RoleRef) Reset()         { *m = RoleRef{} }
 func (m *RoleRef) String() string { return proto.CompactTextString(m) }
 func (*RoleRef) ProtoMessage()    {}
 func (*RoleRef) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3462954d26c055c0, []int{6}
+	return fileDescriptor_3462954d26c055c0, []int{4}
 }
 func (m *RoleRef) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -935,7 +808,7 @@ func (m *RbacConfig) Reset()         { *m = RbacConfig{} }
 func (m *RbacConfig) String() string { return proto.CompactTextString(m) }
 func (*RbacConfig) ProtoMessage()    {}
 func (*RbacConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3462954d26c055c0, []int{7}
+	return fileDescriptor_3462954d26c055c0, []int{5}
 }
 func (m *RbacConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -996,9 +869,6 @@ func (m *RbacConfig) GetEnforcementMode() EnforcementMode {
 type RbacConfig_Target struct {
 	// A list of services.
 	Services []string `protobuf:"bytes,1,rep,name=services,proto3" json:"services,omitempty"`
-	// $hide_from_docs
-	// A list of workload instances.
-	WorkloadSelectors []*WorkloadSelector `protobuf:"bytes,3,rep,name=workload_selectors,json=workloadSelectors,proto3" json:"workload_selectors,omitempty"`
 	// A list of namespaces.
 	Namespaces           []string `protobuf:"bytes,2,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -1010,7 +880,7 @@ func (m *RbacConfig_Target) Reset()         { *m = RbacConfig_Target{} }
 func (m *RbacConfig_Target) String() string { return proto.CompactTextString(m) }
 func (*RbacConfig_Target) ProtoMessage()    {}
 func (*RbacConfig_Target) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3462954d26c055c0, []int{7, 0}
+	return fileDescriptor_3462954d26c055c0, []int{5, 0}
 }
 func (m *RbacConfig_Target) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1046,13 +916,6 @@ func (m *RbacConfig_Target) GetServices() []string {
 	return nil
 }
 
-func (m *RbacConfig_Target) GetWorkloadSelectors() []*WorkloadSelector {
-	if m != nil {
-		return m.WorkloadSelectors
-	}
-	return nil
-}
-
 func (m *RbacConfig_Target) GetNamespaces() []string {
 	if m != nil {
 		return m.Namespaces
@@ -1063,9 +926,6 @@ func (m *RbacConfig_Target) GetNamespaces() []string {
 func init() {
 	proto.RegisterEnum("istio.rbac.v1alpha1.EnforcementMode", EnforcementMode_name, EnforcementMode_value)
 	proto.RegisterEnum("istio.rbac.v1alpha1.RbacConfig_Mode", RbacConfig_Mode_name, RbacConfig_Mode_value)
-	proto.RegisterType((*WorkloadSelector)(nil), "istio.rbac.v1alpha1.WorkloadSelector")
-	proto.RegisterMapType((map[string]string)(nil), "istio.rbac.v1alpha1.WorkloadSelector.LabelsEntry")
-	proto.RegisterType((*AuthorizationPolicy)(nil), "istio.rbac.v1alpha1.AuthorizationPolicy")
 	proto.RegisterType((*ServiceRole)(nil), "istio.rbac.v1alpha1.ServiceRole")
 	proto.RegisterType((*AccessRule)(nil), "istio.rbac.v1alpha1.AccessRule")
 	proto.RegisterType((*AccessRule_Constraint)(nil), "istio.rbac.v1alpha1.AccessRule.Constraint")
@@ -1080,164 +940,57 @@ func init() {
 func init() { proto.RegisterFile("rbac/v1alpha1/rbac.proto", fileDescriptor_3462954d26c055c0) }
 
 var fileDescriptor_3462954d26c055c0 = []byte{
-	// 921 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x56, 0x41, 0x6f, 0x23, 0xb5,
-	0x17, 0xdf, 0xc9, 0x64, 0x92, 0xce, 0xcb, 0xff, 0xdf, 0x4e, 0xbd, 0x0b, 0x8c, 0x02, 0x74, 0xab,
-	0x88, 0x85, 0x68, 0x85, 0x12, 0xb5, 0x88, 0x55, 0x17, 0x69, 0x0f, 0xdb, 0x36, 0x65, 0x23, 0xb5,
-	0x49, 0xe5, 0x14, 0x16, 0x71, 0x89, 0x26, 0x13, 0xb7, 0x31, 0x9d, 0xda, 0x23, 0x8f, 0xd3, 0x52,
-	0x8e, 0x5c, 0x38, 0x72, 0x45, 0x9c, 0x38, 0xf2, 0x51, 0x38, 0xf2, 0x11, 0x50, 0x3f, 0x09, 0xb2,
-	0x3d, 0x9e, 0x64, 0xb3, 0xa1, 0xdd, 0xde, 0xfc, 0xde, 0xef, 0xfd, 0xde, 0xb3, 0xdf, 0xfb, 0x79,
-	0x3c, 0x10, 0x8a, 0x51, 0x14, 0xb7, 0x2f, 0xb7, 0xa2, 0x24, 0x9d, 0x44, 0x5b, 0x6d, 0x65, 0xb5,
-	0x52, 0xc1, 0x25, 0x47, 0x0f, 0x69, 0x26, 0x29, 0x6f, 0x69, 0x8f, 0xc5, 0x1b, 0xbf, 0x39, 0x10,
-	0xbc, 0xe6, 0xe2, 0x3c, 0xe1, 0xd1, 0x78, 0x40, 0x12, 0x12, 0x4b, 0x2e, 0x50, 0x17, 0x2a, 0x49,
-	0x34, 0x22, 0x49, 0x16, 0x3a, 0x9b, 0x6e, 0xb3, 0xb6, 0xbd, 0xd5, 0x5a, 0x42, 0x6d, 0x2d, 0xd2,
-	0x5a, 0x87, 0x9a, 0xd3, 0x61, 0x52, 0x5c, 0xe3, 0x3c, 0x41, 0xfd, 0x39, 0xd4, 0xe6, 0xdc, 0x28,
-	0x00, 0xf7, 0x9c, 0x5c, 0x87, 0xce, 0xa6, 0xd3, 0xf4, 0xb1, 0x5a, 0xa2, 0x47, 0xe0, 0x5d, 0x46,
-	0xc9, 0x94, 0x84, 0x25, 0xed, 0x33, 0xc6, 0x57, 0xa5, 0x1d, 0xa7, 0xf1, 0xa7, 0x03, 0x0f, 0x5f,
-	0x4e, 0xe5, 0x84, 0x0b, 0xfa, 0x53, 0x24, 0x29, 0x67, 0xc7, 0x3c, 0xa1, 0xf1, 0x35, 0xc2, 0xb0,
-	0x7e, 0x95, 0x97, 0x1e, 0x66, 0x79, 0x6d, 0x9d, 0xb1, 0xb6, 0xfd, 0xe4, 0x9d, 0x36, 0x8a, 0x83,
-	0xab, 0xc5, 0x13, 0xbf, 0x00, 0x2f, 0x4a, 0x12, 0x7e, 0x15, 0x96, 0xf4, 0x81, 0x3f, 0x5b, 0x9a,
-	0x67, 0x40, 0xc4, 0x25, 0x8d, 0x09, 0xe6, 0x09, 0xd9, 0xa5, 0x6c, 0x4c, 0xd9, 0x19, 0x36, 0xac,
-	0xc6, 0x3e, 0xd4, 0xe6, 0x40, 0xf4, 0x25, 0x78, 0x62, 0x9a, 0x10, 0xdb, 0xbe, 0xc7, 0x4b, 0xb3,
-	0xbd, 0x8c, 0x63, 0x92, 0x65, 0x78, 0x9a, 0x10, 0x6c, 0xa2, 0x1b, 0x3f, 0xbb, 0x00, 0x33, 0x2f,
-	0xaa, 0xc3, 0x4a, 0x66, 0x92, 0x9a, 0x44, 0x3e, 0x2e, 0x6c, 0xd5, 0xb5, 0x09, 0xcf, 0x64, 0x16,
-	0x7a, 0x1a, 0x30, 0x06, 0xfa, 0x10, 0x7c, 0xc6, 0xe5, 0xd0, 0x20, 0x15, 0x43, 0x61, 0x5c, 0xbe,
-	0xd2, 0xe0, 0x23, 0xf0, 0xd2, 0x48, 0x4e, 0x32, 0x7d, 0x44, 0x1f, 0x1b, 0xc3, 0x52, 0x0c, 0x52,
-	0x2d, 0x28, 0xc7, 0x1a, 0x0c, 0xa1, 0x7a, 0x41, 0xe4, 0x84, 0x8f, 0xb3, 0xd0, 0xd5, 0x90, 0x35,
-	0xd1, 0x63, 0xa8, 0x29, 0x9a, 0x45, 0x57, 0x34, 0x0a, 0x8c, 0xcb, 0xa3, 0x3c, 0x40, 0x55, 0xe3,
-	0x42, 0x66, 0xa1, 0xbf, 0xe9, 0x36, 0x3d, 0x6c, 0x8c, 0xa2, 0x9a, 0x46, 0x40, 0x23, 0xba, 0x9a,
-	0x06, 0x0f, 0xa1, 0x16, 0x73, 0x96, 0x49, 0x11, 0x51, 0x26, 0xb3, 0xb0, 0xac, 0x7b, 0xf7, 0xf4,
-	0x8e, 0xde, 0xb5, 0xf6, 0x0a, 0x0a, 0x9e, 0xa7, 0xd7, 0x9f, 0x01, 0xcc, 0xa0, 0x25, 0xba, 0x7b,
-	0x1f, 0x2a, 0x5a, 0x6a, 0xb6, 0x1f, 0xb9, 0xd5, 0xf8, 0xb5, 0x04, 0xe8, 0xed, 0x41, 0xa3, 0x1d,
-	0x58, 0xc9, 0xa6, 0xa3, 0x1f, 0x48, 0x2c, 0xed, 0x54, 0x3f, 0x5a, 0xae, 0x11, 0x13, 0x84, 0x8b,
-	0x68, 0xf4, 0x0c, 0xaa, 0x82, 0x27, 0x04, 0x93, 0x53, 0x2d, 0xf1, 0xff, 0x22, 0x62, 0x13, 0x83,
-	0x6d, 0x30, 0xda, 0x81, 0xf2, 0x05, 0x1f, 0x93, 0xd0, 0xdd, 0x74, 0x9a, 0xab, 0xdb, 0x9f, 0x2c,
-	0x25, 0x75, 0xd8, 0x29, 0x17, 0x31, 0xb9, 0x20, 0x4c, 0x1e, 0xf1, 0x31, 0xc1, 0x9a, 0x81, 0x9e,
-	0x43, 0x35, 0x8a, 0xd5, 0x85, 0xb1, 0x4d, 0xbc, 0x53, 0x80, 0x36, 0x1e, 0x21, 0x28, 0xab, 0xfa,
-	0xa1, 0xa7, 0x1b, 0xa5, 0xd7, 0x8d, 0x3f, 0x5c, 0xa8, 0xe6, 0xc7, 0x52, 0xf8, 0x34, 0x23, 0x22,
-	0x6f, 0xa4, 0x5e, 0xab, 0x51, 0xb3, 0xe8, 0x82, 0x98, 0x62, 0x3e, 0x36, 0x86, 0x1d, 0xb5, 0x41,
-	0xbc, 0x42, 0x58, 0x3d, 0x0d, 0x86, 0xe0, 0x9d, 0x09, 0x3e, 0x4d, 0xcd, 0xa5, 0xdf, 0x2d, 0x85,
-	0x0e, 0x36, 0x0e, 0x35, 0x16, 0xbd, 0xb0, 0xfa, 0xcd, 0x2d, 0xf4, 0x31, 0x28, 0x75, 0x0d, 0x73,
-	0xcc, 0x08, 0x55, 0x15, 0xf8, 0xda, 0xc0, 0x1b, 0x00, 0xba, 0x52, 0x1a, 0xa9, 0xdb, 0x62, 0xe5,
-	0x58, 0x78, 0xd0, 0x13, 0x58, 0x2d, 0x76, 0x63, 0x62, 0x7c, 0x1d, 0xf3, 0x7f, 0xbb, 0x25, 0x13,
-	0x16, 0x80, 0x4b, 0x53, 0xa3, 0x4c, 0x1f, 0xab, 0x25, 0xfa, 0x00, 0xaa, 0x8a, 0xa8, 0xbc, 0x35,
-	0xb3, 0x21, 0xc6, 0x65, 0x37, 0x55, 0x6a, 0x85, 0x54, 0xf0, 0x94, 0x08, 0x49, 0x89, 0xb9, 0x1e,
-	0xb5, 0xed, 0xcf, 0x6f, 0x93, 0x44, 0xeb, 0xb8, 0x08, 0x37, 0x9f, 0xc8, 0x39, 0x7e, 0xfd, 0x05,
-	0xac, 0x2d, 0xc0, 0xf7, 0xfa, 0x54, 0x6e, 0x41, 0x35, 0xd7, 0x8f, 0x9a, 0xd0, 0x39, 0x65, 0x63,
-	0x3b, 0x21, 0xb5, 0x56, 0x3e, 0x75, 0xf2, 0x9c, 0xa7, 0xd7, 0x8d, 0x5f, 0xca, 0x00, 0x78, 0x14,
-	0xc5, 0x7b, 0x9c, 0x9d, 0xd2, 0xb3, 0x42, 0x6d, 0xce, 0x2d, 0x6a, 0x9b, 0x85, 0xb7, 0xe6, 0xd4,
-	0xb6, 0x0f, 0x3e, 0x65, 0x71, 0x32, 0xcd, 0x28, 0x67, 0xb9, 0xc2, 0x3f, 0xbd, 0x8b, 0x7e, 0x12,
-	0x89, 0x33, 0x22, 0xf1, 0x8c, 0xa8, 0xb2, 0x90, 0x1f, 0x6d, 0x16, 0xf7, 0x7e, 0x59, 0x0a, 0x22,
-	0xea, 0x43, 0x40, 0x66, 0x57, 0x62, 0xa8, 0x4f, 0x54, 0xbe, 0xc7, 0xfd, 0x59, 0x23, 0x6f, 0x3a,
-	0xea, 0xbf, 0x3b, 0x50, 0x31, 0x65, 0x6e, 0xfd, 0x1c, 0x9f, 0x00, 0x7a, 0xeb, 0x49, 0xb2, 0xa2,
-	0x78, 0xc7, 0x37, 0x69, 0x7d, 0xf1, 0x4d, 0x5a, 0x14, 0x75, 0x69, 0x51, 0xd4, 0x8d, 0x0e, 0x94,
-	0xd5, 0x26, 0x51, 0x15, 0xdc, 0xfe, 0xc1, 0x41, 0xf0, 0x00, 0x55, 0xa0, 0xd4, 0xef, 0x05, 0x0e,
-	0x7a, 0x0f, 0xd6, 0xfb, 0xbd, 0xe1, 0xeb, 0xee, 0xc9, 0xab, 0x61, 0xb7, 0xb7, 0x77, 0xf8, 0xcd,
-	0xa0, 0xdb, 0xef, 0x05, 0xa5, 0x79, 0x77, 0xe7, 0x3b, 0xeb, 0x76, 0x9f, 0xb6, 0x61, 0x6d, 0xa1,
-	0x0f, 0xe8, 0x7f, 0xb0, 0xd2, 0xe9, 0x1d, 0xf4, 0xf1, 0x5e, 0x67, 0x3f, 0x78, 0x80, 0x56, 0x01,
-	0x8e, 0x3b, 0xf8, 0xa8, 0x3b, 0x18, 0x74, 0xbf, 0xed, 0x04, 0xce, 0x6e, 0xf3, 0xaf, 0x9b, 0x0d,
-	0xe7, 0xef, 0x9b, 0x0d, 0xe7, 0x9f, 0x9b, 0x0d, 0xe7, 0xfb, 0xba, 0x39, 0x1e, 0xe5, 0xed, 0x28,
-	0xa5, 0xed, 0x37, 0xfe, 0x3e, 0x46, 0x15, 0xfd, 0xe7, 0xf1, 0xc5, 0xbf, 0x01, 0x00, 0x00, 0xff,
-	0xff, 0xcb, 0x76, 0x97, 0x83, 0x95, 0x08, 0x00, 0x00,
-}
-
-func (m *WorkloadSelector) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *WorkloadSelector) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *WorkloadSelector) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if len(m.Labels) > 0 {
-		for k := range m.Labels {
-			v := m.Labels[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintRbac(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintRbac(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintRbac(dAtA, i, uint64(baseI-i))
-			i--
-			dAtA[i] = 0xa
-		}
-	}
-	return len(dAtA) - i, nil
-}
-
-func (m *AuthorizationPolicy) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *AuthorizationPolicy) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *AuthorizationPolicy) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	if m.XXX_unrecognized != nil {
-		i -= len(m.XXX_unrecognized)
-		copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	if len(m.Allow) > 0 {
-		for iNdEx := len(m.Allow) - 1; iNdEx >= 0; iNdEx-- {
-			{
-				size, err := m.Allow[iNdEx].MarshalToSizedBuffer(dAtA[:i])
-				if err != nil {
-					return 0, err
-				}
-				i -= size
-				i = encodeVarintRbac(dAtA, i, uint64(size))
-			}
-			i--
-			dAtA[i] = 0x12
-		}
-	}
-	if m.WorkloadSelector != nil {
-		{
-			size, err := m.WorkloadSelector.MarshalToSizedBuffer(dAtA[:i])
-			if err != nil {
-				return 0, err
-			}
-			i -= size
-			i = encodeVarintRbac(dAtA, i, uint64(size))
-		}
-		i--
-		dAtA[i] = 0xa
-	}
-	return len(dAtA) - i, nil
+	// 796 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x55, 0xdd, 0x6e, 0xf3, 0x44,
+	0x10, 0xfd, 0x6c, 0xc7, 0x71, 0x3c, 0x81, 0xd6, 0x2c, 0x05, 0xac, 0x00, 0x69, 0x14, 0x01, 0x8a,
+	0x2a, 0x94, 0xa8, 0x45, 0x54, 0x05, 0x89, 0x0b, 0x9a, 0xb8, 0x34, 0x52, 0x9b, 0x54, 0x9b, 0xf2,
+	0x23, 0x6e, 0x22, 0xc7, 0xd9, 0x26, 0xa6, 0xc9, 0xae, 0x65, 0x6f, 0x2a, 0x7a, 0xcb, 0x0b, 0xf0,
+	0x0a, 0x3c, 0x02, 0x8f, 0xc1, 0x25, 0x8f, 0x80, 0xfa, 0x24, 0x68, 0x77, 0xbd, 0x4e, 0x5a, 0xe5,
+	0x6b, 0xd5, 0xbb, 0x99, 0x39, 0xe7, 0xec, 0xac, 0x67, 0xce, 0x26, 0xe0, 0xa7, 0x93, 0x30, 0xea,
+	0xdc, 0x1d, 0x86, 0x8b, 0x64, 0x1e, 0x1e, 0x76, 0x44, 0xd6, 0x4e, 0x52, 0xc6, 0x19, 0x7a, 0x3f,
+	0xce, 0x78, 0xcc, 0xda, 0xb2, 0xa2, 0xf1, 0x66, 0x0f, 0xaa, 0x23, 0x92, 0xde, 0xc5, 0x11, 0xc1,
+	0x6c, 0x41, 0xd0, 0xd7, 0x60, 0xa7, 0xab, 0x05, 0xc9, 0x7c, 0xa3, 0x61, 0xb5, 0xaa, 0x47, 0xfb,
+	0xed, 0x2d, 0x9a, 0xf6, 0xf7, 0x51, 0x44, 0xb2, 0x0c, 0xaf, 0x16, 0x04, 0x2b, 0x76, 0xf3, 0x0f,
+	0x0b, 0x60, 0x5d, 0x45, 0x35, 0xa8, 0x64, 0xea, 0x50, 0x75, 0x90, 0x8b, 0x8b, 0x1c, 0xed, 0x81,
+	0x3d, 0x67, 0x19, 0xcf, 0x7c, 0x5b, 0x02, 0x2a, 0x41, 0x1f, 0x83, 0x4b, 0x19, 0x1f, 0x2b, 0xa4,
+	0xac, 0x24, 0x94, 0xf1, 0x73, 0x09, 0xee, 0x81, 0x9d, 0x84, 0x7c, 0x9e, 0xf9, 0xa6, 0x92, 0xc8,
+	0x44, 0x4b, 0x14, 0xe2, 0x14, 0x92, 0x2b, 0x09, 0xfa, 0xe0, 0x2c, 0x09, 0x9f, 0xb3, 0x69, 0xe6,
+	0x5b, 0x12, 0xd2, 0x29, 0xda, 0x87, 0xaa, 0x90, 0x69, 0xb4, 0x22, 0x51, 0xa0, 0x8c, 0x5f, 0xe6,
+	0x04, 0xd1, 0x8d, 0xa5, 0x3c, 0xf3, 0xdd, 0x86, 0xd5, 0xb2, 0xb1, 0x4a, 0x8a, 0x6e, 0x12, 0x01,
+	0x89, 0xc8, 0x6e, 0x12, 0xbc, 0x80, 0x6a, 0xc4, 0x68, 0xc6, 0xd3, 0x30, 0xa6, 0x3c, 0xf3, 0x4b,
+	0x72, 0x76, 0x07, 0x2f, 0xcc, 0xae, 0xdd, 0x2d, 0x24, 0x78, 0x53, 0x5e, 0x3b, 0x06, 0x58, 0x43,
+	0xc8, 0x03, 0xeb, 0x96, 0xdc, 0xfb, 0x46, 0xc3, 0x68, 0xb9, 0x58, 0x84, 0xe8, 0x43, 0x28, 0xdf,
+	0x85, 0x8b, 0x15, 0xd1, 0xf3, 0xc8, 0xb3, 0xe6, 0x9f, 0x26, 0xa0, 0x8d, 0x5d, 0x9e, 0xc6, 0x74,
+	0x1a, 0xd3, 0x19, 0x3a, 0x81, 0x4a, 0xb6, 0x9a, 0xfc, 0x46, 0x22, 0xae, 0xb7, 0xfa, 0xc9, 0xd6,
+	0x9b, 0x8d, 0x14, 0x09, 0x17, 0x6c, 0x74, 0x0c, 0x4e, 0xca, 0x16, 0x04, 0x93, 0x1b, 0xdf, 0x6c,
+	0x18, 0x6f, 0x15, 0x62, 0xc5, 0xc1, 0x9a, 0x8c, 0x4e, 0xa0, 0xb4, 0x64, 0x53, 0xe2, 0x5b, 0x0d,
+	0xa3, 0xb5, 0x73, 0xf4, 0xd9, 0x56, 0x51, 0x40, 0x6f, 0x58, 0x1a, 0x91, 0x25, 0xa1, 0xfc, 0x92,
+	0x4d, 0x09, 0x96, 0x0a, 0xf4, 0x0d, 0x38, 0x61, 0xc4, 0x63, 0x46, 0xf5, 0x10, 0x5f, 0x34, 0xa0,
+	0xe6, 0x23, 0x04, 0x25, 0xd1, 0xdf, 0xb7, 0xe5, 0xa0, 0x64, 0xdc, 0xfc, 0xcb, 0x02, 0x27, 0xff,
+	0x2c, 0x81, 0xaf, 0x32, 0x92, 0xe6, 0x83, 0x94, 0xb1, 0x58, 0x35, 0x0d, 0x97, 0x44, 0x35, 0x73,
+	0xb1, 0x4a, 0xf4, 0xaa, 0x15, 0x62, 0x17, 0xc6, 0x1a, 0x48, 0xd0, 0x07, 0x7b, 0x96, 0xb2, 0x55,
+	0x22, 0x27, 0xe2, 0x9e, 0x9a, 0xbe, 0x81, 0x55, 0x41, 0xac, 0x45, 0x06, 0xda, 0xbf, 0x79, 0x86,
+	0x3e, 0x05, 0xe1, 0xae, 0x71, 0x8e, 0x29, 0xa3, 0x8a, 0x06, 0x3f, 0x28, 0xb8, 0x0e, 0x20, 0x3b,
+	0x25, 0xa1, 0x78, 0x2d, 0xda, 0x8e, 0x45, 0x05, 0x7d, 0x0e, 0x3b, 0xc5, 0x6d, 0x14, 0xc7, 0x95,
+	0x9c, 0x77, 0xf5, 0x95, 0x14, 0xcd, 0x03, 0x2b, 0x4e, 0x94, 0x33, 0x5d, 0x2c, 0x42, 0xf4, 0x11,
+	0x38, 0x42, 0x28, 0xaa, 0x55, 0x75, 0x21, 0xca, 0x78, 0x3f, 0x11, 0x6e, 0x85, 0x24, 0x65, 0x09,
+	0x49, 0x79, 0x4c, 0xd4, 0xf3, 0xa8, 0x1e, 0x7d, 0xf9, 0x9c, 0x25, 0xda, 0x57, 0x05, 0x3d, 0xa0,
+	0x3c, 0xbd, 0xc7, 0x1b, 0xfa, 0xda, 0x77, 0xb0, 0xfb, 0x04, 0xde, 0x62, 0xd9, 0x3d, 0xb0, 0xa5,
+	0x49, 0xd5, 0xd4, 0xb0, 0x4a, 0xbe, 0x35, 0x4f, 0x8c, 0xe6, 0x21, 0x38, 0xb9, 0x7f, 0xc4, 0x86,
+	0x6e, 0x63, 0x3a, 0xd5, 0x1b, 0x12, 0xb1, 0xa8, 0x89, 0x2f, 0xcf, 0x75, 0x32, 0x6e, 0xfe, 0x6d,
+	0x01, 0xe0, 0x49, 0x18, 0x75, 0x19, 0xbd, 0x89, 0x67, 0x85, 0xdb, 0x8c, 0x67, 0xdc, 0xb6, 0xa6,
+	0xb7, 0x37, 0xdc, 0xd6, 0x03, 0x37, 0xa6, 0xd1, 0x62, 0x95, 0xc5, 0x8c, 0xe6, 0x0e, 0xff, 0xe2,
+	0x25, 0xf9, 0x75, 0x98, 0xce, 0x08, 0xc7, 0x6b, 0xa1, 0x38, 0x85, 0xfc, 0xae, 0x4f, 0xb1, 0x5e,
+	0x77, 0x4a, 0x21, 0x44, 0x43, 0xf0, 0xc8, 0xfa, 0x49, 0x8c, 0xe5, 0x17, 0x95, 0x5e, 0xf1, 0x7e,
+	0x76, 0xc9, 0xe3, 0x42, 0xad, 0x07, 0x65, 0xd5, 0xe5, 0xd9, 0x5f, 0xe3, 0xc7, 0xee, 0x33, 0x9f,
+	0xba, 0xaf, 0x19, 0x40, 0x49, 0x9c, 0x86, 0x1c, 0xb0, 0x86, 0x67, 0x67, 0xde, 0x1b, 0x54, 0x06,
+	0x73, 0x38, 0xf0, 0x0c, 0xf4, 0x01, 0xbc, 0x37, 0x1c, 0x8c, 0x7f, 0xee, 0x5f, 0x9f, 0x8f, 0xfb,
+	0x83, 0xee, 0xc5, 0x8f, 0xa3, 0xfe, 0x70, 0xe0, 0x99, 0x9b, 0xe5, 0xe0, 0x17, 0x5d, 0xb6, 0x0e,
+	0x3a, 0xb0, 0xfb, 0xe4, 0xc2, 0xe8, 0x1d, 0xa8, 0x04, 0x83, 0xb3, 0x21, 0xee, 0x06, 0x3d, 0xef,
+	0x0d, 0xda, 0x01, 0xb8, 0x0a, 0xf0, 0x65, 0x7f, 0x34, 0xea, 0xff, 0x14, 0x78, 0xc6, 0x69, 0xeb,
+	0x9f, 0x87, 0xba, 0xf1, 0xef, 0x43, 0xdd, 0xf8, 0xef, 0xa1, 0x6e, 0xfc, 0x5a, 0x53, 0x13, 0x88,
+	0x59, 0x27, 0x4c, 0xe2, 0xce, 0xa3, 0x3f, 0xb8, 0x49, 0x59, 0xfe, 0xb9, 0x7d, 0xf5, 0x7f, 0x00,
+	0x00, 0x00, 0xff, 0xff, 0x90, 0x8d, 0x80, 0x52, 0xf8, 0x06, 0x00, 0x00,
 }
 
 func (m *ServiceRole) Marshal() (dAtA []byte, err error) {
@@ -1306,40 +1059,40 @@ func (m *AccessRule) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.NotPorts) > 0 {
-		dAtA3 := make([]byte, len(m.NotPorts)*10)
-		var j2 int
+		dAtA2 := make([]byte, len(m.NotPorts)*10)
+		var j1 int
 		for _, num1 := range m.NotPorts {
 			num := uint64(num1)
 			for num >= 1<<7 {
-				dAtA3[j2] = uint8(uint64(num)&0x7f | 0x80)
+				dAtA2[j1] = uint8(uint64(num)&0x7f | 0x80)
 				num >>= 7
-				j2++
+				j1++
 			}
-			dAtA3[j2] = uint8(num)
-			j2++
+			dAtA2[j1] = uint8(num)
+			j1++
 		}
-		i -= j2
-		copy(dAtA[i:], dAtA3[:j2])
-		i = encodeVarintRbac(dAtA, i, uint64(j2))
+		i -= j1
+		copy(dAtA[i:], dAtA2[:j1])
+		i = encodeVarintRbac(dAtA, i, uint64(j1))
 		i--
 		dAtA[i] = 0x52
 	}
 	if len(m.Ports) > 0 {
-		dAtA5 := make([]byte, len(m.Ports)*10)
-		var j4 int
+		dAtA4 := make([]byte, len(m.Ports)*10)
+		var j3 int
 		for _, num1 := range m.Ports {
 			num := uint64(num1)
 			for num >= 1<<7 {
-				dAtA5[j4] = uint8(uint64(num)&0x7f | 0x80)
+				dAtA4[j3] = uint8(uint64(num)&0x7f | 0x80)
 				num >>= 7
-				j4++
+				j3++
 			}
-			dAtA5[j4] = uint8(num)
-			j4++
+			dAtA4[j3] = uint8(num)
+			j3++
 		}
-		i -= j4
-		copy(dAtA[i:], dAtA5[:j4])
-		i = encodeVarintRbac(dAtA, i, uint64(j4))
+		i -= j3
+		copy(dAtA[i:], dAtA4[:j3])
+		i = encodeVarintRbac(dAtA, i, uint64(j3))
 		i--
 		dAtA[i] = 0x4a
 	}
@@ -1803,20 +1556,6 @@ func (m *RbacConfig_Target) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i -= len(m.XXX_unrecognized)
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	if len(m.WorkloadSelectors) > 0 {
-		for iNdEx := len(m.WorkloadSelectors) - 1; iNdEx >= 0; iNdEx-- {
-			{
-				size, err := m.WorkloadSelectors[iNdEx].MarshalToSizedBuffer(dAtA[:i])
-				if err != nil {
-					return 0, err
-				}
-				i -= size
-				i = encodeVarintRbac(dAtA, i, uint64(size))
-			}
-			i--
-			dAtA[i] = 0x1a
-		}
-	}
 	if len(m.Namespaces) > 0 {
 		for iNdEx := len(m.Namespaces) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.Namespaces[iNdEx])
@@ -1849,48 +1588,6 @@ func encodeVarintRbac(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *WorkloadSelector) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	if len(m.Labels) > 0 {
-		for k, v := range m.Labels {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovRbac(uint64(len(k))) + 1 + len(v) + sovRbac(uint64(len(v)))
-			n += mapEntrySize + 1 + sovRbac(uint64(mapEntrySize))
-		}
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
-	return n
-}
-
-func (m *AuthorizationPolicy) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	if m.WorkloadSelector != nil {
-		l = m.WorkloadSelector.Size()
-		n += 1 + l + sovRbac(uint64(l))
-	}
-	if len(m.Allow) > 0 {
-		for _, e := range m.Allow {
-			l = e.Size()
-			n += 1 + l + sovRbac(uint64(l))
-		}
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
-	return n
-}
-
 func (m *ServiceRole) Size() (n int) {
 	if m == nil {
 		return 0
@@ -2180,12 +1877,6 @@ func (m *RbacConfig_Target) Size() (n int) {
 			n += 1 + l + sovRbac(uint64(l))
 		}
 	}
-	if len(m.WorkloadSelectors) > 0 {
-		for _, e := range m.WorkloadSelectors {
-			l = e.Size()
-			n += 1 + l + sovRbac(uint64(l))
-		}
-	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -2197,311 +1888,6 @@ func sovRbac(x uint64) (n int) {
 }
 func sozRbac(x uint64) (n int) {
 	return sovRbac(uint64((x << 1) ^ uint64((int64(x) >> 63))))
-}
-func (m *WorkloadSelector) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowRbac
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: WorkloadSelector: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: WorkloadSelector: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowRbac
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthRbac
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthRbac
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.Labels == nil {
-				m.Labels = make(map[string]string)
-			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowRbac
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowRbac
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthRbac
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthRbac
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowRbac
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthRbac
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthRbac
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipRbac(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthRbac
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Labels[mapkey] = mapvalue
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipRbac(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthRbac
-			}
-			if (iNdEx + skippy) < 0 {
-				return ErrInvalidLengthRbac
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *AuthorizationPolicy) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowRbac
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: AuthorizationPolicy: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: AuthorizationPolicy: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field WorkloadSelector", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowRbac
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthRbac
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthRbac
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.WorkloadSelector == nil {
-				m.WorkloadSelector = &WorkloadSelector{}
-			}
-			if err := m.WorkloadSelector.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Allow", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowRbac
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthRbac
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthRbac
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Allow = append(m.Allow, &ServiceRoleBinding{})
-			if err := m.Allow[len(m.Allow)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipRbac(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthRbac
-			}
-			if (iNdEx + skippy) < 0 {
-				return ErrInvalidLengthRbac
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
 }
 func (m *ServiceRole) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -4257,40 +3643,6 @@ func (m *RbacConfig_Target) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Namespaces = append(m.Namespaces, string(dAtA[iNdEx:postIndex]))
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field WorkloadSelectors", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowRbac
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthRbac
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthRbac
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.WorkloadSelectors = append(m.WorkloadSelectors, &WorkloadSelector{})
-			if err := m.WorkloadSelectors[len(m.WorkloadSelectors)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/rbac/v1alpha1/rbac.proto
+++ b/rbac/v1alpha1/rbac.proto
@@ -86,41 +86,6 @@ package istio.rbac.v1alpha1;
 
 option go_package="istio.io/api/rbac/v1alpha1";
 
-// $hide_from_docs
-// This is forked from the networking/v1alpha3/sidecar.proto to avoid a direct
-// dependency from the rbac API on networking API.
-// TODO: Move the WorkloadSelector to a common place to be shared by other packages.
-// WorkloadSelector specifies the criteria used to determine if the Gateway
-// or Sidecar resource can be applied to a proxy. The matching criteria
-// includes the metadata associated with a proxy, workload instance info such as
-// labels attached to the pod/VM, or any other info that the proxy provides
-// to Istio during the initial handshake. If multiple conditions are
-// specified, all conditions need to match in order for the workload instance to be
-// selected. Currently, only label based selection mechanism is supported.
-message WorkloadSelector {
-  // One or more labels that indicate a specific set of pods/VMs on which
-  // this sidecar configuration should be applied. The scope of label
-  // search is restricted to the configuration namespace in which the the
-  // resource is present.
-  map<string, string> labels = 1;
-}
-
-// $hide_from_docs
-// AuthorizationPolicy to enforce access control on a selected workload instance.
-message AuthorizationPolicy {
-  // $hide_from_docs
-  // Optional. One or more labels that indicate a specific set of pods/VMs
-  // on which this authorization policy should be applied. Leave this empty to
-  // select all pods/VMs.
-  // The scope of label search is platform dependent. On Kubernetes, for example,
-  // the scope includes pods running in the same namespace as the authorization policy itself.
-  WorkloadSelector workload_selector = 1;
-
-  // $hide_from_docs
-  // A list of bindings that specify the subjects and permissions to the selected workload instance.
-  repeated ServiceRoleBinding allow = 2;
-}
-
 // ServiceRole specification contains a list of access rules (permissions).
 message ServiceRole {
   // Required. The set of access rules (permissions) that the role has.
@@ -379,10 +344,6 @@ message RbacConfig {
   message Target {
     // A list of services.
     repeated string services = 1;
-
-    // $hide_from_docs
-    // A list of workload instances.
-    repeated WorkloadSelector workload_selectors = 3;
 
     // A list of namespaces.
     repeated string namespaces = 2;

--- a/releaselocks/release-1.1/proto.lock.status
+++ b/releaselocks/release-1.1/proto.lock.status
@@ -1,3 +1,7 @@
+CONFLICT: "AuthorizationPolicy" field: "allow" has been removed, but is not reserved [rbac/v1alpha1/rbac.proto]
+CONFLICT: "AuthorizationPolicy" field: "workload_selector" has been removed, but is not reserved [rbac/v1alpha1/rbac.proto]
+CONFLICT: "AuthorizationPolicy" ID: "1" has been removed, but is not reserved [rbac/v1alpha1/rbac.proto]
+CONFLICT: "AuthorizationPolicy" ID: "2" has been removed, but is not reserved [rbac/v1alpha1/rbac.proto]
 CONFLICT: "ListenerMatch.ListenerProtocol" field: "ALL" has been removed, but is not reserved [networking/v1alpha3/envoy_filter.proto]
 CONFLICT: "ListenerMatch.ListenerProtocol" field: "HTTP" has been removed, but is not reserved [networking/v1alpha3/envoy_filter.proto]
 CONFLICT: "ListenerMatch.ListenerProtocol" field: "TCP" has been removed, but is not reserved [networking/v1alpha3/envoy_filter.proto]
@@ -12,3 +16,5 @@ CONFLICT: "ListenerMatch.ListenerType" integer: "0" has been removed, but is not
 CONFLICT: "ListenerMatch.ListenerType" integer: "1" has been removed, but is not reserved [networking/v1alpha3/envoy_filter.proto]
 CONFLICT: "ListenerMatch.ListenerType" integer: "2" has been removed, but is not reserved [networking/v1alpha3/envoy_filter.proto]
 CONFLICT: "ListenerMatch.ListenerType" integer: "3" has been removed, but is not reserved [networking/v1alpha3/envoy_filter.proto]
+CONFLICT: "WorkloadSelector" field: "labels" has been removed, but is not reserved [rbac/v1alpha1/rbac.proto]
+CONFLICT: "WorkloadSelector" ID: "1" has been removed, but is not reserved [rbac/v1alpha1/rbac.proto]


### PR DESCRIPTION
Now we have the new approved `AuthorizationPolicy` in the `security` directory, it's best to remove the out-dated one to avoid confusions.

The corresponding code had been removed in https://github.com/istio/istio/pull/16119.

istio/istio#12394