### PR TITLE
Use different example in api guidelines

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -35,7 +35,7 @@ This section captures guidelines that apply to the proto form of the configurati
 - **Prefer** complete words for file names.
 
     ```
-    config.proto // Not cfg.proto!
+    index.proto // Not idx.proto!
     ```
 
 #### Package Names


### PR DESCRIPTION
"Config" is short for "configuration" which confused me for a bit. I
think having a more obvious example will help not distract readers from
the point of this guideline.