### PR TITLE
Add Gateway Class annotation

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -11,7 +11,6 @@ const (
     Ingress
     Pod
     Service
-    ServiceEntry
 )
 
 func (r ResourceTypes) String() string {
@@ -24,8 +23,6 @@ func (r ResourceTypes) String() string {
 		return "Pod"
 	case 4:
 		return "Service"
-	case 5:
-		return "ServiceEntry"
 	}
 	return "Unknown"
 }
@@ -129,46 +126,28 @@ var (
 		  Resources: []ResourceTypes{ Ingress, },
         }
 	
-		AlphaNetworkingEndpointsVersion = Instance {
-          Name: "networking.alpha.istio.io/endpointsVersion",
-          Description: "Added to synthetic ServiceEntry resources to provide the "+
-                        "raw resource version from the most recent Kubernetes "+
-                        "endpoints update (if available). NOTE This API is Alpha "+
-                        "and has no stability guarantees.",
-          Hidden: true,
-          Deprecated: false,
-		  Resources: []ResourceTypes{ ServiceEntry, },
-        }
-	
-		AlphaNetworkingNotReadyEndpoints = Instance {
-          Name: "networking.alpha.istio.io/notReadyEndpoints",
-          Description: "Added to synthetic ServiceEntry resources to provide the "+
-                        "'NotReadyAddresses' from the Kubernetes Endpoints "+
-                        "resource. The value is a comma-separated list of IP:port. "+
-                        "NOTE This API is Alpha and has no stability guarantees.",
-          Hidden: true,
-          Deprecated: false,
-		  Resources: []ResourceTypes{ ServiceEntry, },
-        }
-	
-		AlphaNetworkingServiceVersion = Instance {
-          Name: "networking.alpha.istio.io/serviceVersion",
-          Description: "Added to synthetic ServiceEntry resources to provide the "+
-                        "raw resource version from the most recent Kubernetes "+
-                        "service update. This will always be available for "+
-                        "synthetic service entries. NOTE This API is Alpha and has "+
-                        "no stability guarantees.",
-          Hidden: true,
-          Deprecated: false,
-		  Resources: []ResourceTypes{ ServiceEntry, },
-        }
-	
 		NetworkingExportTo = Instance {
           Name: "networking.istio.io/exportTo",
           Description: "Specifies the namespaces to which this service should be "+
                         "exported to. A value of '*' indicates it is reachable "+
                         "within the mesh '.' indicates it is reachable within its "+
                         "namespace.",
+          Hidden: false,
+          Deprecated: false,
+		  Resources: []ResourceTypes{ Service, },
+        }
+	
+		NetworkingGatewayClass = Instance {
+          Name: "networking.istio.io/gatewayClass",
+          Description: "Specifies the type of gateway. Valid values are "+
+                        "'ingress', 'egress', and 'midtier'. Use 'ingress' class "+
+                        "for gateways that receive traffic from outside the "+
+                        "cluster and forward to services inside the cluster. Use "+
+                        "'egress' class for gateways that receive traffic from "+
+                        "services inside the mesh and forward to external services "+
+                        "outside the mesh. Use 'midtier' class for gateways that "+
+                        "receive traffic from services within the cluster and "+
+                        "forward to other services in the same cluster.",
           Hidden: false,
           Deprecated: false,
 		  Resources: []ResourceTypes{ Service, },
@@ -514,10 +493,8 @@ func AllResourceAnnotations() []*Instance {
 		&OperatorInstallOwnerGeneration,
 		&OperatorInstallVersion,
 		&IoKubernetesIngressClass,
-		&AlphaNetworkingEndpointsVersion,
-		&AlphaNetworkingNotReadyEndpoints,
-		&AlphaNetworkingServiceVersion,
 		&NetworkingExportTo,
+		&NetworkingGatewayClass,
 		&PolicyCheck,
 		&PolicyCheckBaseRetryWaitTime,
 		&PolicyCheckMaxRetryWaitTime,
@@ -562,6 +539,5 @@ func AllResourceTypes() []string {
 		"Ingress",
 		"Pod",
 		"Service",
-		"ServiceEntry",
 	}
 }

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -76,18 +76,22 @@ Istio supports to control its behavior.
 			
 		
 			
-		
-			
-		
-			
-		
-			
 				
 					<tr>
 				
 					<td><code>networking.istio.io/exportTo</code></td>
 					<td>[Service]</td>
 					<td>Specifies the namespaces to which this service should be exported to. A value of '*' indicates it is reachable within the mesh '.' indicates it is reachable within its namespace.</td>
+				</tr>
+			
+		
+			
+				
+					<tr>
+				
+					<td><code>networking.istio.io/gatewayClass</code></td>
+					<td>[Service]</td>
+					<td>Specifies the type of gateway. Valid values are 'ingress', 'egress', and 'midtier'. Use 'ingress' class for gateways that receive traffic from outside the cluster and forward to services inside the cluster. Use 'egress' class for gateways that receive traffic from services inside the mesh and forward to external services outside the mesh. Use 'midtier' class for gateways that receive traffic from services within the cluster and forward to other services in the same cluster.</td>
 				</tr>
 			
 		

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -38,36 +38,21 @@ annotations:
     hidden: true
     resources:
       - Pod
-  - name: networking.alpha.istio.io/serviceVersion
-    description: Added to synthetic ServiceEntry resources to provide the raw resource
-      version from the most recent Kubernetes service update. This will always be available for
-      synthetic service entries.
-      NOTE This API is Alpha and has no stability guarantees.
-    deprecated: false
-    hidden: true
-    resources:
-      - ServiceEntry
-  - name: networking.alpha.istio.io/endpointsVersion
-    description: Added to synthetic ServiceEntry resources to provide the raw resource
-      version from the most recent Kubernetes endpoints update (if available).
-      NOTE This API is Alpha and has no stability guarantees.
-    deprecated: false
-    hidden: true
-    resources:
-      - ServiceEntry
-  - name: networking.alpha.istio.io/notReadyEndpoints
-    description: Added to synthetic ServiceEntry resources to provide the
-      'NotReadyAddresses' from the Kubernetes Endpoints resource. The value is a
-      comma-separated list of IP:port.
-      NOTE This API is Alpha and has no stability guarantees.
-    deprecated: false
-    hidden: true
-    resources:
-      - ServiceEntry
   - name: networking.istio.io/exportTo
     description: Specifies the namespaces to which this service should be exported to.
       A value of '*' indicates it is reachable within the mesh '.' indicates it is
       reachable within its namespace.
+    deprecated: false
+    hidden: false
+    resources:
+      - Service
+  - name: networking.istio.io/gatewayClass
+    description: Specifies the type of gateway. Valid values are 'ingress', 'egress', and 'midtier'.
+    Use 'ingress' class for gateways that receive traffic from outside the cluster and forward to
+    services inside the cluster. Use 'egress' class for gateways that receive traffic from services
+    inside the mesh and forward to external services outside the mesh. Use 'midtier' class for
+    gateways that receive traffic from services within the cluster and forward to other services
+    in the same cluster.
     deprecated: false
     hidden: false
     resources:

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -48,11 +48,11 @@ annotations:
       - Service
   - name: networking.istio.io/gatewayClass
     description: Specifies the type of gateway. Valid values are 'ingress', 'egress', and 'midtier'.
-    Use 'ingress' class for gateways that receive traffic from outside the cluster and forward to
-    services inside the cluster. Use 'egress' class for gateways that receive traffic from services
-    inside the mesh and forward to external services outside the mesh. Use 'midtier' class for
-    gateways that receive traffic from services within the cluster and forward to other services
-    in the same cluster.
+      Use 'ingress' class for gateways that receive traffic from outside the cluster and forward to
+      services inside the cluster. Use 'egress' class for gateways that receive traffic from services
+      inside the mesh and forward to external services outside the mesh. Use 'midtier' class for
+      gateways that receive traffic from services within the cluster and forward to other services
+      in the same cluster.
     deprecated: false
     hidden: false
     resources:


### PR DESCRIPTION
As of now, we are not doing any special processing in Pilot based
on this annotation but we will soon set some special settings for
gateways depending on their class (ingress/egress/midtier).

For now, I opted to set this as a service level annotation rather
than pod level annotation. I dont mind switching. But either way, this
is not an API field as we have multiple gateway objects applying to 
the same workload. It doesn't make sense for one object to be ingress and
the other one to be egress.