### PR TITLE
Add includeOutboundPorts annotation

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -496,6 +496,16 @@ var (
 		  Resources: []ResourceTypes{ Pod, },
         }
 	
+		SidecarTrafficIncludeOutboundPorts = Instance {
+          Name: "traffic.sidecar.istio.io/includeOutboundPorts",
+          Description: "A comma separated list of outbound ports for which "+
+                        "traffic is to be redirected to Envoy, regardless of the "+
+                        "destination IP.",
+          Hidden: false,
+          Deprecated: false,
+		  Resources: []ResourceTypes{ Pod, },
+        }
+	
 		SidecarTrafficKubevirtInterfaces = Instance {
           Name: "traffic.sidecar.istio.io/kubevirtInterfaces",
           Description: "A comma separated list of virtual interfaces whose "+
@@ -556,6 +566,7 @@ func AllResourceAnnotations() []*Instance {
 		&SidecarTrafficExcludeOutboundPorts,
 		&SidecarTrafficIncludeInboundPorts,
 		&SidecarTrafficIncludeOutboundIPRanges,
+		&SidecarTrafficIncludeOutboundPorts,
 		&SidecarTrafficKubevirtInterfaces,
 	}
 }

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -461,6 +461,16 @@ Istio supports to control its behavior.
 				
 					<tr>
 				
+					<td><code>traffic.sidecar.istio.io/includeOutboundPorts</code></td>
+					<td>[Pod]</td>
+					<td>A comma separated list of outbound ports for which traffic is to be redirected to Envoy, regardless of the destination IP.</td>
+				</tr>
+			
+		
+			
+				
+					<tr>
+				
 					<td><code>traffic.sidecar.istio.io/kubevirtInterfaces</code></td>
 					<td>[Pod]</td>
 					<td>A comma separated list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound.</td>

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -260,6 +260,13 @@ annotations:
     hidden: false
     resources:
       - Pod
+  - name: traffic.sidecar.istio.io/includeOutboundPorts
+    description: A comma separated list of outbound ports for which traffic is to be
+      redirected to Envoy, regardless of the destination IP.
+    deprecated: false
+    hidden: false
+    resources:
+      - Pod
   - name: traffic.sidecar.istio.io/excludeOutboundPorts
     description: A comma separated list of outbound ports to be excluded from redirection
       to Envoy.


### PR DESCRIPTION
Related to https://github.com/istio/istio/pull/23941 and in preparation for a matching CNI PR, this change defines the new `includeOutboundPorts` annotation that is ultimately used by `istio-iptables`.