### PR TITLE
doc: correct the comment of Gateway

### DIFF
--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -27,7 +27,7 @@
 // sequentially in order of creation time.  The behavior is undefined
 // if multiple EnvoyFilter configurations conflict with each other.
 //
-// **NOTE 3**: *_To apply an EnvoyFilter resource to all workloads
+// **NOTE 3**: To apply an EnvoyFilter resource to all workloads
 // (sidecars and gateways) in the system, define the resource in the
 // config [root
 // namespace](https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig),

--- a/networking/v1alpha3/envoy_filter.pb.html
+++ b/networking/v1alpha3/envoy_filter.pb.html
@@ -34,7 +34,7 @@ workload in a given namespace, all patches will be processed
 sequentially in order of creation time.  The behavior is undefined
 if multiple EnvoyFilter configurations conflict with each other.</p>
 
-<p><strong>NOTE 3</strong>: *_To apply an EnvoyFilter resource to all workloads
+<p><strong>NOTE 3</strong>: To apply an EnvoyFilter resource to all workloads
 (sidecars and gateways) in the system, define the resource in the
 config <a href="https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig">root
 namespace</a>,

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -50,7 +50,7 @@ import "networking/v1alpha3/sidecar.proto";
 // sequentially in order of creation time.  The behavior is undefined
 // if multiple EnvoyFilter configurations conflict with each other.
 //
-// **NOTE 3**: *_To apply an EnvoyFilter resource to all workloads
+// **NOTE 3**: To apply an EnvoyFilter resource to all workloads
 // (sidecars and gateways) in the system, define the resource in the
 // config [root
 // namespace](https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig),

--- a/networking/v1alpha3/envoy_filter_deepcopy.gen.go
+++ b/networking/v1alpha3/envoy_filter_deepcopy.gen.go
@@ -27,7 +27,7 @@
 // sequentially in order of creation time.  The behavior is undefined
 // if multiple EnvoyFilter configurations conflict with each other.
 //
-// **NOTE 3**: *_To apply an EnvoyFilter resource to all workloads
+// **NOTE 3**: To apply an EnvoyFilter resource to all workloads
 // (sidecars and gateways) in the system, define the resource in the
 // config [root
 // namespace](https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig),

--- a/networking/v1alpha3/envoy_filter_json.gen.go
+++ b/networking/v1alpha3/envoy_filter_json.gen.go
@@ -27,7 +27,7 @@
 // sequentially in order of creation time.  The behavior is undefined
 // if multiple EnvoyFilter configurations conflict with each other.
 //
-// **NOTE 3**: *_To apply an EnvoyFilter resource to all workloads
+// **NOTE 3**: To apply an EnvoyFilter resource to all workloads
 // (sidecars and gateways) in the system, define the resource in the
 // config [root
 // namespace](https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig),

--- a/networking/v1alpha3/gateway.gen.json
+++ b/networking/v1alpha3/gateway.gen.json
@@ -18,7 +18,7 @@
             }
           },
           "selector": {
-            "description": "One or more labels that indicate a specific set of pods/VMs on which this gateway configuration should be applied. The scope of label search is restricted to the configuration namespace in which the the resource is present. In other words, the Gateway resource must reside in the same namespace as the gateway workload instance.",
+            "description": "One or more labels that indicate a specific set of pods/VMs on which this gateway configuration should be applied. The scope of label search is restricted to the configuration namespace in which the the resource is present. In other words, the Gateway resource must reside in the same namespace as the gateway workload instance. If selector is nil, the Gateway will be applied to all workloads.",
             "type": "object",
             "additionalProperties": {
               "type": "string",

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -478,6 +478,7 @@ type Gateway struct {
 	// label search is restricted to the configuration namespace in which the
 	// the resource is present. In other words, the Gateway resource must
 	// reside in the same namespace as the gateway workload instance.
+	// If selector is nil, the Gateway will be applied to all workloads.
 	Selector             map[string]string `protobuf:"bytes,2,rep,name=selector,proto3" json:"selector,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -377,7 +377,8 @@ Yes
 on which this gateway configuration should be applied. The scope of
 label search is restricted to the configuration namespace in which the
 the resource is present. In other words, the Gateway resource must
-reside in the same namespace as the gateway workload instance.</p>
+reside in the same namespace as the gateway workload instance.
+If selector is nil, the Gateway will be applied to all workloads.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -383,6 +383,7 @@ message Gateway {
   // label search is restricted to the configuration namespace in which the
   // the resource is present. In other words, the Gateway resource must
   // reside in the same namespace as the gateway workload instance.
+  // If selector is nil, the Gateway will be applied to all workloads.
   map<string, string> selector = 2 [(google.api.field_behavior) = REQUIRED];
 }
 

--- a/networking/v1beta1/gateway.gen.json
+++ b/networking/v1beta1/gateway.gen.json
@@ -18,7 +18,7 @@
             }
           },
           "selector": {
-            "description": "One or more labels that indicate a specific set of pods/VMs on which this gateway configuration should be applied. The scope of label search is restricted to the configuration namespace in which the the resource is present. In other words, the Gateway resource must reside in the same namespace as the gateway workload instance.",
+            "description": "One or more labels that indicate a specific set of pods/VMs on which this gateway configuration should be applied. The scope of label search is restricted to the configuration namespace in which the the resource is present. In other words, the Gateway resource must reside in the same namespace as the gateway workload instance. If selector is nil, the Gateway will be applied to all workloads.",
             "type": "object",
             "additionalProperties": {
               "type": "string",

--- a/networking/v1beta1/gateway.pb.go
+++ b/networking/v1beta1/gateway.pb.go
@@ -479,6 +479,7 @@ type Gateway struct {
 	// label search is restricted to the configuration namespace in which the
 	// the resource is present. In other words, the Gateway resource must
 	// reside in the same namespace as the gateway workload instance.
+	// If selector is nil, the Gateway will be applied to all workloads.
 	Selector             map[string]string `protobuf:"bytes,2,rep,name=selector,proto3" json:"selector,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`

--- a/networking/v1beta1/gateway.proto
+++ b/networking/v1beta1/gateway.proto
@@ -384,6 +384,7 @@ message Gateway {
   // label search is restricted to the configuration namespace in which the
   // the resource is present. In other words, the Gateway resource must
   // reside in the same namespace as the gateway workload instance.
+  // If selector is nil, the Gateway will be applied to all workloads.
   map<string, string> selector = 2 [(google.api.field_behavior) = REQUIRED];
 }
 


### PR DESCRIPTION
The scope of label search is not only restricted to the configuration namespace in which the Gateway resource is present, the current comment may confuse users.