### PR TITLE
CORS Policy Example: Change allowOrigins block

### DIFF
--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -2615,8 +2615,8 @@ func (m *HTTPRetry) GetRetryRemoteLocalities() *types.BoolValue {
 //         host: ratings.prod.svc.cluster.local
 //         subset: v1
 //     corsPolicy:
-//       allowOrigin:
-//       - example.com
+//       allowOrigins:
+//       - exact: https://example.com
 //       allowMethods:
 //       - POST
 //       - GET
@@ -2642,8 +2642,8 @@ func (m *HTTPRetry) GetRetryRemoteLocalities() *types.BoolValue {
 //         host: ratings.prod.svc.cluster.local
 //         subset: v1
 //     corsPolicy:
-//       allowOrigin:
-//       - example.com
+//       allowOrigins:
+//       - exact: https://example.com
 //       allowMethods:
 //       - POST
 //       - GET

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -2261,8 +2261,8 @@ spec:
         host: ratings.prod.svc.cluster.local
         subset: v1
     corsPolicy:
-      allowOrigin:
-      - example.com
+      allowOrigins:
+      - exact: https://example.com
       allowMethods:
       - POST
       - GET
@@ -2289,8 +2289,8 @@ spec:
         host: ratings.prod.svc.cluster.local
         subset: v1
     corsPolicy:
-      allowOrigin:
-      - example.com
+      allowOrigins:
+      - exact: https://example.com
       allowMethods:
       - POST
       - GET

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -1582,8 +1582,8 @@ message HTTPRetry {
 //         host: ratings.prod.svc.cluster.local
 //         subset: v1
 //     corsPolicy:
-//       allowOrigin:
-//       - example.com
+//       allowOrigins:
+//       - exact: https://example.com
 //       allowMethods:
 //       - POST
 //       - GET
@@ -1609,8 +1609,8 @@ message HTTPRetry {
 //         host: ratings.prod.svc.cluster.local
 //         subset: v1
 //     corsPolicy:
-//       allowOrigin:
-//       - example.com
+//       allowOrigins:
+//       - exact: https://example.com
 //       allowMethods:
 //       - POST
 //       - GET

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -2614,8 +2614,8 @@ func (m *HTTPRetry) GetRetryRemoteLocalities() *types.BoolValue {
 //         host: ratings.prod.svc.cluster.local
 //         subset: v1
 //     corsPolicy:
-//       allowOrigin:
-//       - example.com
+//       allowOrigins:
+//       - exact: https://example.com
 //       allowMethods:
 //       - POST
 //       - GET
@@ -2641,8 +2641,8 @@ func (m *HTTPRetry) GetRetryRemoteLocalities() *types.BoolValue {
 //         host: ratings.prod.svc.cluster.local
 //         subset: v1
 //     corsPolicy:
-//       allowOrigin:
-//       - example.com
+//       allowOrigins:
+//       - exact: https://example.com
 //       allowMethods:
 //       - POST
 //       - GET

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -1579,8 +1579,8 @@ message HTTPRetry {
 //         host: ratings.prod.svc.cluster.local
 //         subset: v1
 //     corsPolicy:
-//       allowOrigin:
-//       - example.com
+//       allowOrigins:
+//       - exact: https://example.com
 //       allowMethods:
 //       - POST
 //       - GET
@@ -1606,8 +1606,8 @@ message HTTPRetry {
 //         host: ratings.prod.svc.cluster.local
 //         subset: v1
 //     corsPolicy:
-//       allowOrigin:
-//       - example.com
+//       allowOrigins:
+//       - exact: https://example.com
 //       allowMethods:
 //       - POST
 //       - GET


### PR DESCRIPTION
### Description
In this PR, we change the block of CORS Policy definition from `allowOrigin` to `allowOrigins` so not to be misleading for people who take this example as guide to setup their meshes.

After the upgrading to Istio 1.6, the block with deprecated `allowOrigin` is not respected thus not working.

### Addresses
https://github.com/istio/istio/issues/24145