### PR TITLE
Add preserveUnknownFields to CRDs

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -20,6 +20,7 @@ spec:
     listKind: HTTPAPISpecList
     plural: httpapispecs
     singular: httpapispec
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -289,6 +290,7 @@ spec:
     listKind: HTTPAPISpecBindingList
     plural: httpapispecbindings
     singular: httpapispecbinding
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -382,6 +384,7 @@ spec:
     listKind: QuotaSpecList
     plural: quotaspecs
     singular: quotaspec
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -475,6 +478,7 @@ spec:
     listKind: QuotaSpecBindingList
     plural: quotaspecbindings
     singular: quotaspecbinding
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -570,6 +574,7 @@ spec:
     shortNames:
     - dr
     singular: destinationrule
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -1691,6 +1696,7 @@ spec:
     listKind: EnvoyFilterList
     plural: envoyfilters
     singular: envoyfilter
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -1927,6 +1933,7 @@ spec:
     shortNames:
     - gw
     singular: gateway
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -2100,6 +2107,7 @@ spec:
     shortNames:
     - se
     singular: serviceentry
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -2236,6 +2244,7 @@ spec:
     listKind: SidecarList
     plural: sidecars
     singular: sidecar
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -2599,6 +2608,7 @@ spec:
     shortNames:
     - vs
     singular: virtualservice
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3406,6 +3416,7 @@ spec:
     shortNames:
     - we
     singular: workloadentry
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3477,6 +3488,7 @@ spec:
     listKind: attributemanifestList
     plural: attributemanifests
     singular: attributemanifest
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3553,6 +3565,7 @@ spec:
     listKind: handlerList
     plural: handlers
     singular: handler
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3760,6 +3773,7 @@ spec:
     listKind: instanceList
     plural: instances
     singular: instance
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3822,6 +3836,7 @@ spec:
     listKind: ruleList
     plural: rules
     singular: rule
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3976,6 +3991,7 @@ spec:
     listKind: ClusterRbacConfigList
     plural: clusterrbacconfigs
     singular: clusterrbacconfig
+  preserveUnknownFields: false
   scope: Cluster
   subresources:
     status: {}
@@ -4063,6 +4079,7 @@ spec:
     listKind: RbacConfigList
     plural: rbacconfigs
     singular: rbacconfig
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -4150,6 +4167,7 @@ spec:
     listKind: ServiceRoleList
     plural: serviceroles
     singular: servicerole
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -4273,6 +4291,7 @@ spec:
     listKind: ServiceRoleBindingList
     plural: servicerolebindings
     singular: servicerolebinding
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -4460,6 +4479,7 @@ spec:
     listKind: AuthorizationPolicyList
     plural: authorizationpolicies
     singular: authorizationpolicy
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -4661,6 +4681,7 @@ spec:
     shortNames:
     - pa
     singular: peerauthentication
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -4739,6 +4760,7 @@ spec:
     shortNames:
     - ra
     singular: requestauthentication
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/mixer/v1/config/client/api_spec.pb.go
+++ b/mixer/v1/config/client/api_spec.pb.go
@@ -93,6 +93,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // +cue-gen:HTTPAPISpec:subresource:status
 // +cue-gen:HTTPAPISpec:scope:Namespaced
 // +cue-gen:HTTPAPISpec:resource:categories=istio-io,apim-istio-io
+// +cue-gen:HTTPAPISpec:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -422,6 +423,7 @@ var xxx_messageInfo_HTTPAPISpecReference proto.InternalMessageInfo
 // +cue-gen:HTTPAPISpecBinding:subresource:status
 // +cue-gen:HTTPAPISpecBinding:scope:Namespaced
 // +cue-gen:HTTPAPISpecBinding:resource:categories=istio-io,apim-istio-io
