### PR TITLE
Update policy.proto

### DIFF
--- a/authentication/v1alpha1/policy.proto
+++ b/authentication/v1alpha1/policy.proto
@@ -53,7 +53,7 @@ message MutualTls {
     // Client cert must be presented, connection is in TLS.
     STRICT = 0;
 
-    // Connection can be either plaintext or TLS, and client cert can be omitted.
+    // Connection can be either plaintext or TLS with Client cert.
     PERMISSIVE = 1;
   };
 


### PR DESCRIPTION
Even with permissive mode, the filter chain adds "require_client_certificate": true" and required you to pass client cert.