### PR TITLE
feat(label): add label package

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
 // Package label contains common definitions for workload labels used by Istio.
 package label
 

--- a/label/label.go
+++ b/label/label.go
@@ -1,0 +1,14 @@
+// Package label contains common definitions for workload labels used by Istio.
+package label
+
+const (
+	// TLSMode is the name of label given to service instances to determine whether to use mTLS or
+	// fallback to plaintext/tls
+	TLSMode = "security.istio.io/tlsMode"
+
+	// IstioCanonicalServiceName is the name of label for the Istio Canonical Service for a workload instance.
+	IstioCanonicalServiceName = "service.istio.io/canonical-name"
+
+	// IstioCanonicalServiceRevision is the name of label for the Istio Canonical Service revision for a workload instance.
+	IstioCanonicalServiceRevision = "service.istio.io/canonical-revision"
+)


### PR DESCRIPTION
This PR adds a new package that holds definitions for labels used by Istio.

This was a FR from the knative team. The request is to have a common package for these definitions that can be used without taking a dependency on the `istio/istio` repo (dep already exists to `istio/api`).

The values are taken, initially, from [Pilot code](https://github.com/istio/istio/blob/2d1b8d6fc2a30787d397770e6f6aa1eec6a46b03/pilot/pkg/model/service.go#L136-L155).

These are not placed in the `annotation` package, as they are not resource annotations. It is possible that we will want to expand the package to include docs generation similar to `annotation`, but for now that is not part of the initial request.

Signed-off-by: Douglas Reid <dougreid@google.com>