### PR TITLE
Even with permissive mode, the TLS require client cert

### DIFF
--- a/authentication/v1alpha1/istio.authentication.v1alpha1.pb.html
+++ b/authentication/v1alpha1/istio.authentication.v1alpha1.pb.html
@@ -305,7 +305,7 @@ No
 <tr id="MutualTls-Mode-PERMISSIVE">
 <td><code>PERMISSIVE</code></td>
 <td>
-<p>Connection can be either plaintext or TLS, and client cert can be omitted.</p>
+<p>Connection can be either plaintext or TLS with Client cert.</p>
 
 </td>
 </tr>

--- a/authentication/v1alpha1/policy.pb.go
+++ b/authentication/v1alpha1/policy.pb.go
@@ -59,7 +59,7 @@ type MutualTls_Mode int32
 const (
 	// Client cert must be presented, connection is in TLS.
 	MutualTls_STRICT MutualTls_Mode = 0
-	// Connection can be either plaintext or TLS, and client cert can be omitted.
+	// Connection can be either plaintext or TLS with Client cert.
 	MutualTls_PERMISSIVE MutualTls_Mode = 1
 )
 

--- a/authentication/v1alpha1/policy.proto
+++ b/authentication/v1alpha1/policy.proto
@@ -53,7 +53,7 @@ message MutualTls {
     // Client cert must be presented, connection is in TLS.
     STRICT = 0;
 
-    // Connection can be either plaintext or TLS, and client cert can be omitted.
+    // Connection can be either plaintext or TLS with Client cert.
     PERMISSIVE = 1;
   };
 

--- a/proto.lock
+++ b/proto.lock
@@ -35275,6 +35275,137 @@
       }
     },
     {
+      "protopath": "extensions:/:field_rules.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "google.protobuf.FieldOptions",
+            "fields": [
+              {
+                "id": 1200,
+                "name": "rules",
+                "type": "FieldRules"
+              }
+            ]
+          },
+          {
+            "name": "FieldRules",
+            "fields": [
+              {
+                "id": 1,
+                "name": "float",
+                "type": "FloatRules"
+              },
+              {
+                "id": 2,
+                "name": "double",
+                "type": "DoubleRules"
+              },
+              {
+                "id": 3,
+                "name": "string",
+                "type": "StringRules"
+              },
+              {
+                "id": 4,
+                "name": "bool",
+                "type": "BoolRules"
+              },
+              {
+                "id": 5,
+                "name": "int32",
+                "type": "Int32Rules"
+              },
+              {
+                "id": 6,
+                "name": "int64",
+                "type": "Int64Rules"
+              }
+            ]
+          },
+          {
+            "name": "FloatRules",
+            "fields": [
+              {
+                "id": 1,
+                "name": "default",
+                "type": "float"
+              }
+            ]
+          },
+          {
+            "name": "DoubleRules",
+            "fields": [
+              {
+                "id": 1,
+                "name": "default",
+                "type": "double"
+              }
+            ]
+          },
+          {
+            "name": "StringRules",
+            "fields": [
+              {
+                "id": 1,
+                "name": "default",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "pattern",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "BoolRules",
+            "fields": [
+              {
+                "id": 1,
+                "name": "default",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "Int32Rules",
+            "fields": [
+              {
+                "id": 1,
+                "name": "default",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "Int64Rules",
+            "fields": [
+              {
+                "id": 1,
+                "name": "default",
+                "type": "int64"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "google/protobuf/descriptor.proto"
+          }
+        ],
+        "package": {
+          "name": "istio.extensions"
+        },
+        "options": [
+          {
+            "name": "go_package",
+            "value": "istio.io/api/extensions"
+          }
+        ]
+      }
+    },
+    {
       "protopath": "mcp:/:v1alpha1:/:mcp.proto",
       "def": {
         "messages": [
@@ -40312,7 +40443,18 @@
               {
                 "id": 18,
                 "name": "mirror_percent",
-                "type": "google.protobuf.UInt32Value"
+                "type": "google.protobuf.UInt32Value",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "id": 19,
+                "name": "mirror_percentage",
+                "type": "Percent"
               },
               {
                 "id": 10,


### PR DESCRIPTION
Even with permissive mode, the filter chain adds "require_client_certificate": true" and required you to pass client cert.

@rshriram pls review 