### PR TITLE
Add the traffic.istio.io/locality annotation

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -327,6 +327,14 @@ var (
           Deprecated: false,
         }
 	
+		TrafficLocality = Instance {
+          Name: "traffic.istio.io/locality",
+          Description: "Specifies the component locality in the "+
+                        "region/zone/sub_zone format.",
+          Hidden: true,
+          Deprecated: false,
+        }
+	
 		SidecarTrafficExcludeInboundPorts = Instance {
           Name: "traffic.sidecar.istio.io/excludeInboundPorts",
           Description: "A comma separated list of inbound ports to be excluded "+

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -294,6 +294,8 @@ Istio supports to control its behavior.
 			
 		
 			
+		
+			
 				
 					<tr>
 				

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -168,6 +168,10 @@ annotations:
       to receive traffic.
     deprecated: false
     hidden: false
+  - name: traffic.istio.io/locality
+    description: Specifies the component locality in the region/zone/sub_zone format.
+    deprecated: false
+    hidden: true
   - name: traffic.sidecar.istio.io/includeOutboundIPRanges
     description: A comma separated list of IP ranges in CIDR form to redirect to envoy
       (optional). The wildcard character '*' can be used to redirect all outbound traffic.


### PR DESCRIPTION
This adds a new `traffic.istio.io/locality` annotation which will allow users to configure the locality of sidecars and other components (egress gateway, etc.). Currently, this functionality is achieved by applying the `istio-locality` label on sidecars, and by additionally setting the `ISTIO_META_istio-locality` environment variable on egress gateways. The label only supports values in the `region.zone.sub_zone` format while this annotation will allow users to configure locality in the well-known `region/zone/sub_zone` format.

/cc @istio/wg-networking-maintainers 