### PR TITLE
refine NetworkEndpoints fromRegistry description

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -850,7 +850,7 @@ inside a mesh and how to route to endpoints in each network. For example</p>
 <pre><code class="language-yaml">networks:
   network1:
   - endpoints:
-    - fromRegistry: registry1 #must match secret name in Kubernetes
+    - fromRegistry: registry1 #must match kubeconfig name in Kubernetes secret
     - fromCidr: 192.168.100.0/22 #a VM network for example
     gateways:
     - registryServiceName: istio-ingressgateway.istio-system.svc.cluster.local
@@ -1025,8 +1025,8 @@ ranges for endpoints from different networks must not overlap.</p>
 <td><code>string (oneof)</code></td>
 <td>
 <p>Add all endpoints from the specified registry into this network.
-The names of the registries should correspond to the secret name
-that was used to configure the registry (Kubernetes multicluster) or
+The names of the registries should correspond to the kubeconfig file name
+inside the secret that was used to configure the registry (Kubernetes multicluster) or
 supplied by MCP server.</p>
 
 </td>


### PR DESCRIPTION
Description in Network.NetworkEndpoints field fromRegistry is misleading by guiding to use a Kubernetes secret name rather than a kubeconfig filename used as a data key inside the secret.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Make-up for #4880