### PR TITLE
Initial draft to allow customization of Certificate signing

### DIFF
--- a/mesh/v1alpha1/config.pb.go
+++ b/mesh/v1alpha1/config.pb.go
@@ -462,7 +462,8 @@ type MeshConfig struct {
 	// - `%SERVICE_FQDN%_%SERVICE_PORT%` will use reviews.prod.svc.cluster.local_7443 as the stats name.
 	// - `%SERVICE%` will use reviews.prod as the stats name.
 	OutboundClusterStatName string `protobuf:"bytes,45,opt,name=outbound_cluster_stat_name,json=outboundClusterStatName,proto3" json:"outboundClusterStatName,omitempty"`
-	// Configure the provision of certificates.
+	// Configure the provision of certificates. This is used by Istiod certificate signing
+	// feature.
 	Certificates []*Certificate `protobuf:"bytes,47,rep,name=certificates,proto3" json:"certificates,omitempty"`
 	// Set configuration for Thrift protocol
 	ThriftConfig *MeshConfig_ThriftConfig `protobuf:"bytes,49,opt,name=thrift_config,json=thriftConfig,proto3" json:"thriftConfig,omitempty"`
@@ -1183,7 +1184,11 @@ func (m *ConfigSource) GetSubscribedResources() []Resource {
 	return nil
 }
 
-// Certificate configures the provision of a certificate and its key.
+// Certificate configures the provision of a certificate.
+//
+// Starting with Istio 1.6 certificates are no longer saved as
+// secrets.
+//
 // Example 1: key and cert stored in a secret
 // { secretName: galley-cert
 //   secretNamespace: istio-system
@@ -1198,10 +1203,11 @@ func (m *ConfigSource) GetSubscribedResources() []Resource {
 //     - pilot.mydomain.com
 // }
 type Certificate struct {
-	// Name of the secret the certificate and its key will be stored into.
+	// Deprecated. Name of the secret the certificate and its key will be stored into.
 	// If it is empty, it will not be stored into a secret.
 	// Instead, the certificate and its key will be stored into a hard-coded directory.
 	SecretName string `protobuf:"bytes,1,opt,name=secret_name,json=secretName,proto3" json:"secretName,omitempty"`
+
 	// The DNS names for the certificate. A certificate may contain
 	// multiple DNS names.
 	DnsNames             []string `protobuf:"bytes,2,rep,name=dns_names,json=dnsNames,proto3" json:"dnsNames,omitempty"`

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -594,13 +594,18 @@ message Certificate {
   // OIDC is used, or a k8s identity, if K8S tokens are used.
   //
   // Treated as an opaque string in matching a request.
+  //
+  // If a Gateway or Istiod instance is requesting certificates, this is the
+  // service account running the Istiod or Gateway deployment.
   string principal = 3;
 
   // List of URI SANs allowed in the CSR request.
   // This is primarily used for explicit SPIFFE identities.
   repeated string uri_SANs = 4;
 
-  // List of allowed namespaces for issuing SPIFFE CSRs.
+  // List of allowed namespaces for issuing SPIFFE CSRs. A CI/CD, admin
+  // or Istiod tenant instance may be restricted to only specific
+  // namespaces where they're allowed to provision identity.
   //
   // This allows a CI/CD or admin to provision certificates for
   // a set of managed namespaces, or a managed VM to use istio-agent

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -393,7 +393,18 @@ message MeshConfig {
   // - `%SERVICE%` will use reviews.prod as the stats name.
   string outbound_cluster_stat_name = 45;
 
-  // Configure the provision of certificates.
+  // Configure the provision of certificates by Istiod, if certificate management
+  // is enabled in the current revision.
+  // Users may use external certificate management, or enable only specific
+  // Istiod revisions to handle certificates - for example only a subset of clusters,
+  // or a subset of revisions.
+  //
+  // Istiod can also delegate to other CA - like K8S. In such cases the config
+  // is used as a filter, but ultimate decision rests with the primary CA.
+  // When delegation happens, Istiod may use its own credentials and permissions
+  // when authenticating to the external CA - so user will still need to use
+  // the Istiod configuration to limit the certificates that workloads can retrieve.
+  //
   repeated Certificate certificates = 47;
 
   message ThriftConfig {
@@ -506,8 +517,8 @@ message ConfigSource {
 // CSR signing service and to specify what identities are allowed
 // in the CSR.
 //
-// Starting with Istio 1.6 certificates are no longer saved as
-// secrets.
+// Starting with release 1.6, Istio-generated certificates are no longer saved
+// as secrets.
 //
 // Example 1: Configure DNS certificate content for Istiod
 // {
@@ -531,6 +542,29 @@ message ConfigSource {
 //     namespaces:
 //     - bookinfo
 // }
+//
+// Example 4: Provision certificate for a tenant or Istiod revision.
+// The Istiod instance will use a separate SA without RBAC permissions to
+// read the master CA. The istiod revision signing CSRs may run in an isolated,
+// more trusted cluster or in a separate namespace.
+//
+// {
+//     principal: istiod-service-account-staging.istio-system-staging
+//     dnsNames:
+//        - istiod-staging.istio-system-staging
+//        - istiod-staging.istio-staging.example.com
+// }
+//
+// Example 5: Provisioning certificate for an Istio Gateway dispatching
+// requests to multiple revisions or tenants:
+//
+// {
+//     principal: istio-ingressgateway-service-account
+//     dnsNames:
+//        - istiod.istio-system.svc
+//        - xds.example.com
+// }
+//
 message Certificate {
   // Deprecated. All requests will use the istiod signing interface.
   // Name of the secret the certificate and its key will be stored into.
@@ -545,16 +579,27 @@ message Certificate {
   // from the certificate, if present in the CSR.
   repeated string dns_names = 2;
 
-  // This is the identity of the caller of the signing service.
-  // For example it can be a SPIFFE identity, if Istio certificates
-  // are used for authentication, or the principal in a JWT token of
-  // OIDC is used. It can also be a k8s identity, if K8S tokens are used.
-  // Treated as an opaque string.
+  // This is the opaque identity of the CSR requester. Istiod must be
+  // configured to authenticate the caller using mTLS, JWT tokens or
+  // other plugins.
+  //
+  // The format matches the identity provided by the auth plugin - for
+  // example a SPIFFE URI for mTLS, or the principal in a JWT token of
+  // OIDC is used, or a k8s identity, if K8S tokens are used.
+  //
+  // Treated as an opaque string in matching a request.
   string principal = 3;
 
+  // List of URI SANs allowed in the CSR request.
+  // This is primarily used for explicit SPIFFE identities.
+  repeated string uri_SANs = 4;
+
   // List of allowed namespaces for issuing SPIFFE CSRs.
+  //
   // This allows a CI/CD or admin to provision certificates for
   // a set of managed namespaces, or a managed VM to use istio-agent
   // to retrieve certificates in its own namespace.
-  repeated string namespaces = 4;
+  repeated string namespaces = 5;
+
+
 }

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -512,13 +512,19 @@ message ConfigSource {
 
 
 
-// Certificate configures the provision of a certificate.
-// It allows the admin to specify the identity of the caller of the
-// CSR signing service and to specify what identities are allowed
-// in the CSR.
+// Certificate configures Istiod's certificate signing feature.
+//
+// Requests to Istiod are authenticated using mTLS, JWT or an authentication
+// plugin. The authenticated principal determines what is allowed in the
+// CSR request.
 //
 // Starting with release 1.6, Istio-generated certificates are no longer saved
-// as secrets.
+// as secrets, but served using SDS to Envoy.
+//
+// This is an internal config for Istiod when acting as a CA - it is not
+// a general API for certificate issuance nor a general purpose RBAC system.
+// The features are intentionally kept to the minimum set of features required
+// for Istio operation - external CAs should be used for more advanced features.
 //
 // Example 1: Configure DNS certificate content for Istiod
 // {

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -501,26 +501,60 @@ message ConfigSource {
 
 
 
-// Certificate configures the provision of a certificate and its key.
-// Example 1: key and cert stored in a secret
-// { secretName: galley-cert
-//   secretNamespace: istio-system
-//   dnsNames:
-//     - galley.istio-system.svc
-//     - galley.mydomain.com
+// Certificate configures the provision of a certificate.
+// It allows the admin to specify the identity of the caller of the
+// CSR signing service and to specify what identities are allowed
+// in the CSR.
+//
+// Starting with Istio 1.6 certificates are no longer saved as
+// secrets.
+//
+// Example 1: Configure DNS certificate content for Istiod
+// {
+//     principal: istiod-service-account.istio-system
+//     dnsNames:
+//     - istiod.istio-system.svc
+//     - istiod.mydomain.com
 // }
-// Example 2: key and cert stored in a directory
-// { dnsNames:
-//     - pilot.istio-system
-//     - pilot.istio-system.svc
-//     - pilot.mydomain.com
+//
+// Example 2: Certificate provisioning for a VM using a CI/CD
+// {
+//     principal: istio@github.com
+//     namespaces:
+//     - bookinfo
+//     - bookinfo-staging
+// }
+//
+// Example 3: Certificate provisioning for a VM using a managed SA.
+// {
+//     principal: aws-sa@amazon-iam
+//     namespaces:
+//     - bookinfo
 // }
 message Certificate {
+  // Deprecated. All requests will use the istiod signing interface.
   // Name of the secret the certificate and its key will be stored into.
   // If it is empty, it will not be stored into a secret.
   // Instead, the certificate and its key will be stored into a hard-coded directory.
   string secret_name = 1;
+
+
   // The DNS names for the certificate. A certificate may contain
-  // multiple DNS names.
+  // multiple DNS names as well as SPIFFE SANs.
+  // Wildcards are permitted. Names not in this list will be removed
+  // from the certificate, if present in the CSR.
   repeated string dns_names = 2;
+
+  // This is the identity of the caller of the signing service.
+  // For example it can be a SPIFFE identity, if Istio certificates
+  // are used for authentication, or the principal in a JWT token of
+  // OIDC is used. It can also be a k8s identity, if K8S tokens are used.
+  // Treated as an opaque string.
+  string principal = 3;
+
+  // List of allowed namespaces for issuing SPIFFE CSRs.
+  // This allows a CI/CD or admin to provision certificates for
+  // a set of managed namespaces, or a managed VM to use istio-agent
+  // to retrieve certificates in its own namespace.
+  repeated string namespaces = 4;
 }

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -337,6 +337,11 @@ message ProxyConfig {
     // filtering and manipulation. This mode also configures the sidecar to run with the
     // CAP_NET_ADMIN capability, which is required to use TPROXY.
     TPROXY = 1;
+
+    // NONE mode disables iptables capture. Envoy will use explicit configurations from Sidecar.
+    // Outbound traffic can use HTTP_PROXY for HTTP, or explicit localhost ports that forward
+    // to the outbound destinations.
+    NONE = 2;
   }
 
   // The mode used to redirect inbound traffic to Envoy.


### PR DESCRIPTION
Fix the broken 'secretName' option of the Certificate option.

Add fields to indicate the principals that are allowed to request certificates with custom format.

Indicate what namespaces a principal requesting a certificate is allowed to use. Note that granularity
of namespace matches typical user needs - we can also use specific Spiffee URLs or service accounts, but maybe when this feature is promoted from mesh config. 

The implementation in istio-api will use this config and the authenticated principal on the CSR signing
request to determine which SANs are allowed in the CSR. 

https://docs.google.com/document/d/1mL658zm9CWzVSjm3yuk6O5vIJDlVi0LU0Tv1in5zGKg/edit#heading=h.xw1gqgyqs5b
