### PR TITLE
Fix WorkloadEntry CRD

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -4938,6 +4938,10 @@ spec:
       lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
     name: Age
     type: date
+  - JSONPath: .spec.address
+    description: Address associated with the network endpoint.
+    name: Address
+    type: string
   group: networking.istio.io
   names:
     categories:
@@ -4994,7 +4998,7 @@ spec:
     storage: true
   - name: v1beta1
     served: true
-    storage: true
+    storage: false
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/networking/v1alpha3/workload_entry.pb.go
+++ b/networking/v1alpha3/workload_entry.pb.go
@@ -244,6 +244,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/workload_entry.proto
+++ b/networking/v1alpha3/workload_entry.proto
@@ -246,6 +246,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/workload_entry.pb.go
+++ b/networking/v1beta1/workload_entry.pb.go
@@ -234,7 +234,6 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // <!-- crd generation tags
 // +cue-gen:WorkloadEntry:groupName:networking.istio.io
 // +cue-gen:WorkloadEntry:version:v1beta1
-// +cue-gen:WorkloadEntry:storageVersion
 // +cue-gen:WorkloadEntry:annotations:helm.sh/resource-policy=keep
 // +cue-gen:WorkloadEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadEntry:subresource:status
@@ -244,6 +243,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/workload_entry.proto
+++ b/networking/v1beta1/workload_entry.proto
@@ -236,7 +236,6 @@ option go_package = "istio.io/api/networking/v1beta1";
 // <!-- crd generation tags
 // +cue-gen:WorkloadEntry:groupName:networking.istio.io
 // +cue-gen:WorkloadEntry:version:v1beta1
-// +cue-gen:WorkloadEntry:storageVersion
 // +cue-gen:WorkloadEntry:annotations:helm.sh/resource-policy=keep
 // +cue-gen:WorkloadEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadEntry:subresource:status
@@ -246,6 +245,7 @@ option go_package = "istio.io/api/networking/v1beta1";
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
 // -->
 //
 // <!-- go code generation tags


### PR DESCRIPTION
Currently the workload entry is generating an invalid CRD as its trying
to store both alpha and beta - it should just be one. I also added an
extra column to print out the address

For https://github.com/istio/istio/pull/22472