+// +cue-gen:HTTPAPISpecBinding:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/mixer/v1/config/client/api_spec.proto
+++ b/mixer/v1/config/client/api_spec.proto
@@ -95,6 +95,7 @@ option (gogoproto.stable_marshaler_all) = true;
 // +cue-gen:HTTPAPISpec:subresource:status
 // +cue-gen:HTTPAPISpec:scope:Namespaced
 // +cue-gen:HTTPAPISpec:resource:categories=istio-io,apim-istio-io
+// +cue-gen:HTTPAPISpec:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -254,6 +255,7 @@ message HTTPAPISpecReference {
 // +cue-gen:HTTPAPISpecBinding:subresource:status
 // +cue-gen:HTTPAPISpecBinding:scope:Namespaced
 // +cue-gen:HTTPAPISpecBinding:resource:categories=istio-io,apim-istio-io
+// +cue-gen:HTTPAPISpecBinding:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/mixer/v1/config/client/quota.pb.go
+++ b/mixer/v1/config/client/quota.pb.go
@@ -39,6 +39,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // +cue-gen:QuotaSpec:subresource:status
 // +cue-gen:QuotaSpec:scope:Namespaced
 // +cue-gen:QuotaSpec:resource:categories=istio-io,apim-istio-io
+// +cue-gen:QuotaSpec:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -305,6 +306,7 @@ var xxx_messageInfo_Quota proto.InternalMessageInfo
 // +cue-gen:QuotaSpecBinding:subresource:status
 // +cue-gen:QuotaSpecBinding:scope:Namespaced
 // +cue-gen:QuotaSpecBinding:resource:categories=istio-io,apim-istio-io
+// +cue-gen:QuotaSpecBinding:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/mixer/v1/config/client/quota.proto
+++ b/mixer/v1/config/client/quota.proto
@@ -79,6 +79,7 @@ option (gogoproto.stable_marshaler_all) = true;
 // +cue-gen:QuotaSpec:subresource:status
 // +cue-gen:QuotaSpec:scope:Namespaced
 // +cue-gen:QuotaSpec:resource:categories=istio-io,apim-istio-io
+// +cue-gen:QuotaSpec:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -156,6 +157,7 @@ message Quota {
 // +cue-gen:QuotaSpecBinding:subresource:status
 // +cue-gen:QuotaSpecBinding:scope:Namespaced
 // +cue-gen:QuotaSpecBinding:resource:categories=istio-io,apim-istio-io
+// +cue-gen:QuotaSpecBinding:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -301,6 +301,7 @@ func (ClientTLSSettings_TLSmode) EnumDescriptor() ([]byte, []int) {
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:DestinationRule:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -185,6 +185,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. 
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:DestinationRule:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -426,6 +426,7 @@ func (EnvoyFilter_Patch_Operation) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:EnvoyFilter:subresource:status
 // +cue-gen:EnvoyFilter:scope:Namespaced
 // +cue-gen:EnvoyFilter:resource:categories=istio-io,networking-istio-io
+// +cue-gen:EnvoyFilter:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -219,6 +219,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:EnvoyFilter:subresource:status
 // +cue-gen:EnvoyFilter:scope:Namespaced
 // +cue-gen:EnvoyFilter:resource:categories=istio-io,networking-istio-io
+// +cue-gen:EnvoyFilter:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -461,6 +461,7 @@ func (ServerTLSSettings_TLSProtocol) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:Gateway:subresource:status
 // +cue-gen:Gateway:scope:Namespaced
 // +cue-gen:Gateway:resource:categories=istio-io,networking-istio-io,shortNames=gw
+// +cue-gen:Gateway:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -365,6 +365,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:Gateway:subresource:status
 // +cue-gen:Gateway:scope:Namespaced
 // +cue-gen:Gateway:resource:categories=istio-io,networking-istio-io,shortNames=gw
+// +cue-gen:Gateway:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -880,6 +880,7 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:ServiceEntry:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -796,6 +796,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:ServiceEntry:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -480,6 +480,7 @@ func (OutboundTrafficPolicy_Mode) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:Sidecar:subresource:status
 // +cue-gen:Sidecar:scope:Namespaced
 // +cue-gen:Sidecar:resource:categories=istio-io,networking-istio-io
