### PR TITLE
Fix gen of proto

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SHELL := /bin/bash
+
 all: gen
 
 ########################

--- a/mixer/v1/config/client/quota.pb.go
+++ b/mixer/v1/config/client/quota.pb.go
@@ -400,7 +400,9 @@ func init() {
 	proto.RegisterType((*QuotaSpecBinding_QuotaSpecReference)(nil), "istio.mixer.v1.config.client.QuotaSpecBinding.QuotaSpecReference")
 }
 
-func init() { proto.RegisterFile("mixer/v1/config/client/quota.proto", fileDescriptor_81777b5d047af315) }
+func init() {
+	proto.RegisterFile("mixer/v1/config/client/quota.proto", fileDescriptor_81777b5d047af315)
+}
 
 var fileDescriptor_81777b5d047af315 = []byte{
 	// 569 bytes of a gzipped FileDescriptorProto

--- a/operator/v1alpha1/kubernetes.pb.go
+++ b/operator/v1alpha1/kubernetes.pb.go
@@ -2158,7 +2158,9 @@ func init() {
 	proto.RegisterType((*ExternalMetricSource)(nil), "istio.operator.v1alpha1.ExternalMetricSource")
 }
 
-func init() { proto.RegisterFile("operator/v1alpha1/kubernetes.proto", fileDescriptor_b13c6c8501de3a11) }
+func init() {
+	proto.RegisterFile("operator/v1alpha1/kubernetes.proto", fileDescriptor_b13c6c8501de3a11)
+}
 
 var fileDescriptor_b13c6c8501de3a11 = []byte{
 	// 2190 bytes of a gzipped FileDescriptorProto

--- a/policy/v1beta1/http_response.pb.go
+++ b/policy/v1beta1/http_response.pb.go
@@ -286,7 +286,9 @@ func init() {
 	proto.RegisterMapType((map[string]string)(nil), "istio.policy.v1beta1.DirectHttpResponse.HeadersEntry")
 }
 
-func init() { proto.RegisterFile("policy/v1beta1/http_response.proto", fileDescriptor_dffd274153c8a074) }
+func init() {
+	proto.RegisterFile("policy/v1beta1/http_response.proto", fileDescriptor_dffd274153c8a074)
+}
 
 var fileDescriptor_dffd274153c8a074 = []byte{
 	// 1042 bytes of a gzipped FileDescriptorProto


### PR DESCRIPTION
When the build tools image changed, these were not regenerated properly. See https://github.com/istio/api/pull/1385 where an unchanged PR fails. We need the /bin/bash change or we run into another issue:
```
$ make lint-yaml
/bin/sh: 1: set: Illegal option -o pipefail
common/Makefile.common.mk:33: recipe for target 'lint-yaml' failed
make[1]: *** [lint-yaml] Error 2
make: *** [Makefile:46: lint-yaml] Error 2
```