### PR TITLE
Remove incorrect escape character.

### DIFF
--- a/rbac/v1alpha1/istio.rbac.v1alpha1.pb.html
+++ b/rbac/v1alpha1/istio.rbac.v1alpha1.pb.html
@@ -22,7 +22,7 @@ the following standard fields:</p>
 
 <ul>
 <li>services: a list of services.</li>
-<li>methods: A list of HTTP methods. You can set the value to <code>\*</code> to include all HTTP methods.
+<li>methods: A list of HTTP methods. You can set the value to <code>[&quot;*&quot;]</code> to include all HTTP methods.
          This field should not be set for TCP services. The policy will be ignored.
          For gRPC services, only <code>POST</code> is allowed; other methods will result in denying services.</li>
 <li>paths: HTTP paths or gRPC methods. Note that gRPC methods should be

--- a/rbac/v1alpha1/rbac.pb.go
+++ b/rbac/v1alpha1/rbac.pb.go
@@ -11,7 +11,7 @@
 // the following standard fields:
 //
 //   * services: a list of services.
-//   * methods: A list of HTTP methods. You can set the value to `\*` to include all HTTP methods.
+//   * methods: A list of HTTP methods. You can set the value to `["*"]` to include all HTTP methods.
 //              This field should not be set for TCP services. The policy will be ignored.
 //              For gRPC services, only `POST` is allowed; other methods will result in denying services.
 //   * paths: HTTP paths or gRPC methods. Note that gRPC methods should be

--- a/rbac/v1alpha1/rbac.proto
+++ b/rbac/v1alpha1/rbac.proto
@@ -35,7 +35,7 @@ import "google/api/field_behavior.proto";
 // the following standard fields:
 //
 //   * services: a list of services.
-//   * methods: A list of HTTP methods. You can set the value to `\*` to include all HTTP methods.
+//   * methods: A list of HTTP methods. You can set the value to `["*"]` to include all HTTP methods.
 //              This field should not be set for TCP services. The policy will be ignored.
 //              For gRPC services, only `POST` is allowed; other methods will result in denying services.
 //   * paths: HTTP paths or gRPC methods. Note that gRPC methods should be

--- a/rbac/v1alpha1/rbac_deepcopy.gen.go
+++ b/rbac/v1alpha1/rbac_deepcopy.gen.go
@@ -11,7 +11,7 @@
 // the following standard fields:
 //
 //   * services: a list of services.
-//   * methods: A list of HTTP methods. You can set the value to `\*` to include all HTTP methods.
+//   * methods: A list of HTTP methods. You can set the value to `["*"]` to include all HTTP methods.
 //              This field should not be set for TCP services. The policy will be ignored.
 //              For gRPC services, only `POST` is allowed; other methods will result in denying services.
 //   * paths: HTTP paths or gRPC methods. Note that gRPC methods should be

--- a/rbac/v1alpha1/rbac_json.gen.go
+++ b/rbac/v1alpha1/rbac_json.gen.go
@@ -11,7 +11,7 @@
 // the following standard fields:
 //
 //   * services: a list of services.
-//   * methods: A list of HTTP methods. You can set the value to `\*` to include all HTTP methods.
+//   * methods: A list of HTTP methods. You can set the value to `["*"]` to include all HTTP methods.
 //              This field should not be set for TCP services. The policy will be ignored.
 //              For gRPC services, only `POST` is allowed; other methods will result in denying services.
 //   * paths: HTTP paths or gRPC methods. Note that gRPC methods should be


### PR DESCRIPTION
Also add full syntax for the YAML value, to remove ambiguity.