### PR TITLE
Deprecate authentication alpha policy

### DIFF
--- a/authentication/v1alpha1/istio.authentication.v1alpha1.gen.json
+++ b/authentication/v1alpha1/istio.authentication.v1alpha1.gen.json
@@ -61,7 +61,7 @@
         ]
       },
       "istio.authentication.v1alpha1.MutualTls": {
-        "description": "TLS authentication params.",
+        "description": "Deprecated. Please use security/v1beta1/PeerAuthentication instead. TLS authentication params.",
         "type": "object",
         "properties": {
           "allowTls": {
@@ -155,7 +155,7 @@
         }
       },
       "istio.authentication.v1alpha1.PeerAuthenticationMethod": {
-        "description": "PeerAuthenticationMethod defines one particular type of authentication. Only mTLS is supported at the moment. The type can be progammatically determine by checking the type of the \"params\" field.",
+        "description": "Deprecated. Please use security/v1beta1/PeerAuthentication instead. PeerAuthenticationMethod defines one particular type of authentication. Only mTLS is supported at the moment. The type can be progammatically determine by checking the type of the \"params\" field.",
         "type": "object",
         "oneOf": [
           {
@@ -211,7 +211,7 @@
             "deprecated": true
           },
           "peers": {
-            "description": "List of authentication methods that can be used for peer authentication. They will be evaluated in order; the first validate one will be used to set peer identity (source.user) and other peer attributes. If none of these methods pass, request will be rejected with authentication failed error (401). Leave the list empty if peer authentication is not required",
+            "description": "Deprecated. Please use security/v1beta1/PeerAuthentication instead. List of authentication methods that can be used for peer authentication. They will be evaluated in order; the first validate one will be used to set peer identity (source.user) and other peer attributes. If none of these methods pass, request will be rejected with authentication failed error (401). Leave the list empty if peer authentication is not required",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/istio.authentication.v1alpha1.PeerAuthenticationMethod"

--- a/authentication/v1alpha1/istio.authentication.v1alpha1.pb.html
+++ b/authentication/v1alpha1/istio.authentication.v1alpha1.pb.html
@@ -7,55 +7,10 @@ generator: protoc-gen-docs
 schema: istio.authentication.v1alpha1.Policy
 weight: 10
 aliases: [/docs/reference/config/istio.authentication.v1alpha1]
-number_of_entries: 4
+number_of_entries: 2
 ---
 <p>This package defines user-facing authentication policy.</p>
 
-<h2 id="MutualTls">MutualTls</h2>
-<section>
-<p>TLS authentication params.</p>
-
-<table class="message-fields">
-<thead>
-<tr>
-<th>Field</th>
-<th>Type</th>
-<th>Description</th>
-<th>Required</th>
-</tr>
-</thead>
-<tbody>
-<tr id="MutualTls-mode">
-<td><code>mode</code></td>
-<td><code><a href="#MutualTls-Mode">Mode</a></code></td>
-<td>
-<p>Defines the mode of mTLS authentication.</p>
-
-</td>
-<td>
-No
-</td>
-</tr>
-<tr id="MutualTls-allow_tls" class="deprecated ">
-<td><code>allowTls</code></td>
-<td><code>bool</code></td>
-<td>
-<p>Deprecated. Please use mode = PERMISSIVE instead.
-If set, will translate to <code>TLS_PERMISSIVE</code> mode.
-Set this flag to true to allow regular TLS (i.e without client x509
-certificate). If request carries client certificate, identity will be
-extracted and used (set to peer identity). Otherwise, peer identity will
-be left unset.
-When the flag is false (default), request must have client certificate.</p>
-
-</td>
-<td>
-No
-</td>
-</tr>
-</tbody>
-</table>
-</section>
 <h2 id="MutualTls-Mode">MutualTls.Mode</h2>
 <section>
 <p>Defines the acceptable connection TLS mode.</p>
@@ -80,37 +35,6 @@ No
 <td>
 <p>Connection can be either plaintext or TLS with Client cert.</p>
 
-</td>
-</tr>
-</tbody>
-</table>
-</section>
-<h2 id="PeerAuthenticationMethod">PeerAuthenticationMethod</h2>
-<section>
-<p>PeerAuthenticationMethod defines one particular type of authentication. Only mTLS is supported
-at the moment.
-The type can be progammatically determine by checking the type of the
-&ldquo;params&rdquo; field.</p>
-
-<table class="message-fields">
-<thead>
-<tr>
-<th>Field</th>
-<th>Type</th>
-<th>Description</th>
-<th>Required</th>
-</tr>
-</thead>
-<tbody>
-<tr id="PeerAuthenticationMethod-mtls" class="oneof oneof-start">
-<td><code>mtls</code></td>
-<td><code><a href="#MutualTls">MutualTls (oneof)</a></code></td>
-<td>
-<p>Set if mTLS is used.</p>
-
-</td>
-<td>
-Yes
 </td>
 </tr>
 </tbody>
@@ -199,21 +123,6 @@ spec:
 </tr>
 </thead>
 <tbody>
-<tr id="Policy-peers">
-<td><code>peers</code></td>
-<td><code><a href="#PeerAuthenticationMethod">PeerAuthenticationMethod[]</a></code></td>
-<td>
-<p>List of authentication methods that can be used for peer authentication.
-They will be evaluated in order; the first validate one will be used to
-set peer identity (source.user) and other peer attributes. If none of
-these methods pass, request will be rejected with authentication failed error (401).
-Leave the list empty if peer authentication is not required</p>
-
-</td>
-<td>
-No
-</td>
-</tr>
 <tr id="Policy-targets" class="deprecated ">
 <td><code>targets</code></td>
 <td><code><a href="#TargetSelector">TargetSelector[]</a></code></td>

--- a/authentication/v1alpha1/policy.pb.go
+++ b/authentication/v1alpha1/policy.pb.go
@@ -200,6 +200,8 @@ func (*StringMatch) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// $hide_from_docs
+// Deprecated. Please use security/v1beta1/PeerAuthentication instead.
 // TLS authentication params.
 type MutualTls struct {
 	// Deprecated. Please use mode = PERMISSIVE instead.
@@ -529,6 +531,8 @@ func (m *Jwt_TriggerRule) GetIncludedPaths() []*StringMatch {
 	return nil
 }
 
+// $hide_from_docs
+// Deprecated. Please use security/v1beta1/PeerAuthentication instead.
 // PeerAuthenticationMethod defines one particular type of authentication. Only mTLS is supported
 // at the moment.
 // The type can be progammatically determine by checking the type of the
@@ -783,6 +787,8 @@ type Policy struct {
 	// List rules to select workloads that the policy should be applied on.
 	// If empty, policy will be used on all workloads in the same namespace.
 	Targets []*TargetSelector `protobuf:"bytes,1,rep,name=targets,proto3" json:"targets,omitempty"` // Deprecated: Do not use.
+	// $hide_from_docs
+	// Deprecated. Please use security/v1beta1/PeerAuthentication instead.
 	// List of authentication methods that can be used for peer authentication.
 	// They will be evaluated in order; the first validate one will be used to
 	// set peer identity (source.user) and other peer attributes. If none of

--- a/authentication/v1alpha1/policy.proto
+++ b/authentication/v1alpha1/policy.proto
@@ -47,6 +47,8 @@ message StringMatch {
   }
 }
 
+// $hide_from_docs
+// Deprecated. Please use security/v1beta1/PeerAuthentication instead.
 // TLS authentication params.
 message MutualTls {
   // Defines the acceptable connection TLS mode.
@@ -223,6 +225,8 @@ message Jwt {
   // Next available field number: 11
 }
 
+// $hide_from_docs
+// Deprecated. Please use security/v1beta1/PeerAuthentication instead.
 // PeerAuthenticationMethod defines one particular type of authentication. Only mTLS is supported
 // at the moment.
 // The type can be progammatically determine by checking the type of the
@@ -370,6 +374,8 @@ message Policy {
   // If empty, policy will be used on all workloads in the same namespace.
   repeated TargetSelector targets = 1 [deprecated=true];
 
+  // $hide_from_docs
+  // Deprecated. Please use security/v1beta1/PeerAuthentication instead.
   // List of authentication methods that can be used for peer authentication.
   // They will be evaluated in order; the first validate one will be used to
   // set peer identity (source.user) and other peer attributes. If none of

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -351,8 +351,6 @@ spec:
               description: Deprecated.
               type: boolean
             peers:
-              description: List of authentication methods that can be used for peer
-                authentication.
               items:
                 oneOf:
                 - required:
@@ -1076,8 +1074,6 @@ spec:
               description: Deprecated.
               type: boolean
             peers:
-              description: List of authentication methods that can be used for peer
-                authentication.
               items:
                 oneOf:
                 - required:


### PR DESCRIPTION
This is replaced by security/v1beta1/peer_authentication.proto