+// +cue-gen:Sidecar:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -419,6 +419,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:Sidecar:subresource:status
 // +cue-gen:Sidecar:scope:Namespaced
 // +cue-gen:Sidecar:resource:categories=istio-io,networking-istio-io
+// +cue-gen:Sidecar:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -191,6 +191,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:VirtualService:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -193,6 +193,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. 
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:VirtualService:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/workload_entry.pb.go
+++ b/networking/v1alpha3/workload_entry.pb.go
@@ -245,6 +245,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
 // +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
+// +cue-gen:WorkloadEntry:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/workload_entry.proto
+++ b/networking/v1alpha3/workload_entry.proto
@@ -247,6 +247,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
 // +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
+// +cue-gen:WorkloadEntry:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -300,6 +300,7 @@ func (ClientTLSSettings_TLSmode) EnumDescriptor() ([]byte, []int) {
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:DestinationRule:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -184,6 +184,7 @@ option go_package = "istio.io/api/networking/v1beta1";
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. 
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:DestinationRule:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/gateway.pb.go
+++ b/networking/v1beta1/gateway.pb.go
@@ -462,6 +462,7 @@ func (ServerTLSSettings_TLSProtocol) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:Gateway:subresource:status
 // +cue-gen:Gateway:scope:Namespaced
 // +cue-gen:Gateway:resource:categories=istio-io,networking-istio-io,shortNames=gw
+// +cue-gen:Gateway:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/gateway.proto
+++ b/networking/v1beta1/gateway.proto
@@ -366,6 +366,7 @@ option go_package = "istio.io/api/networking/v1beta1";
 // +cue-gen:Gateway:subresource:status
 // +cue-gen:Gateway:scope:Namespaced
 // +cue-gen:Gateway:resource:categories=istio-io,networking-istio-io,shortNames=gw
+// +cue-gen:Gateway:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/service_entry.pb.go
+++ b/networking/v1beta1/service_entry.pb.go
@@ -879,6 +879,7 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:ServiceEntry:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/service_entry.proto
+++ b/networking/v1beta1/service_entry.proto
@@ -795,6 +795,7 @@ option go_package = "istio.io/api/networking/v1beta1";
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:ServiceEntry:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/sidecar.pb.go
+++ b/networking/v1beta1/sidecar.pb.go
@@ -479,6 +479,7 @@ func (OutboundTrafficPolicy_Mode) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:Sidecar:subresource:status
 // +cue-gen:Sidecar:scope:Namespaced
 // +cue-gen:Sidecar:resource:categories=istio-io,networking-istio-io
+// +cue-gen:Sidecar:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/sidecar.proto
+++ b/networking/v1beta1/sidecar.proto
@@ -418,6 +418,7 @@ option go_package = "istio.io/api/networking/v1beta1";
 // +cue-gen:Sidecar:subresource:status
 // +cue-gen:Sidecar:scope:Namespaced
 // +cue-gen:Sidecar:resource:categories=istio-io,networking-istio-io
+// +cue-gen:Sidecar:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -190,6 +190,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:VirtualService:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -192,6 +192,7 @@ option go_package = "istio.io/api/networking/v1beta1";
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. 
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:VirtualService:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/workload_entry.pb.go
+++ b/networking/v1beta1/workload_entry.pb.go
@@ -244,6 +244,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
 // +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
+// +cue-gen:WorkloadEntry:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1beta1/workload_entry.proto
+++ b/networking/v1beta1/workload_entry.proto
@@ -246,6 +246,7 @@ option go_package = "istio.io/api/networking/v1beta1";
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
 // +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
+// +cue-gen:WorkloadEntry:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/policy/v1beta1/cfg.pb.go
+++ b/policy/v1beta1/cfg.pb.go
@@ -127,6 +127,7 @@ func (Tls_AuthHeader) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:attributemanifest:subresource:status
 // +cue-gen:attributemanifest:scope:Namespaced
 // +cue-gen:attributemanifest:resource:categories=istio-io,policy-istio-io
