### PR TITLE
typo fix rbac/v1alpha1/rbac.pb.go

### DIFF
--- a/rbac/v1alpha1/istio.rbac.v1alpha1.json
+++ b/rbac/v1alpha1/istio.rbac.v1alpha1.json
@@ -24,7 +24,7 @@
         "type": "object",
         "properties": {
           "services": {
-            "description": "Required. A list of service names. Exact match, prefix match, and suffix match are supported for service names. For example, the service name \"bookstore.mtv.cluster.local\" matches \"bookstore.mtv.cluster.local\" (exact match), or \"bookstore*\" (prefix match), or \"*.mtv.cluster.local\" (suffix match). If set to [\"*\"], it refers to all services in the namespace.",
+            "description": "Required. A list of service names. Exact match, prefix match, and suffix match are supported for service names. For example, the service name \"bookstore.mtv.cluster.local\" matches \"bookstore.mtv.cluster.local\" (exact match), or \"bookstore\\*\" (prefix match), or \"\\*.mtv.cluster.local\" (suffix match). If set to [\"\\*\"], it refers to all services in the namespace.",
             "type": "array",
             "items": {
               "type": "string",
@@ -32,7 +32,7 @@
             }
           },
           "hosts": {
-            "description": "Optional. A list of HTTP hosts. This is matched against the HOST header in a HTTP request. Exact match, prefix match and suffix match are supported. For example, the host \"test.abc.com\" matches \"test.abc.com\" (exact match), or \"*.abc.com\" (prefix match), or \"test.abc.*\" (suffix match). If not specified, it matches to any host. This field should not be set for TCP services. The policy will be ignored.",
+            "description": "Optional. A list of HTTP hosts. This is matched against the HOST header in a HTTP request. Exact match, prefix match and suffix match are supported. For example, the host \"test.abc.com\" matches \"test.abc.com\" (exact match), or \"\\*.abc.com\" (prefix match), or \"test.abc.\\*\" (suffix match). If not specified, it matches to any host. This field should not be set for TCP services. The policy will be ignored.",
             "type": "array",
             "items": {
               "type": "string",
@@ -48,7 +48,7 @@
             }
           },
           "paths": {
-            "description": "Optional. A list of HTTP paths or gRPC methods. gRPC methods must be presented as fully-qualified name in the form of \"/packageName.serviceName/methodName\" and are case sensitive. Exact match, prefix match, and suffix match are supported. For example, the path \"/books/review\" matches \"/books/review\" (exact match), or \"/books/*\" (prefix match), or \"*/review\" (suffix match). If not specified, it matches to any path. This field should not be set for TCP services. The policy will be ignored.",
+            "description": "Optional. A list of HTTP paths or gRPC methods. gRPC methods must be presented as fully-qualified name in the form of \"/packageName.serviceName/methodName\" and are case sensitive. Exact match, prefix match, and suffix match are supported. For example, the path \"/books/review\" matches \"/books/review\" (exact match), or \"/books/\\*\" (prefix match), or \"\\*/review\" (suffix match). If not specified, it matches to any path. This field should not be set for TCP services. The policy will be ignored.",
             "type": "array",
             "items": {
               "type": "string",
@@ -64,7 +64,7 @@
             }
           },
           "methods": {
-            "description": "Optional. A list of HTTP methods (e.g., \"GET\", \"POST\"). If not specified or specified as \"*\", it matches to any methods. This field should not be set for TCP services. The policy will be ignored. For gRPC services, only `POST` is allowed; other methods will result in denying services.",
+            "description": "Optional. A list of HTTP methods (e.g., \"GET\", \"POST\"). If not specified or specified as \"\\*\", it matches to any methods. This field should not be set for TCP services. The policy will be ignored. For gRPC services, only `POST` is allowed; other methods will result in denying services.",
             "type": "array",
             "items": {
               "type": "string",
@@ -114,7 +114,7 @@
             "format": "string"
           },
           "values": {
-            "description": "List of valid values for the constraint. Exact match, prefix match, and suffix match are supported. For example, the value \"v1alpha2\" matches \"v1alpha2\" (exact match), or \"v1*\" (prefix match), or \"*alpha2\" (suffix match).",
+            "description": "List of valid values for the constraint. Exact match, prefix match, and suffix match are supported. For example, the value \"v1alpha2\" matches \"v1alpha2\" (exact match), or \"v1\\*\" (prefix match), or \"\\*alpha2\" (suffix match).",
             "type": "array",
             "items": {
               "type": "string",
@@ -175,7 +175,7 @@
             "format": "string"
           },
           "names": {
-            "description": "Optional. A list of subject names. This is matched to the `source.principal` attribute. If one of subject names is \"*\", it matches to a subject with any name. Prefix and suffix matches are supported.",
+            "description": "Optional. A list of subject names. This is matched to the `source.principal` attribute. If one of subject names is \"\\*\", it matches to a subject with any name. Prefix and suffix matches are supported.",
             "type": "array",
             "items": {
               "type": "string",

--- a/rbac/v1alpha1/istio.rbac.v1alpha1.pb.html
+++ b/rbac/v1alpha1/istio.rbac.v1alpha1.pb.html
@@ -14,7 +14,7 @@ the following standard fields:</p>
 
 <ul>
 <li>services: a list of services.</li>
-<li>methods: A list of HTTP methods. You can set the value to <code>*</code> to include all HTTP methods.
+<li>methods: A list of HTTP methods. You can set the value to <code>\*</code> to include all HTTP methods.
          This field should not be set for TCP services. The policy will be ignored.
          For gRPC services, only <code>POST</code> is allowed; other methods will result in denying services.</li>
 <li>paths: HTTP paths or gRPC methods. Note that gRPC methods should be
@@ -95,9 +95,9 @@ spec:
 <p>Required. A list of service names.
 Exact match, prefix match, and suffix match are supported for service names.
 For example, the service name &ldquo;bookstore.mtv.cluster.local&rdquo; matches
-&ldquo;bookstore.mtv.cluster.local&rdquo; (exact match), or &ldquo;bookstore<em>&rdquo; (prefix match),
-or &ldquo;</em>.mtv.cluster.local&rdquo; (suffix match).
-If set to [&ldquo;*&rdquo;], it refers to all services in the namespace.</p>
+&ldquo;bookstore.mtv.cluster.local&rdquo; (exact match), or &ldquo;bookstore*&rdquo; (prefix match),
+or &ldquo;*.mtv.cluster.local&rdquo; (suffix match).
+If set to [&rdquo;*&rdquo;], it refers to all services in the namespace.</p>
 
 </td>
 </tr>
@@ -110,7 +110,7 @@ gRPC methods must be presented as fully-qualified name in the form of
 &ldquo;/packageName.serviceName/methodName&rdquo; and are case sensitive.
 Exact match, prefix match, and suffix match are supported. For example,
 the path &ldquo;/books/review&rdquo; matches &ldquo;/books/review&rdquo; (exact match),
-or &ldquo;/books/<em>&rdquo; (prefix match), or &ldquo;</em>/review&rdquo; (suffix match).
+or &ldquo;/books/*&rdquo; (prefix match), or &ldquo;*/review&rdquo; (suffix match).
 If not specified, it matches to any path.
 This field should not be set for TCP services. The policy will be ignored.</p>
 
@@ -166,7 +166,7 @@ For gRPC services, only <code>POST</code> is allowed; other methods will result 
 <p>List of valid values for the constraint.
 Exact match, prefix match, and suffix match are supported.
 For example, the value &ldquo;v1alpha2&rdquo; matches &ldquo;v1alpha2&rdquo; (exact match),
-or &ldquo;v1<em>&rdquo; (prefix match), or &ldquo;</em>alpha2&rdquo; (suffix match).</p>
+or &ldquo;v1*&rdquo; (prefix match), or &ldquo;*alpha2&rdquo; (suffix match).</p>
 
 </td>
 </tr>

--- a/rbac/v1alpha1/rbac.pb.go
+++ b/rbac/v1alpha1/rbac.pb.go
@@ -8,7 +8,7 @@
 // the following standard fields:
 //
 //   * services: a list of services.
-//   * methods: A list of HTTP methods. You can set the value to `*` to include all HTTP methods.
+//   * methods: A list of HTTP methods. You can set the value to `\*` to include all HTTP methods.
 //              This field should not be set for TCP services. The policy will be ignored.
 //              For gRPC services, only `POST` is allowed; other methods will result in denying services.
 //   * paths: HTTP paths or gRPC methods. Note that gRPC methods should be
@@ -213,15 +213,15 @@ type AccessRule struct {
 	// Required. A list of service names.
 	// Exact match, prefix match, and suffix match are supported for service names.
 	// For example, the service name "bookstore.mtv.cluster.local" matches
-	// "bookstore.mtv.cluster.local" (exact match), or "bookstore*" (prefix match),
-	// or "*.mtv.cluster.local" (suffix match).
-	// If set to ["*"], it refers to all services in the namespace.
+	// "bookstore.mtv.cluster.local" (exact match), or "bookstore\*" (prefix match),
+	// or "\*.mtv.cluster.local" (suffix match).
+	// If set to ["\*"], it refers to all services in the namespace.
 	Services []string `protobuf:"bytes,1,rep,name=services,proto3" json:"services,omitempty"`
 	// $hide_from_docs
 	// Optional. A list of HTTP hosts. This is matched against the HOST header in
 	// a HTTP request. Exact match, prefix match and suffix match are supported.
 	// For example, the host "test.abc.com" matches "test.abc.com" (exact match),
-	// or "*.abc.com" (prefix match), or "test.abc.*" (suffix match).
+	// or "\*.abc.com" (prefix match), or "test.abc.\*" (suffix match).
 	// If not specified, it matches to any host.
 	// This field should not be set for TCP services. The policy will be ignored.
 	Hosts []string `protobuf:"bytes,5,rep,name=hosts,proto3" json:"hosts,omitempty"`
@@ -233,7 +233,7 @@ type AccessRule struct {
 	// "/packageName.serviceName/methodName" and are case sensitive.
 	// Exact match, prefix match, and suffix match are supported. For example,
 	// the path "/books/review" matches "/books/review" (exact match),
-	// or "/books/*" (prefix match), or "*/review" (suffix match).
+	// or "/books/\*" (prefix match), or "\*/review" (suffix match).
 	// If not specified, it matches to any path.
 	// This field should not be set for TCP services. The policy will be ignored.
 	Paths []string `protobuf:"bytes,2,rep,name=paths,proto3" json:"paths,omitempty"`
@@ -241,7 +241,7 @@ type AccessRule struct {
 	// Optional. A list of HTTP paths or gRPC methods that must not be matched.
 	NotPaths []string `protobuf:"bytes,7,rep,name=not_paths,json=notPaths,proto3" json:"not_paths,omitempty"`
 	// Optional. A list of HTTP methods (e.g., "GET", "POST").
-	// If not specified or specified as "*", it matches to any methods.
+	// If not specified or specified as "\*", it matches to any methods.
 	// This field should not be set for TCP services. The policy will be ignored.
 	// For gRPC services, only `POST` is allowed; other methods will result in denying services.
 	Methods []string `protobuf:"bytes,3,rep,name=methods,proto3" json:"methods,omitempty"`
@@ -375,7 +375,7 @@ type AccessRule_Constraint struct {
 	// List of valid values for the constraint.
 	// Exact match, prefix match, and suffix match are supported.
 	// For example, the value "v1alpha2" matches "v1alpha2" (exact match),
-	// or "v1*" (prefix match), or "*alpha2" (suffix match).
+	// or "v1\*" (prefix match), or "\*alpha2" (suffix match).
 	Values               []string `protobuf:"bytes,2,rep,name=values,proto3" json:"values,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -556,7 +556,7 @@ type Subject struct {
 	User string `protobuf:"bytes,1,opt,name=user,proto3" json:"user,omitempty"`
 	// $hide_from_docs
 	// Optional. A list of subject names. This is matched to the
-	// `source.principal` attribute. If one of subject names is "*", it matches to a subject with any name.
+	// `source.principal` attribute. If one of subject names is "\*", it matches to a subject with any name.
 	// Prefix and suffix matches are supported.
 	Names []string `protobuf:"bytes,4,rep,name=names,proto3" json:"names,omitempty"`
 	// $hide_from_docs

--- a/rbac/v1alpha1/rbac.proto
+++ b/rbac/v1alpha1/rbac.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 // the following standard fields:
 //
 //   * services: a list of services.
-//   * methods: A list of HTTP methods. You can set the value to `*` to include all HTTP methods.
+//   * methods: A list of HTTP methods. You can set the value to `\*` to include all HTTP methods.
 //              This field should not be set for TCP services. The policy will be ignored.
 //              For gRPC services, only `POST` is allowed; other methods will result in denying services.
 //   * paths: HTTP paths or gRPC methods. Note that gRPC methods should be
@@ -97,16 +97,16 @@ message AccessRule {
   // Required. A list of service names.
   // Exact match, prefix match, and suffix match are supported for service names.
   // For example, the service name "bookstore.mtv.cluster.local" matches
-  // "bookstore.mtv.cluster.local" (exact match), or "bookstore*" (prefix match),
-  // or "*.mtv.cluster.local" (suffix match).
-  // If set to ["*"], it refers to all services in the namespace.
+  // "bookstore.mtv.cluster.local" (exact match), or "bookstore\*" (prefix match),
+  // or "\*.mtv.cluster.local" (suffix match).
+  // If set to ["\*"], it refers to all services in the namespace.
   repeated string services = 1;
 
   // $hide_from_docs
   // Optional. A list of HTTP hosts. This is matched against the HOST header in
   // a HTTP request. Exact match, prefix match and suffix match are supported.
   // For example, the host "test.abc.com" matches "test.abc.com" (exact match),
-  // or "*.abc.com" (prefix match), or "test.abc.*" (suffix match).
+  // or "\*.abc.com" (prefix match), or "test.abc.\*" (suffix match).
   // If not specified, it matches to any host.
   // This field should not be set for TCP services. The policy will be ignored.
   repeated string hosts = 5;
@@ -120,7 +120,7 @@ message AccessRule {
   // "/packageName.serviceName/methodName" and are case sensitive.
   // Exact match, prefix match, and suffix match are supported. For example,
   // the path "/books/review" matches "/books/review" (exact match),
-  // or "/books/*" (prefix match), or "*/review" (suffix match).
+  // or "/books/\*" (prefix match), or "\*/review" (suffix match).
   // If not specified, it matches to any path.
   // This field should not be set for TCP services. The policy will be ignored.
   repeated string paths = 2;
@@ -130,7 +130,7 @@ message AccessRule {
   repeated string not_paths = 7;
 
   // Optional. A list of HTTP methods (e.g., "GET", "POST").
-  // If not specified or specified as "*", it matches to any methods.
+  // If not specified or specified as "\*", it matches to any methods.
   // This field should not be set for TCP services. The policy will be ignored.
   // For gRPC services, only `POST` is allowed; other methods will result in denying services.
   repeated string methods = 3;
@@ -159,7 +159,7 @@ message AccessRule {
     // List of valid values for the constraint.
     // Exact match, prefix match, and suffix match are supported.
     // For example, the value "v1alpha2" matches "v1alpha2" (exact match),
-    // or "v1*" (prefix match), or "*alpha2" (suffix match).
+    // or "v1\*" (prefix match), or "\*alpha2" (suffix match).
     repeated string values = 2;
   }
 
@@ -246,7 +246,7 @@ message Subject {
 
   // $hide_from_docs
   // Optional. A list of subject names. This is matched to the
-  // `source.principal` attribute. If one of subject names is "*", it matches to a subject with any name.
+  // `source.principal` attribute. If one of subject names is "\*", it matches to a subject with any name.
   // Prefix and suffix matches are supported.
   repeated string names = 4;
 


### PR DESCRIPTION
Typo fix for `*`s not displayed correctly because they are treated as italic markers.