### PR TITLE
Set release managers as CODEOWNERS for release-1.3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @geeknoid, @rshriram, @andraxylia, @costinm, @diemtvu, @frankbu, @GregHanson, @mandarjog, @ozevren, @wattli
+* @istio/release-managers-1-3


### PR DESCRIPTION
Setting up the release-1.3 branch, cf. https://github.com/istio/istio/issues/16201.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure