### PR TITLE
Add istio api extensions definitions

### DIFF
--- a/extensions/field_rules.proto
+++ b/extensions/field_rules.proto
@@ -1,0 +1,71 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.extensions;
+
+option go_package="istio.io/api/extensions";
+
+import "google/protobuf/descriptor.proto";
+
+// Values applied at the field level.
+extend google.protobuf.FieldOptions {
+    FieldRules rules = 1200;
+}
+
+// Field rules for a particular type.
+// Currently only primitive types of OpenAPI schemas are included. (https://swagger.io/docs/specification/data-models/data-types)
+message FieldRules {
+    oneof type {
+        FloatRules float = 1;
+        DoubleRules double = 2;
+        StringRules string = 3;
+        BoolRules bool = 4;
+        Int32Rules int32 = 5;
+        Int64Rules int64 = 6;  
+    }
+}
+
+// FloatRules describe the rules for the float type.
+message FloatRules {
+    float default = 1;
+}
+
+// DoubleRules describe the rules for the double type.
+message DoubleRules {
+    double default = 1;
+}
+
+// StringRules describe the rules for the string type.
+message StringRules {
+    string default = 1;
+    // The regular expression the field must match against (RE2 syntax).
+    string pattern = 2;
+}
+
+// BoolRules describe the rules for the bool type.
+message BoolRules {
+    bool default = 1;
+}
+
+// Int32Rules describe the rules for the int32 type.
+message Int32Rules {
+    int32 default = 1;
+}
+
+// Int64Rules describe the rules for the int64 type.
+message Int64Rules {
+    int64 default = 1;
+}


### PR DESCRIPTION
Proposing some extensions for Istio API protos. With these extensions, we are able to specify additional rules to the API fields. e.g.

``` protobuf
message Destination {
...
string subset = 2 [(extension.rules).string.pattern = "^[a-zA-Z0-9](?:[-a-z-A-Z0-9]*[a-zA-Z0-9])?$"];
...
}
```

This will allow us to express richer schema syntax, more docs and better API/client tooling.
