### PR TITLE
fix: typo

### DIFF
--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -27,7 +27,7 @@ package istio.security.v1beta1;
 option go_package="istio.io/api/security/v1beta1";
 
 // RequestAuthentication defines what request authentication methods are supported by a workload.
-// If will reject a request if the request contains invalid authentication information, based on the
+// It will reject a request if the request contains invalid authentication information, based on the
 // configured authentication rules. A request that does not contain any authentication credentials
 // will be accepted but will not have any authenticated identity. To restrict access to authenticated
 // requests only, this should be accompanied by an authorization rule.


### PR DESCRIPTION
Fixes a tiny and easy to miss typo in the docs.