### PR TITLE
Typo fix for config.proto

### DIFF
--- a/mesh/v1alpha1/config.pb.go
+++ b/mesh/v1alpha1/config.pb.go
@@ -225,7 +225,7 @@ type MeshConfig struct {
 	// If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
 	TcpKeepalive *v1alpha3.ConnectionPoolSettings_TCPSettings_TcpKeepalive `protobuf:"bytes,28,opt,name=tcp_keepalive,json=tcpKeepalive,proto3" json:"tcp_keepalive,omitempty"`
 	// Class of ingress resources to be processed by Istio ingress
-	// controller.  This corresponds to the value of
+	// controller. This corresponds to the value of
 	// "kubernetes.io/ingress.class" annotation.
 	IngressClass string `protobuf:"bytes,7,opt,name=ingress_class,json=ingressClass,proto3" json:"ingress_class,omitempty"`
 	// Name of theKubernetes service used for the istio ingress controller.
@@ -269,7 +269,7 @@ type MeshConfig struct {
 	// dependencies, instead of using allow_any, so that traffic to these
 	// services can be monitored.
 	OutboundTrafficPolicy *MeshConfig_OutboundTrafficPolicy `protobuf:"bytes,17,opt,name=outbound_traffic_policy,json=outboundTrafficPolicy,proto3" json:"outbound_traffic_policy,omitempty"`
-	// Enables clide side policy checks.
+	// Enables client side policy checks.
 	EnableClientSidePolicyCheck bool `protobuf:"varint,19,opt,name=enable_client_side_policy_check,json=enableClientSidePolicyCheck,proto3" json:"enable_client_side_policy_check,omitempty"`
 	// Unix Domain Socket through which Envoy communicates with NodeAgent SDS to get key/cert for mTLS.
 	// Use secret-mount files instead of SDS if set to empty.

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -89,7 +89,7 @@ message MeshConfig {
   istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.TcpKeepalive tcp_keepalive = 28;
 
   // Class of ingress resources to be processed by Istio ingress
-  // controller.  This corresponds to the value of
+  // controller. This corresponds to the value of
   // "kubernetes.io/ingress.class" annotation.
   string ingress_class = 7;
 
@@ -195,7 +195,7 @@ message MeshConfig {
 
   reserved 18;
 
-  // Enables clide side policy checks.
+  // Enables client side policy checks.
   bool enable_client_side_policy_check = 19;
 
   // Unix Domain Socket through which Envoy communicates with NodeAgent SDS to get key/cert for mTLS.

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.json
@@ -106,7 +106,7 @@
             "format": "string"
           },
           "enableClientSidePolicyCheck": {
-            "description": "Enables clide side policy checks.",
+            "description": "Enables client side policy checks.",
             "type": "boolean"
           },
           "sdsUdsPath": {

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -375,7 +375,7 @@ for the client to send the first bits of data. (MUST BE &gt;=1ms)</p>
 <td><code>string</code></td>
 <td>
 <p>Class of ingress resources to be processed by Istio ingress
-controller.  This corresponds to the value of
+controller. This corresponds to the value of
 &ldquo;kubernetes.io/ingress.class&rdquo; annotation.</p>
 
 </td>
@@ -473,7 +473,7 @@ services can be monitored.</p>
 <td><code>enableClientSidePolicyCheck</code></td>
 <td><code>bool</code></td>
 <td>
-<p>Enables clide side policy checks.</p>
+<p>Enables client side policy checks.</p>
 
 </td>
 </tr>


### PR DESCRIPTION
Typo fix for config.proto, this PR is to fix the automatically-generated [PR](https://github.com/istio/api/pull/1071)