### PR TITLE
Add annotation for suppressing analyzer messages per-resource

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -79,6 +79,21 @@ var (
 		  Resources: []ResourceTypes{ Service, },
         }
 	
+		GalleyAnalyzeSuppress = Instance {
+          Name: "galley.istio.io/analyze-suppress",
+          Description: "A comma separated list of configuration analysis message "+
+                        "codes to suppress when Istio analyzers are run. For "+
+                        "example, to suppress reporting of IST0103 "+
+                        "(PodMissingProxy) and IST0108 (UnknownAnnotation) on a "+
+                        "resource, apply the annotation "+
+                        "'galley.istio.io/analyze-suppress=IST0108,IST0103'. If "+
+                        "the value is '*', then all configuration analysis "+
+                        "messages are suppressed.",
+          Hidden: false,
+          Deprecated: false,
+		  Resources: []ResourceTypes{ Any, },
+        }
+	
 		OperatorInstallChartOwner = Instance {
           Name: "install.operator.istio.io/chart-owner",
           Description: "Represents the name of the chart used to create this "+
@@ -494,6 +509,7 @@ func AllResourceAnnotations() []*Instance {
 		&AlphaCanonicalServiceAccounts,
 		&AlphaIdentity,
 		&AlphaKubernetesServiceAccounts,
+		&GalleyAnalyzeSuppress,
 		&OperatorInstallChartOwner,
 		&OperatorInstallOwnerGeneration,
 		&OperatorInstallVersion,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -29,6 +29,16 @@ Istio supports to control its behavior.
 				
 					<tr>
 				
+					<td><code>galley.istio.io/analyze-suppress</code></td>
+					<td>[Any]</td>
+					<td>A comma separated list of configuration analysis message codes to suppress when Istio analyzers are run. For example, to suppress reporting of IST0103 (PodMissingProxy) and IST0108 (UnknownAnnotation) on a resource, apply the annotation 'galley.istio.io/analyze-suppress=IST0108,IST0103'. If the value is '*', then all configuration analysis messages are suppressed.</td>
+				</tr>
+			
+		
+			
+				
+					<tr>
+				
 					<td><code>install.operator.istio.io/chart-owner</code></td>
 					<td>[Any]</td>
 					<td>Represents the name of the chart used to create this resource.</td>

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -336,3 +336,14 @@ annotations:
     hidden: false
     resources:
       - Any
+  - name: galley.istio.io/analyze-suppress
+    description: A comma separated list of configuration analysis message codes
+      to suppress when Istio analyzers are run. For example, to suppress
+      reporting of IST0103 (PodMissingProxy) and IST0108 (UnknownAnnotation) on
+      a resource, apply the annotation
+      'galley.istio.io/analyze-suppress=IST0108,IST0103'. If the value is '*',
+      then all configuration analysis messages are suppressed.
+    deprecated: false
+    hidden: false
+    resources:
+      - Any


### PR DESCRIPTION
Note that this is slightly different than the annotation originally decided in https://docs.google.com/document/d/1r1hOBIwkDesZ8vYaHMj2YThEcUxegB-fLMPBst_yXIU/edit#heading=h.xw1gqgyqs5b. Originally the annotation was called `galley.istio.io/noanalyze`, but I was worried that the name itself might be potentially confusing (for example, the presence of this annotation appears to imply that the resource is never analyzed, rather than a specific list of codes).

Due to this change i've added approvers from the doc as approvers on this PR as well.

