### PR TITLE
Making `tls_settings` use code font.

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -771,7 +771,7 @@
         }
       },
       "istio.networking.v1alpha3.TLSSettings": {
-        "description": "Use the tls_settings to specify the tls mode to use. If the remote service uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS mode as `ISTIO_MUTUAL`.",
+        "description": "Use the `tls_settings` to specify the TLS mode to use. If the remote service uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS mode as `ISTIO_MUTUAL`.",
         "type": "object",
         "properties": {
           "mode": {

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -1506,7 +1506,7 @@ No
 <td><code>tlsSettings</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/networking/destination-rule.html#TLSSettings">TLSSettings</a></code></td>
 <td>
-<p>Use the tls_settings to specify the tls mode to use. If the remote service
+<p>Use the <code>tls_settings</code> to specify the TLS mode to use. If the remote service
 uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS
 mode as <code>ISTIO_MUTUAL</code>.</p>
 

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -825,7 +825,7 @@ type RemoteService struct {
 	// receiver, metrics receiver, etc.). Can be IP address or a fully
 	// qualified DNS name.
 	Address string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
-	// Use the tls_settings to specify the tls mode to use. If the remote service
+	// Use the `tls_settings` to specify the TLS mode to use. If the remote service
 	// uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS
 	// mode as `ISTIO_MUTUAL`.
 	TlsSettings *v1alpha3.TLSSettings `protobuf:"bytes,2,opt,name=tls_settings,json=tlsSettings,proto3" json:"tls_settings,omitempty"`

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -237,7 +237,7 @@ message RemoteService {
   // qualified DNS name.
   string address = 1;
 
-  // Use the tls_settings to specify the tls mode to use. If the remote service
+  // Use the `tls_settings` to specify the TLS mode to use. If the remote service
   // uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS
   // mode as `ISTIO_MUTUAL`.
   istio.networking.v1alpha3.TLSSettings tls_settings = 2;


### PR DESCRIPTION
The underscore get's interpreted as "start italics". [See][1]

![Screen Shot 2020-02-10 at 2 20 25 PM](https://user-images.githubusercontent.com/520669/74195642-8c953d80-4c10-11ea-8dcf-64247865d472.png)

[1]: https://istio.io/docs/reference/config/istio.mesh.v1alpha1/