### PR TITLE
Fix comment indent

### DIFF
--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -36,8 +36,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // apiVersion: security.istio.io/v1beta1
 // kind: RequestAuthentication
 // metadata:
-//  name: httpbin
-//  namespace: foo
+//   name: httpbin
+//   namespace: foo
 // spec:
 //   selector:
 //     matchLabels:
@@ -49,16 +49,16 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // apiVersion: security.istio.io/v1beta1
 // kind: AuthorizationPolicy
 // metadata:
-//  name: httpbin
-//  namespace: foo
+//   name: httpbin
+//   namespace: foo
 // spec:
-//  selector:
-//    matchLabels:
-//      app: httpbin
-//  rules:
-//  - from:
-//    - source:
-//        requestPrincipals: ["*"]
+//   selector:
+//     matchLabels:
+//       app: httpbin
+//   rules:
+//   - from:
+//     - source:
+//         requestPrincipals: ["*"]
 // ```
 //
 // - The next example shows how to set a different JWT requirement for a different `host`. The `RequestAuthentication`
@@ -68,8 +68,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // apiVersion: security.istio.io/v1beta1
 // kind: RequestAuthentication
 // metadata:
-//  name: httpbin
-//  namespace: foo
+//   name: httpbin
+//   namespace: foo
 // spec:
 //   selector:
 //     matchLabels:
@@ -81,12 +81,12 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // apiVersion: security.istio.io/v1beta1
 // kind: AuthorizationPolicy
 // metadata:
-//  name: httpbin
-//  namespace: foo
+//   name: httpbin
+//   namespace: foo
 // spec:
-//  selector:
-//    matchLabels:
-//      app: httpbin
+//   selector:
+//     matchLabels:
+//       app: httpbin
 //  rules:
 //  - from:
 //    - source:
@@ -108,12 +108,12 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // apiVersion: security.istio.io/v1beta1
 // kind: AuthorizationPolicy
 // metadata:
-//  name: httpbin
-//  namespace: foo
+//   name: httpbin
+//   namespace: foo
 // spec:
-//  selector:
-//    matchLabels:
-//      app: httpbin
+//   selector:
+//     matchLabels:
+//       app: httpbin
 //  rules:
 //  - from:
 //    - source:

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -24,8 +24,8 @@ Examples:</p>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
- name: httpbin
- namespace: foo
+  name: httpbin
+  namespace: foo
 spec:
   selector:
     matchLabels:
@@ -37,16 +37,16 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
- name: httpbin
- namespace: foo
+  name: httpbin
+  namespace: foo
 spec:
- selector:
-   matchLabels:
-     app: httpbin
- rules:
- - from:
-   - source:
-       requestPrincipals: [&quot;*&quot;]
+  selector:
+    matchLabels:
+      app: httpbin
+  rules:
+  - from:
+    - source:
+        requestPrincipals: [&quot;*&quot;]
 </code></pre>
 
 <ul>

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -39,8 +39,8 @@ option go_package="istio.io/api/security/v1beta1";
 // apiVersion: security.istio.io/v1beta1
 // kind: RequestAuthentication
 // metadata:
-//  name: httpbin
-//  namespace: foo
+//   name: httpbin
+//   namespace: foo
 // spec:
 //   selector:
 //     matchLabels:
@@ -52,16 +52,16 @@ option go_package="istio.io/api/security/v1beta1";
 // apiVersion: security.istio.io/v1beta1
 // kind: AuthorizationPolicy
 // metadata:
-//  name: httpbin
-//  namespace: foo
+//   name: httpbin
+//   namespace: foo
 // spec:
-//  selector:
-//    matchLabels:
-//      app: httpbin
-//  rules:
-//  - from:
-//    - source:
-//        requestPrincipals: ["*"]
+//   selector:
+//     matchLabels:
+//       app: httpbin
+//   rules:
+//   - from:
+//     - source:
+//         requestPrincipals: ["*"]
 // ```
 //
 // - The next example shows how to set a different JWT requirement for a different `host`. The `RequestAuthentication`
@@ -71,8 +71,8 @@ option go_package="istio.io/api/security/v1beta1";
 // apiVersion: security.istio.io/v1beta1
 // kind: RequestAuthentication
 // metadata:
-//  name: httpbin
-//  namespace: foo
+//   name: httpbin
+//   namespace: foo
 // spec:
 //   selector:
 //     matchLabels:
@@ -84,12 +84,12 @@ option go_package="istio.io/api/security/v1beta1";
 // apiVersion: security.istio.io/v1beta1
 // kind: AuthorizationPolicy
 // metadata:
-//  name: httpbin
-//  namespace: foo
+//   name: httpbin
+//   namespace: foo
 // spec:
-//  selector:
-//    matchLabels:
-//      app: httpbin
+//   selector:
+//     matchLabels:
+//       app: httpbin
 //  rules:
 //  - from:
 //    - source:
@@ -111,12 +111,12 @@ option go_package="istio.io/api/security/v1beta1";
 // apiVersion: security.istio.io/v1beta1
 // kind: AuthorizationPolicy
 // metadata:
-//  name: httpbin
-//  namespace: foo
+//   name: httpbin
+//   namespace: foo
 // spec:
-//  selector:
-//    matchLabels:
-//      app: httpbin
+//   selector:
+//     matchLabels:
+//       app: httpbin
 //  rules:
 //  - from:
 //    - source:


### PR DESCRIPTION
Adding spaces to correct `yaml` examples 