### PR TITLE
Deprecated "consecutiveErrors" is replaced with "consecutive5xxErrors"

### DIFF
--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -677,7 +677,7 @@ message ConnectionPoolSettings {
 //         http2MaxRequests: 1000
 //         maxRequestsPerConnection: 10
 //     outlierDetection:
-//       consecutiveErrors: 7
+//       consecutive5xxErrors: 7
 //       interval: 5m
 //       baseEjectionTime: 15m
 // ```
@@ -699,7 +699,7 @@ message ConnectionPoolSettings {
 //         http2MaxRequests: 1000
 //         maxRequestsPerConnection: 10
 //     outlierDetection:
-//       consecutiveErrors: 7
+//       consecutive5xxErrors: 7
 //       interval: 5m
 //       baseEjectionTime: 15m
 // ```


### PR DESCRIPTION
Deprecated "consecutiveErrors" is replaced with "consecutive5xxErrors".

https://github.com/istio/istio.io/pull/7611