### PR TITLE
Fix typo

### DIFF
--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -242,7 +242,7 @@ message MeshConfig {
   bool sds_use_k8s_sa_jwt = 29;
 
   // The trust domain corresponds to the trust root of a system.
-  // Refer to [SPIFEE-ID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain)
+  // Refer to [SPIFFE-ID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain)
   // Fallback to old identity format(without trust domain) if not set.
   string trust_domain = 26;
 

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -308,7 +308,7 @@ import "networking/v1alpha3/gateway.proto";
 //
 // The following example illustrates the usage of a `ServiceEntry`
 // containing a subject alternate name
-// whose format conforms to the [SPIFEE standard](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md):
+// whose format conforms to the [SPIFFE standard](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md):
 //
 // ```yaml
 // apiVersion: networking.istio.io/v1alpha3


### PR DESCRIPTION
Correct the word.  (s/SPIFEE/SPIFFE/)

https://spiffe.io/spiffe/