### PR TITLE
Fix link to attribute vocabulary

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -43851,6 +43851,11 @@
                 "id": 8,
                 "name": "output_payload_to_header",
                 "type": "string"
+              },
+              {
+                "id": 9,
+                "name": "forward_original_token",
+                "type": "bool"
               }
             ]
           },

--- a/security/v1beta1/authorization.gen.json
+++ b/security/v1beta1/authorization.gen.json
@@ -72,7 +72,7 @@
         "type": "object",
         "properties": {
           "key": {
-            "description": "The name of an Istio attribute. See the [full list of supported attributes](https://istio.io/docs/reference/config/).",
+            "description": "The name of an Istio attribute. See the [full list of supported attributes](https://istio.io/docs/reference/config/policy-and-telemetry/attribute-vocabulary/).",
             "type": "string",
             "format": "string"
           },

--- a/security/v1beta1/authorization.pb.go
+++ b/security/v1beta1/authorization.pb.go
@@ -589,7 +589,7 @@ func (m *Operation) GetPaths() []string {
 // Condition specifies additional required attributes.
 type Condition struct {
 	// The name of an Istio attribute.
-	// See the [full list of supported attributes](https://istio.io/docs/reference/config/).
+	// See the [full list of supported attributes](https://istio.io/docs/reference/config/policy-and-telemetry/attribute-vocabulary/).
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// The allowed values for the attribute.
 	Values               []string `protobuf:"bytes,2,rep,name=values,proto3" json:"values,omitempty"`

--- a/security/v1beta1/authorization.pb.html
+++ b/security/v1beta1/authorization.pb.html
@@ -195,7 +195,7 @@ No
 <td><code>string</code></td>
 <td>
 <p>The name of an Istio attribute.
-See the <a href="https://istio.io/docs/reference/config/">full list of supported attributes</a>.</p>
+See the <a href="https://istio.io/docs/reference/config/policy-and-telemetry/attribute-vocabulary/">full list of supported attributes</a>.</p>
 
 </td>
 <td>

--- a/security/v1beta1/authorization.proto
+++ b/security/v1beta1/authorization.proto
@@ -279,7 +279,7 @@ message Operation {
 // Condition specifies additional required attributes.
 message Condition {
   // The name of an Istio attribute.
-  // See the [full list of supported attributes](https://istio.io/docs/reference/config/).
+  // See the [full list of supported attributes](https://istio.io/docs/reference/config/policy-and-telemetry/attribute-vocabulary/).
   string key = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The allowed values for the attribute.


### PR DESCRIPTION
Fix the link to the attribute vocabulary from the Authorization Policy Conditions.