### PR TITLE
[1.5] Fix bug with JSON tag camelCase conversion (#1324)

### DIFF
--- a/operator/fixup_structs/main.go
+++ b/operator/fixup_structs/main.go
@@ -70,6 +70,9 @@ var (
 		"github.com/gogo/protobuf/protobuf/google/protobuf": "github.com/gogo/protobuf/types",
 		goFieldToken: "",
 	}
+
+	regexJSONTag        = regexp.MustCompile(`json\:"[a-z|0-9|_]+,`)
+	regexJSONTagIllegal = regexp.MustCompile(`json\:"_`)
 )
 
 func main() {
@@ -121,8 +124,11 @@ func main() {
 			tmp = append(tmp, lines[i+1])
 			i += 2
 		case strings.Contains(l, goFieldJSONTagPrefix) && strings.Contains(l, "_"):
-			rgx := regexp.MustCompile(`json\:"[a-z|0-9]+_[a-z|0-9]+,`)
-			l = rgx.ReplaceAllStringFunc(l, func(m string) string {
+			if regexJSONTagIllegal.MatchString(l) {
+				fmt.Printf("Illegal leading _ in json field tag: %s\n", l)
+				os.Exit(1) //nolint: gomnd
+			}
+			l = regexJSONTag.ReplaceAllStringFunc(l, func(m string) string {
 				lvs := strings.Split(m, "_")
 				for i, v := range lvs {
 					if i > 0 {

--- a/operator/v1alpha1/component.pb.go
+++ b/operator/v1alpha1/component.pb.go
@@ -435,19 +435,19 @@ type KubernetesResourcesSpec struct {
 	HpaSpec *HorizontalPodAutoscalerSpec `protobuf:"bytes,3,opt,name=hpa_spec,json=hpaSpec,proto3" json:"hpaSpec,omitempty"`
 	// k8s imagePullPolicy.
 	// https://kubernetes.io/docs/concepts/containers/images/
-	ImagePullPolicy string `protobuf:"bytes,4,opt,name=image_pull_policy,json=imagePullPolicy,proto3" json:"image_pull_policy,omitempty"`
+	ImagePullPolicy string `protobuf:"bytes,4,opt,name=image_pull_policy,json=imagePullPolicy,proto3" json:"imagePullPolicy,omitempty"`
 	// k8s nodeSelector.
 	// https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 	NodeSelector map[string]string `protobuf:"bytes,5,rep,name=node_selector,json=nodeSelector,proto3" json:"nodeSelector,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// k8s PodDisruptionBudget settings.
 	// https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#how-disruption-budgets-work
-	PodDisruptionBudget *PodDisruptionBudgetSpec `protobuf:"bytes,6,opt,name=pod_disruption_budget,json=podDisruptionBudget,proto3" json:"pod_disruption_budget,omitempty"`
+	PodDisruptionBudget *PodDisruptionBudgetSpec `protobuf:"bytes,6,opt,name=pod_disruption_budget,json=podDisruptionBudget,proto3" json:"podDisruptionBudget,omitempty"`
 	// k8s pod annotations.
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	PodAnnotations map[string]string `protobuf:"bytes,7,rep,name=pod_annotations,json=podAnnotations,proto3" json:"podAnnotations,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// k8s priority_class_name. Default for all resources unless overridden.
 	// https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-	PriorityClassName string `protobuf:"bytes,8,opt,name=priority_class_name,json=priorityClassName,proto3" json:"priority_class_name,omitempty"`
+	PriorityClassName string `protobuf:"bytes,8,opt,name=priority_class_name,json=priorityClassName,proto3" json:"priorityClassName,omitempty"`
 	// k8s readinessProbe settings.
 	// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 	// k8s.io.api.core.v1.Probe readiness_probe = 9;

--- a/operator/v1alpha1/operator.pb.go
+++ b/operator/v1alpha1/operator.pb.go
@@ -75,7 +75,7 @@ type IstioOperatorSpec struct {
 	Profile string `protobuf:"bytes,10,opt,name=profile,proto3" json:"profile,omitempty"`
 	// Path for the install package. e.g.
 	//     - /tmp/istio-installer/nightly (local file path)
-	InstallPackagePath string `protobuf:"bytes,11,opt,name=install_package_path,json=installPackagePath,proto3" json:"install_package_path,omitempty"`
+	InstallPackagePath string `protobuf:"bytes,11,opt,name=install_package_path,json=installPackagePath,proto3" json:"installPackagePath,omitempty"`
 	// Root for docker image paths e.g. docker.io/istio
 	Hub string `protobuf:"bytes,12,opt,name=hub,proto3" json:"hub,omitempty"`
 	// Version tag for docker images e.g. 1.0.6


### PR DESCRIPTION
Manual cherry pick of https://github.com/istio/api/pull/1324.

https://github.com/istio/api/pull/1301 introduced a bug where some fields are not converted from snake to camel case because the regex expected at most a single underscore - so fields like my_long_named_field would not match it. 