### PR TITLE
add annotation to redirect from destination 127.0.0.1 to local podIP

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -426,6 +426,19 @@ var (
 		  Resources: []ResourceTypes{ Pod, },
         }
 	
+		SidecarTrafficBindPodIPPorts = Instance {
+          Name: "traffic.sidecar.istio.io/bindPodIPPorts",
+          Description: "A Comma separated list of inbound ports for which are "+
+                        "binding to pod IP only. By default, Envoy will redirect "+
+                        "inbound traffic to 127.0.0.1:${port}, if the port is only "+
+                        "bind to pod IP instead of 127.0.0.1, this annotation "+
+                        "should be addressed to redirect 127.0.0.1:${port} to "+
+                        "${podIP}:${port}.",
+          Hidden: false,
+          Deprecated: false,
+		  Resources: []ResourceTypes{ Pod, },
+        }
+	
 		SidecarTrafficExcludeInboundPorts = Instance {
           Name: "traffic.sidecar.istio.io/excludeInboundPorts",
           Description: "A comma separated list of inbound ports to be excluded "+
@@ -530,6 +543,7 @@ func AllResourceAnnotations() []*Instance {
 		&SidecarUserVolume,
 		&SidecarUserVolumeMount,
 		&SidecarStatusPort,
+		&SidecarTrafficBindPodIPPorts,
 		&SidecarTrafficExcludeInboundPorts,
 		&SidecarTrafficExcludeOutboundIPRanges,
 		&SidecarTrafficExcludeOutboundPorts,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -391,6 +391,16 @@ Istio supports to control its behavior.
 				
 					<tr>
 				
+					<td><code>traffic.sidecar.istio.io/bindPodIPPorts</code></td>
+					<td>[Pod]</td>
+					<td>A Comma separated list of inbound ports for which are binding to pod IP only. By default, Envoy will redirect inbound traffic to 127.0.0.1:${port}, if the port is only bind to pod IP instead of 127.0.0.1, this annotation should be addressed to redirect 127.0.0.1:${port} to ${podIP}:${port}.</td>
+				</tr>
+			
+		
+			
+				
+					<tr>
+				
 					<td><code>traffic.sidecar.istio.io/excludeInboundPorts</code></td>
 					<td>[Pod]</td>
 					<td>A comma separated list of inbound ports to be excluded from redirection to Envoy. Only applies when all inbound traffic (i.e. '*') is being redirected.</td>

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -335,3 +335,12 @@ annotations:
     hidden: false
     resources:
       - Any
+  - name: traffic.sidecar.istio.io/bindPodIPPorts
+    description: A Comma separated list of inbound ports for which are binding to pod IP only.
+      By default, Envoy will redirect inbound traffic to 127.0.0.1:${port}, if the port is only bind to
+      pod IP instead of 127.0.0.1, this annotation should be addressed to redirect 127.0.0.1:${port} to
+      ${podIP}:${port}.
+    deprecated: false
+    hidden: false
+    resources:
+      - Pod


### PR DESCRIPTION
There are some services only listen on pod IP in k8s for some reason instead of 0.0.0.0 or 127.0.0.1.
After using istio, the inbound traffic will be intercepted to envoy and redirect to 127.0.0.1, istio assuming that user service should listen on lo address, then the traffic will fail if it is not the truth.

This change introduce an annotation `traffic.sidecar.istio.io/bindPodIPPorts`, istio should handle this annotation and redirect those port's traffic to podIP:port than then 127.0.0.1:port.

Signed-off-by: Lingpeng Chen <forrest0579@gmail.com>