### PR TITLE
fix the sidecar egress order in the example

### DIFF
--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -95,14 +95,14 @@ spec:
       name: somename
     defaultEndpoint: unix:///var/run/someuds.sock
   egress:
+  - hosts:
+    - &quot;istio-system/*&quot;  
   - port:
       number: 9080
       protocol: HTTP
       name: egresshttp
     hosts:
-    - &quot;prod-us1/*&quot;
-  - hosts:
-    - &quot;istio-system/*&quot;    
+    - &quot;prod-us1/*&quot; 
 </code></pre>
 
 <p>If the workload is deployed without IPTables based traffic capture, the

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -96,13 +96,13 @@ spec:
     defaultEndpoint: unix:///var/run/someuds.sock
   egress:
   - hosts:
-    - &quot;istio-system/*&quot;  
+    - &quot;istio-system/*&quot;
   - port:
       number: 9080
       protocol: HTTP
       name: egresshttp
     hosts:
-    - &quot;prod-us1/*&quot; 
+    - &quot;prod-us1/*&quot;
 </code></pre>
 
 <p>If the workload is deployed without IPTables based traffic capture, the

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -95,14 +95,14 @@ spec:
       name: somename
     defaultEndpoint: unix:///var/run/someuds.sock
   egress:
-  - hosts:
-    - &quot;istio-system/*&quot;
   - port:
       number: 9080
       protocol: HTTP
       name: egresshttp
     hosts:
     - &quot;prod-us1/*&quot;
+  - hosts:
+    - &quot;istio-system/*&quot;    
 </code></pre>
 
 <p>If the workload is deployed without IPTables based traffic capture, the

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -112,14 +112,14 @@ import "networking/v1alpha3/gateway.proto";
 //       name: somename
 //     defaultEndpoint: unix:///var/run/someuds.sock
 //   egress:
-//   - hosts:
-//     - "istio-system/*"
 //   - port:
 //       number: 9080
 //       protocol: HTTP
 //       name: egresshttp
 //     hosts:
 //     - "prod-us1/*"
+//   - hosts:
+//     - "istio-system/*"
 // ```
 //
 // If the workload is deployed without IPTables based traffic capture, the


### PR DESCRIPTION
The sidecar config caused the following error when I applied it.
	* sidecar: the egress listener with empty port should be the last listener in the list