### PR TITLE
refine NetworkEndpoints fromRegistry field description

### DIFF
--- a/mesh/v1alpha1/network.proto
+++ b/mesh/v1alpha1/network.proto
@@ -51,9 +51,9 @@ message Network {
     string from_cidr = 1;
 
     // Add all endpoints from the specified registry into this network.
-    // The names of the registries should correspond to the secret name
-    // that was used to configure the registry (Kubernetes multicluster) or
-    // supplied by MCP server.
+    // The names of the registries should correspond to the kubeconfig file name
+    // inside the secret that was used to configure the registry (Kubernetes
+    // multicluster) or supplied by MCP server.
     string from_registry = 2;
     }
   }
@@ -101,7 +101,7 @@ message Network {
 // networks:
 //   network1:
 //   - endpoints:
-//     - fromRegistry: registry1 #must match secret name in Kubernetes
+//     - fromRegistry: registry1 #must match kubeconfig name in Kubernetes secret
 //     - fromCidr: 192.168.100.0/22 #a VM network for example
 //     gateways:
 //     - registryServiceName: istio-ingressgateway.istio-system.svc.cluster.local


### PR DESCRIPTION
Description in Network.NetworkEndpoints field fromRegistry is misleading by guiding to use a Kubernetes secret name rather than a kubeconfig filename used as a data key inside the secret.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Make-up for #4880 and #1076