+// +cue-gen:attributemanifest:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -331,6 +332,7 @@ func (m *AttributeManifest_AttributeInfo) GetValueType() ValueType {
 // +cue-gen:rule:subresource:status
 // +cue-gen:rule:scope:Namespaced
 // +cue-gen:rule:resource:categories=istio-io,policy-istio-io
+// +cue-gen:rule:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -622,6 +624,7 @@ func (m *Action) GetName() string {
 // +cue-gen:instance:subresource:status
 // +cue-gen:instance:scope:Namespaced
 // +cue-gen:instance:resource:categories=istio-io,policy-istio-io
+// +cue-gen:instance:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -799,6 +802,7 @@ func (m *Instance) GetAttributeBindings() map[string]string {
 // +cue-gen:handler:subresource:status
 // +cue-gen:handler:scope:Namespaced
 // +cue-gen:handler:resource:categories=istio-io,policy-istio-io
+// +cue-gen:handler:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/policy/v1beta1/cfg.proto
+++ b/policy/v1beta1/cfg.proto
@@ -37,6 +37,7 @@ option go_package="istio.io/api/policy/v1beta1";
 // +cue-gen:attributemanifest:subresource:status
 // +cue-gen:attributemanifest:scope:Namespaced
 // +cue-gen:attributemanifest:resource:categories=istio-io,policy-istio-io
+// +cue-gen:attributemanifest:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -143,6 +144,7 @@ message AttributeManifest {
 // +cue-gen:rule:subresource:status
 // +cue-gen:rule:scope:Namespaced
 // +cue-gen:rule:resource:categories=istio-io,policy-istio-io
+// +cue-gen:rule:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -282,6 +284,7 @@ message Action {
 // +cue-gen:instance:subresource:status
 // +cue-gen:instance:scope:Namespaced
 // +cue-gen:instance:resource:categories=istio-io,policy-istio-io
+// +cue-gen:instance:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -396,6 +399,7 @@ message Instance {
 // +cue-gen:handler:subresource:status
 // +cue-gen:handler:scope:Namespaced
 // +cue-gen:handler:resource:categories=istio-io,policy-istio-io
+// +cue-gen:handler:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/rbac/v1alpha1/rbac.pb.go
+++ b/rbac/v1alpha1/rbac.pb.go
@@ -176,6 +176,7 @@ func (RbacConfig_Mode) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:ServiceRole:subresource:status
 // +cue-gen:ServiceRole:scope:Namespaced
 // +cue-gen:ServiceRole:resource:categories=istio-io,rbac-istio-io
