### PR TITLE
Remove preserveUnknownFields from EnvoyFilter

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -3564,7 +3564,6 @@ spec:
     listKind: handlerList
     plural: handlers
     singular: handler
-  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -3772,7 +3771,6 @@ spec:
     listKind: instanceList
     plural: instances
     singular: instance
-  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -1696,7 +1696,6 @@ spec:
     listKind: EnvoyFilterList
     plural: envoyfilters
     singular: envoyfilter
-  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -426,7 +426,6 @@ func (EnvoyFilter_Patch_Operation) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:EnvoyFilter:subresource:status
 // +cue-gen:EnvoyFilter:scope:Namespaced
 // +cue-gen:EnvoyFilter:resource:categories=istio-io,networking-istio-io
-// +cue-gen:EnvoyFilter:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -219,7 +219,6 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:EnvoyFilter:subresource:status
 // +cue-gen:EnvoyFilter:scope:Namespaced
 // +cue-gen:EnvoyFilter:resource:categories=istio-io,networking-istio-io
-// +cue-gen:EnvoyFilter:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/policy/v1beta1/cfg.pb.go
+++ b/policy/v1beta1/cfg.pb.go
@@ -624,7 +624,6 @@ func (m *Action) GetName() string {
 // +cue-gen:instance:subresource:status
 // +cue-gen:instance:scope:Namespaced
 // +cue-gen:instance:resource:categories=istio-io,policy-istio-io
-// +cue-gen:instance:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -802,7 +801,6 @@ func (m *Instance) GetAttributeBindings() map[string]string {
 // +cue-gen:handler:subresource:status
 // +cue-gen:handler:scope:Namespaced
 // +cue-gen:handler:resource:categories=istio-io,policy-istio-io
-// +cue-gen:handler:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags

--- a/policy/v1beta1/cfg.proto
+++ b/policy/v1beta1/cfg.proto
@@ -284,7 +284,6 @@ message Action {
 // +cue-gen:instance:subresource:status
 // +cue-gen:instance:scope:Namespaced
 // +cue-gen:instance:resource:categories=istio-io,policy-istio-io
-// +cue-gen:instance:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags
@@ -399,7 +398,6 @@ message Instance {
 // +cue-gen:handler:subresource:status
 // +cue-gen:handler:scope:Namespaced
 // +cue-gen:handler:resource:categories=istio-io,policy-istio-io
-// +cue-gen:handler:preserveUnknownFields:false
 // -->
 //
 // <!-- go code generation tags


### PR DESCRIPTION
As mentioned in https://github.com/istio/istio/pull/23559#issuecomment-624412699, the field is causing validation failure in EnvoyFilter. Will create a follow up PR to add such field for EnvoyFilter.

Also remove from `handler` and `instance` where google.protobuf.Struct exists in their fields.