+// +cue-gen:ServiceRole:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -472,6 +473,7 @@ func (m *AccessRule_Constraint) GetValues() []string {
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:ServiceRoleBinding:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -846,6 +848,7 @@ func (m *RoleRef) GetName() string {
 // +cue-gen:RbacConfig:subresource:status
 // +cue-gen:RbacConfig:scope:Namespaced
 // +cue-gen:RbacConfig:resource:categories=istio-io,rbac-istio-io
+// +cue-gen:RbacConfig:preserveUnknownFields:false
 // -->
 //
 // <!-- crd generation tags
@@ -857,6 +860,7 @@ func (m *RoleRef) GetName() string {
 // +cue-gen:ClusterRbacConfig:subresource:status
 // +cue-gen:ClusterRbacConfig:scope:Cluster
 // +cue-gen:ClusterRbacConfig:resource:categories=istio-io,rbac-istio-io
+// +cue-gen:ClusterRbacConfig:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/rbac/v1alpha1/rbac.proto
+++ b/rbac/v1alpha1/rbac.proto
@@ -103,6 +103,7 @@ option go_package="istio.io/api/rbac/v1alpha1";
 // +cue-gen:ServiceRole:subresource:status
 // +cue-gen:ServiceRole:scope:Namespaced
 // +cue-gen:ServiceRole:resource:categories=istio-io,rbac-istio-io
+// +cue-gen:ServiceRole:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -228,6 +229,7 @@ enum EnforcementMode {
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. 
 // Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 // Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+// +cue-gen:ServiceRoleBinding:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -385,6 +387,7 @@ message RoleRef {
 // +cue-gen:RbacConfig:subresource:status
 // +cue-gen:RbacConfig:scope:Namespaced
 // +cue-gen:RbacConfig:resource:categories=istio-io,rbac-istio-io
+// +cue-gen:RbacConfig:preserveUnknownFields:false
 // -->
 //
 // <!-- crd generation tags
@@ -396,6 +399,7 @@ message RoleRef {
 // +cue-gen:ClusterRbacConfig:subresource:status
 // +cue-gen:ClusterRbacConfig:scope:Cluster
 // +cue-gen:ClusterRbacConfig:resource:categories=istio-io,rbac-istio-io
+// +cue-gen:ClusterRbacConfig:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/security/v1beta1/authorization.pb.go
+++ b/security/v1beta1/authorization.pb.go
@@ -218,6 +218,7 @@ func (AuthorizationPolicy_Action) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:AuthorizationPolicy:subresource:status
 // +cue-gen:AuthorizationPolicy:scope:Namespaced
 // +cue-gen:AuthorizationPolicy:resource:categories=istio-io,security-istio-io,plural=authorizationpolicies
+// +cue-gen:AuthorizationPolicy:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/security/v1beta1/authorization.proto
+++ b/security/v1beta1/authorization.proto
@@ -192,6 +192,7 @@ option go_package="istio.io/api/security/v1beta1";
 // +cue-gen:AuthorizationPolicy:subresource:status
 // +cue-gen:AuthorizationPolicy:scope:Namespaced
 // +cue-gen:AuthorizationPolicy:resource:categories=istio-io,security-istio-io,plural=authorizationpolicies
+// +cue-gen:AuthorizationPolicy:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/security/v1beta1/peer_authentication.pb.go
+++ b/security/v1beta1/peer_authentication.pb.go
@@ -145,6 +145,7 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:PeerAuthentication:subresource:status
 // +cue-gen:PeerAuthentication:scope:Namespaced
 // +cue-gen:PeerAuthentication:resource:categories=istio-io,security-istio-io,shortNames=pa
+// +cue-gen:PeerAuthentication:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/security/v1beta1/peer_authentication.proto
+++ b/security/v1beta1/peer_authentication.proto
@@ -112,6 +112,7 @@ option go_package="istio.io/api/security/v1beta1";
 // +cue-gen:PeerAuthentication:subresource:status
 // +cue-gen:PeerAuthentication:scope:Namespaced
 // +cue-gen:PeerAuthentication:resource:categories=istio-io,security-istio-io,shortNames=pa
+// +cue-gen:PeerAuthentication:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -133,6 +133,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // +cue-gen:RequestAuthentication:subresource:status
 // +cue-gen:RequestAuthentication:scope:Namespaced
 // +cue-gen:RequestAuthentication:resource:categories=istio-io,security-istio-io,shortNames=ra
+// +cue-gen:RequestAuthentication:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -136,6 +136,7 @@ option go_package="istio.io/api/security/v1beta1";
 // +cue-gen:RequestAuthentication:subresource:status
 // +cue-gen:RequestAuthentication:scope:Namespaced
 // +cue-gen:RequestAuthentication:resource:categories=istio-io,security-istio-io,shortNames=ra
+// +cue-gen:RequestAuthentication:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags


### PR DESCRIPTION
Starting Istio 1.6, the min version of k8s is 1.15(https://github.com/kubernetes/apiextensions-apiserver/blob/release-1.15/pkg/apis/apiextensions/v1beta1/types.go#L86) and we are able to support `preserveUnknownFields` field in CRDs. This enables `kubectl explain` as well as unknown fields validation.