### PR TITLE
Specify defaults for mesh and proxy configs

### DIFF
--- a/mesh/v1alpha1/config.pb.go
+++ b/mesh/v1alpha1/config.pb.go
@@ -226,11 +226,11 @@ type MeshConfig struct {
 	// calls.
 	MixerReportServer string `protobuf:"bytes,2,opt,name=mixer_report_server,json=mixerReportServer,proto3" json:"mixerReportServer,omitempty"` // Deprecated: Do not use.
 	// Disable policy checks by the Mixer service. Default
-	// is false, i.e. Mixer policy check is enabled by default.
+	// is true, i.e. Mixer policy check is disabled by default.
 	DisablePolicyChecks bool `protobuf:"varint,3,opt,name=disable_policy_checks,json=disablePolicyChecks,proto3" json:"disablePolicyChecks,omitempty"` // Deprecated: Do not use.
 	// $hide_from_docs
 	// Disable telemetry reporting by the Mixer service for HTTP traffic.
-	// Default is false (telemetry reporting via Mixer is enabled).
+	// Default is true (telemetry reporting via Mixer is disabled).
 	// This option provides a transition path for Istio extensibility v2.
 	DisableMixerHttpReports bool `protobuf:"varint,48,opt,name=disable_mixer_http_reports,json=disableMixerHttpReports,proto3" json:"disableMixerHttpReports,omitempty"` // Deprecated: Do not use.
 	// Allow all traffic in cases when the Mixer policy service cannot be reached.
@@ -238,25 +238,26 @@ type MeshConfig struct {
 	// to connect to Mixer.
 	PolicyCheckFailOpen bool `protobuf:"varint,25,opt,name=policy_check_fail_open,json=policyCheckFailOpen,proto3" json:"policyCheckFailOpen,omitempty"` // Deprecated: Do not use.
 	// Enable session affinity for Envoy Mixer reports so that calls from a proxy will
-	// always target the same Mixer instance.
+	// always target the same Mixer instance. Default value is false.
 	SidecarToTelemetrySessionAffinity bool `protobuf:"varint,30,opt,name=sidecar_to_telemetry_session_affinity,json=sidecarToTelemetrySessionAffinity,proto3" json:"sidecarToTelemetrySessionAffinity,omitempty"` // Deprecated: Do not use.
 	// Port on which Envoy should listen for incoming connections from
-	// other services.
+	// other services. Default port is 15001.
 	ProxyListenPort int32 `protobuf:"varint,4,opt,name=proxy_listen_port,json=proxyListenPort,proto3" json:"proxyListenPort,omitempty"`
 	// Port on which Envoy should listen for HTTP PROXY requests if set.
 	ProxyHttpPort int32 `protobuf:"varint,5,opt,name=proxy_http_port,json=proxyHttpPort,proto3" json:"proxyHttpPort,omitempty"`
 	// Connection timeout used by Envoy. (MUST BE >=1ms)
+	// Default timeout is 10s.
 	ConnectTimeout *types.Duration `protobuf:"bytes,6,opt,name=connect_timeout,json=connectTimeout,proto3" json:"connectTimeout,omitempty"`
 	// Automatic protocol detection uses a set of heuristics to
 	// determine whether the connection is using TLS or not (on the
 	// server side), as well as the application protocol being used
 	// (e.g., http vs tcp). These heuristics rely on the client sending
 	// the first bits of data. For server first protocols like MySQL,
-	// MongoDB, etc., Envoy will timeout on the protocol detection after
+	// MongoDB, etc. Envoy will timeout on the protocol detection after
 	// the specified period, defaulting to non mTLS plain TCP
 	// traffic. Set this field to tweak the period that Envoy will wait
 	// for the client to send the first bits of data. (MUST BE >=1ms or
-	// 0s to disable)
+	// 0s to disable). Default detection timeout is 5s.
 	ProtocolDetectionTimeout *types.Duration `protobuf:"bytes,42,opt,name=protocol_detection_timeout,json=protocolDetectionTimeout,proto3" json:"protocolDetectionTimeout,omitempty"`
 	// If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
 	TcpKeepalive *v1alpha3.ConnectionPoolSettings_TCPSettings_TcpKeepalive `protobuf:"bytes,28,opt,name=tcp_keepalive,json=tcpKeepalive,proto3" json:"tcpKeepalive,omitempty"`
@@ -265,8 +266,10 @@ type MeshConfig struct {
 	// "kubernetes.io/ingress.class" annotation.
 	IngressClass string `protobuf:"bytes,7,opt,name=ingress_class,json=ingressClass,proto3" json:"ingressClass,omitempty"`
 	// Name of the Kubernetes service used for the istio ingress controller.
+	// If no ingress controller is specified, the default value `istio-ingressgateway` is used.
 	IngressService string `protobuf:"bytes,8,opt,name=ingress_service,json=ingressService,proto3" json:"ingressService,omitempty"`
 	// Defines whether to use Istio ingress controller for annotated or all ingress resources.
+	// Default mode is STRICT.
 	IngressControllerMode MeshConfig_IngressControllerMode `protobuf:"varint,9,opt,name=ingress_controller_mode,json=ingressControllerMode,proto3,enum=istio.mesh.v1alpha1.MeshConfig_IngressControllerMode" json:"ingressControllerMode,omitempty"`
 	// Defines which gateway deployment to use as the Ingress controller. This field corresponds to
 	// the Gateway.selector field, and will be set as `istio: INGRESS_SELECTOR`.
@@ -293,6 +296,7 @@ type MeshConfig struct {
 	// This flag enables Envoy's gRPC Access Log Service.
 	// See [Access Log Service](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto)
 	// for details about Envoy's gRPC Access Log Service API.
+	// Default value is false.
 	EnableEnvoyAccessLogService bool `protobuf:"varint,40,opt,name=enable_envoy_access_log_service,json=enableEnvoyAccessLogService,proto3" json:"enableEnvoyAccessLogService,omitempty"`
 	// Default proxy config used by the proxy injection mechanism operating in the mesh
 	// (e.g. Kubernetes admission controller)
@@ -307,12 +311,13 @@ type MeshConfig struct {
 	// more external services that are not known apriori, setting the
 	// policy to ALLOW_ANY will cause the sidecars to route any unknown
 	// traffic originating from the application to its requested
-	// destination.  Users are strongly encouraged to use ServiceEntries
+	// destination. Users are strongly encouraged to use ServiceEntries
 	// to explicitly declare any external dependencies, instead of using
 	// allow_any, so that traffic to these services can be
 	// monitored. Can be overridden at a Sidecar level by setting the
 	// OutboundTrafficPolicy in the [Sidecar
 	// API](https://istio.io/docs/reference/config/networking/sidecar/#OutboundTrafficPolicy).
+	// Default mode is ALLOW_ANY which means outbound traffic to unknown destinations will be allowed.
 	OutboundTrafficPolicy *MeshConfig_OutboundTrafficPolicy `protobuf:"bytes,17,opt,name=outbound_traffic_policy,json=outboundTrafficPolicy,proto3" json:"outboundTrafficPolicy,omitempty"`
 	// Enables client side policy checks.
 	EnableClientSidePolicyCheck bool `protobuf:"varint,19,opt,name=enable_client_side_policy_check,json=enableClientSidePolicyCheck,proto3" json:"enableClientSidePolicyCheck,omitempty"`
@@ -345,6 +350,7 @@ type MeshConfig struct {
 	// for Kubernetes service account trustworthy JWT(which is available with Kubernetes 1.12 or higher), so that the Kubernetes API server
 	// mounts Kubernetes service account trustworthy JWT to the Envoy container, which will be used to request key/cert eventually.
 	// This isn't supported for non-Kubernetes cases.
+	// Default value is set to false.
 	EnableSdsTokenMount bool `protobuf:"varint,23,opt,name=enable_sds_token_mount,json=enableSdsTokenMount,proto3" json:"enableSdsTokenMount,omitempty"`
 	// $hide_from_docs
 	// This flag is used by secret discovery service(SDS).
@@ -415,18 +421,19 @@ type MeshConfig struct {
 	// Locality based load balancing distribution or failover settings.
 	LocalityLbSetting *v1alpha3.LocalityLoadBalancerSetting `protobuf:"bytes,35,opt,name=locality_lb_setting,json=localityLbSetting,proto3" json:"localityLbSetting,omitempty"`
 	// Configures DNS refresh rate for Envoy clusters of type STRICT_DNS
+	// Default refresh rate is 5s.
 	DnsRefreshRate *types.Duration `protobuf:"bytes,36,opt,name=dns_refresh_rate,json=dnsRefreshRate,proto3" json:"dnsRefreshRate,omitempty"`
 	// The flag to disable report batch.
 	DisableReportBatch bool `protobuf:"varint,37,opt,name=disable_report_batch,json=disableReportBatch,proto3" json:"disableReportBatch,omitempty"` // Deprecated: Do not use.
 	// When disable_report_batch is false, this value specifies the maximum number
 	// of requests that are batched in report. If left unspecified, the default value
 	// of report_batch_max_entries == 0 will use the hardcoded defaults of
-	// istio::mixerclient::ReportOptions.
+	// istio::mixerclient::ReportOptions. Default value is 100.
 	ReportBatchMaxEntries uint32 `protobuf:"varint,38,opt,name=report_batch_max_entries,json=reportBatchMaxEntries,proto3" json:"reportBatchMaxEntries,omitempty"` // Deprecated: Do not use.
 	// When disable_report_batch is false, this value specifies the maximum elapsed
 	// time a batched report will be sent after a user request is processed. If left
 	// unspecified, the default report_batch_max_time == 0 will use the hardcoded
-	// defaults of istio::mixerclient::ReportOptions.
+	// defaults of istio::mixerclient::ReportOptions. Default max time is 1s.
 	ReportBatchMaxTime *types.Duration `protobuf:"bytes,39,opt,name=report_batch_max_time,json=reportBatchMaxTime,proto3" json:"reportBatchMaxTime,omitempty"` // Deprecated: Do not use.
 	// Specify if http1.1 connections should be upgraded to http2 by default.
 	// if sidecar is installed on all pods in the mesh, then this should be set to UPGRADE.

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -54,12 +54,12 @@ message MeshConfig {
   string mixer_report_server = 2 [deprecated=true];
 
   // Disable policy checks by the Mixer service. Default
-  // is false, i.e. Mixer policy check is enabled by default.
+  // is true, i.e. Mixer policy check is disabled by default.
   bool disable_policy_checks = 3 [deprecated=true];
 
   // $hide_from_docs
   // Disable telemetry reporting by the Mixer service for HTTP traffic.
-  // Default is false (telemetry reporting via Mixer is enabled).
+  // Default is true (telemetry reporting via Mixer is disabled).
   // This option provides a transition path for Istio extensibility v2.
   bool disable_mixer_http_reports = 48 [deprecated=true];
 
@@ -69,17 +69,18 @@ message MeshConfig {
   bool policy_check_fail_open = 25 [deprecated=true];
 
   // Enable session affinity for Envoy Mixer reports so that calls from a proxy will
-  // always target the same Mixer instance.
+  // always target the same Mixer instance. Default value is false.
   bool sidecar_to_telemetry_session_affinity = 30 [deprecated=true];
 
   // Port on which Envoy should listen for incoming connections from
-  // other services.
+  // other services. Default port is 15001.
   int32 proxy_listen_port = 4;
 
   // Port on which Envoy should listen for HTTP PROXY requests if set.
   int32 proxy_http_port = 5;
 
   // Connection timeout used by Envoy. (MUST BE >=1ms)
+  // Default timeout is 10s.
   google.protobuf.Duration connect_timeout = 6;
 
   // Automatic protocol detection uses a set of heuristics to
@@ -87,11 +88,11 @@ message MeshConfig {
   // server side), as well as the application protocol being used
   // (e.g., http vs tcp). These heuristics rely on the client sending
   // the first bits of data. For server first protocols like MySQL,
-  // MongoDB, etc., Envoy will timeout on the protocol detection after
+  // MongoDB, etc. Envoy will timeout on the protocol detection after
   // the specified period, defaulting to non mTLS plain TCP
   // traffic. Set this field to tweak the period that Envoy will wait
   // for the client to send the first bits of data. (MUST BE >=1ms or 
-  // 0s to disable)
+  // 0s to disable). Default detection timeout is 5s.
   google.protobuf.Duration protocol_detection_timeout = 42;
 
   // If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
@@ -103,6 +104,7 @@ message MeshConfig {
   string ingress_class = 7;
 
   // Name of the Kubernetes service used for the istio ingress controller.
+  // If no ingress controller is specified, the default value `istio-ingressgateway` is used.
   string ingress_service = 8;
 
   enum IngressControllerMode {
@@ -128,6 +130,7 @@ message MeshConfig {
   }
 
   // Defines whether to use Istio ingress controller for annotated or all ingress resources.
+  // Default mode is STRICT.
   IngressControllerMode ingress_controller_mode = 9;
 
   // Defines which gateway deployment to use as the Ingress controller. This field corresponds to
@@ -173,6 +176,7 @@ message MeshConfig {
   // This flag enables Envoy's gRPC Access Log Service.
   // See [Access Log Service](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto)
   // for details about Envoy's gRPC Access Log Service API.
+  // Default value is false.
   bool enable_envoy_access_log_service = 40;
 
   // Default proxy config used by the proxy injection mechanism operating in the mesh
@@ -207,12 +211,13 @@ message MeshConfig {
   // more external services that are not known apriori, setting the
   // policy to ALLOW_ANY will cause the sidecars to route any unknown
   // traffic originating from the application to its requested
-  // destination.  Users are strongly encouraged to use ServiceEntries
+  // destination. Users are strongly encouraged to use ServiceEntries
   // to explicitly declare any external dependencies, instead of using
   // allow_any, so that traffic to these services can be
   // monitored. Can be overridden at a Sidecar level by setting the
   // OutboundTrafficPolicy in the [Sidecar
   // API](https://istio.io/docs/reference/config/networking/sidecar/#OutboundTrafficPolicy).
+  // Default mode is ALLOW_ANY which means outbound traffic to unknown destinations will be allowed.
   OutboundTrafficPolicy outbound_traffic_policy = 17;
 
   reserved 18;
@@ -253,6 +258,7 @@ message MeshConfig {
   // for Kubernetes service account trustworthy JWT(which is available with Kubernetes 1.12 or higher), so that the Kubernetes API server
   // mounts Kubernetes service account trustworthy JWT to the Envoy container, which will be used to request key/cert eventually.
   // This isn't supported for non-Kubernetes cases.
+  // Default value is set to false.
   bool enable_sds_token_mount = 23;
 
   // $hide_from_docs
@@ -332,6 +338,7 @@ message MeshConfig {
   istio.networking.v1alpha3.LocalityLoadBalancerSetting locality_lb_setting = 35;
 
   // Configures DNS refresh rate for Envoy clusters of type STRICT_DNS
+  // Default refresh rate is 5s.
   google.protobuf.Duration dns_refresh_rate = 36;
 
   // The flag to disable report batch.
@@ -340,13 +347,13 @@ message MeshConfig {
   // When disable_report_batch is false, this value specifies the maximum number
   // of requests that are batched in report. If left unspecified, the default value
   // of report_batch_max_entries == 0 will use the hardcoded defaults of
-  // istio::mixerclient::ReportOptions.
+  // istio::mixerclient::ReportOptions. Default value is 100.
   uint32 report_batch_max_entries = 38 [deprecated=true];
 
   // When disable_report_batch is false, this value specifies the maximum elapsed
   // time a batched report will be sent after a user request is processed. If left
   // unspecified, the default report_batch_max_time == 0 will use the hardcoded
-  // defaults of istio::mixerclient::ReportOptions.
+  // defaults of istio::mixerclient::ReportOptions. Default max time is 1s.
   google.protobuf.Duration report_batch_max_time = 39 [deprecated=true];
 
   // Default Policy for upgrading http1.1 connections to http2.

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -14,7 +14,7 @@
             "$ref": "#/components/schemas/istio.networking.v1alpha3.LocalityLoadBalancerSetting"
           },
           "connectTimeout": {
-            "description": "Connection timeout used by Envoy. (MUST BE \u003e=1ms)",
+            "description": "Connection timeout used by Envoy. (MUST BE \u003e=1ms) Default timeout is 10s.",
             "type": "string"
           },
           "tcpKeepalive": {
@@ -39,12 +39,12 @@
             "deprecated": true
           },
           "disablePolicyChecks": {
-            "description": "Disable policy checks by the Mixer service. Default is false, i.e. Mixer policy check is enabled by default.",
+            "description": "Disable policy checks by the Mixer service. Default is true, i.e. Mixer policy check is disabled by default.",
             "type": "boolean",
             "deprecated": true
           },
           "disableMixerHttpReports": {
-            "description": "Disable telemetry reporting by the Mixer service for HTTP traffic. Default is false (telemetry reporting via Mixer is enabled). This option provides a transition path for Istio extensibility v2.",
+            "description": "Disable telemetry reporting by the Mixer service for HTTP traffic. Default is true (telemetry reporting via Mixer is disabled). This option provides a transition path for Istio extensibility v2.",
             "type": "boolean",
             "deprecated": true
           },
@@ -54,12 +54,12 @@
             "deprecated": true
           },
           "sidecarToTelemetrySessionAffinity": {
-            "description": "Enable session affinity for Envoy Mixer reports so that calls from a proxy will always target the same Mixer instance.",
+            "description": "Enable session affinity for Envoy Mixer reports so that calls from a proxy will always target the same Mixer instance. Default value is false.",
             "type": "boolean",
             "deprecated": true
           },
           "proxyListenPort": {
-            "description": "Port on which Envoy should listen for incoming connections from other services.",
+            "description": "Port on which Envoy should listen for incoming connections from other services. Default port is 15001.",
             "type": "integer",
             "format": "int32"
           },
@@ -69,7 +69,7 @@
             "format": "int32"
           },
           "protocolDetectionTimeout": {
-            "description": "Automatic protocol detection uses a set of heuristics to determine whether the connection is using TLS or not (on the server side), as well as the application protocol being used (e.g., http vs tcp). These heuristics rely on the client sending the first bits of data. For server first protocols like MySQL, MongoDB, etc., Envoy will timeout on the protocol detection after the specified period, defaulting to non mTLS plain TCP traffic. Set this field to tweak the period that Envoy will wait for the client to send the first bits of data. (MUST BE \u003e=1ms or 0s to disable)",
+            "description": "Automatic protocol detection uses a set of heuristics to determine whether the connection is using TLS or not (on the server side), as well as the application protocol being used (e.g., http vs tcp). These heuristics rely on the client sending the first bits of data. For server first protocols like MySQL, MongoDB, etc. Envoy will timeout on the protocol detection after the specified period, defaulting to non mTLS plain TCP traffic. Set this field to tweak the period that Envoy will wait for the client to send the first bits of data. (MUST BE \u003e=1ms or 0s to disable). Default detection timeout is 5s.",
             "type": "string"
           },
           "ingressClass": {
@@ -78,7 +78,7 @@
             "format": "string"
           },
           "ingressService": {
-            "description": "Name of the Kubernetes service used for the istio ingress controller.",
+            "description": "Name of the Kubernetes service used for the istio ingress controller. If no ingress controller is specified, the default value `istio-ingressgateway` is used.",
             "type": "string",
             "format": "string"
           },
@@ -116,7 +116,7 @@
             "$ref": "#/components/schemas/istio.mesh.v1alpha1.MeshConfig.AccessLogEncoding"
           },
           "enableEnvoyAccessLogService": {
-            "description": "This flag enables Envoy's gRPC Access Log Service. See [Access Log Service](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto) for details about Envoy's gRPC Access Log Service API.",
+            "description": "This flag enables Envoy's gRPC Access Log Service. See [Access Log Service](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto) for details about Envoy's gRPC Access Log Service API. Default value is false.",
             "type": "boolean"
           },
           "defaultConfig": {
@@ -154,7 +154,7 @@
             "nullable": true
           },
           "enableSdsTokenMount": {
-            "description": "This flag is used by secret discovery service(SDS). If set to true ([prerequisite](https://kubernetes.io/docs/concepts/storage/volumes/#projected)), Istio will inject volumes mount for Kubernetes service account trustworthy JWT(which is available with Kubernetes 1.12 or higher), so that the Kubernetes API server mounts Kubernetes service account trustworthy JWT to the Envoy container, which will be used to request key/cert eventually. This isn't supported for non-Kubernetes cases.",
+            "description": "This flag is used by secret discovery service(SDS). If set to true ([prerequisite](https://kubernetes.io/docs/concepts/storage/volumes/#projected)), Istio will inject volumes mount for Kubernetes service account trustworthy JWT(which is available with Kubernetes 1.12 or higher), so that the Kubernetes API server mounts Kubernetes service account trustworthy JWT to the Envoy container, which will be used to request key/cert eventually. This isn't supported for non-Kubernetes cases. Default value is set to false.",
             "type": "boolean"
           },
           "sdsUseK8sSaJwt": {
@@ -204,7 +204,7 @@
             "format": "string"
           },
           "dnsRefreshRate": {
-            "description": "Configures DNS refresh rate for Envoy clusters of type STRICT_DNS",
+            "description": "Configures DNS refresh rate for Envoy clusters of type STRICT_DNS Default refresh rate is 5s.",
             "type": "string"
           },
           "disableReportBatch": {
@@ -213,12 +213,12 @@
             "deprecated": true
           },
           "reportBatchMaxEntries": {
-            "description": "When disable_report_batch is false, this value specifies the maximum number of requests that are batched in report. If left unspecified, the default value of report_batch_max_entries == 0 will use the hardcoded defaults of istio::mixerclient::ReportOptions.",
+            "description": "When disable_report_batch is false, this value specifies the maximum number of requests that are batched in report. If left unspecified, the default value of report_batch_max_entries == 0 will use the hardcoded defaults of istio::mixerclient::ReportOptions. Default value is 100.",
             "type": "integer",
             "deprecated": true
           },
           "reportBatchMaxTime": {
-            "description": "When disable_report_batch is false, this value specifies the maximum elapsed time a batched report will be sent after a user request is processed. If left unspecified, the default report_batch_max_time == 0 will use the hardcoded defaults of istio::mixerclient::ReportOptions.",
+            "description": "When disable_report_batch is false, this value specifies the maximum elapsed time a batched report will be sent after a user request is processed. If left unspecified, the default report_batch_max_time == 0 will use the hardcoded defaults of istio::mixerclient::ReportOptions. Default max time is 1s.",
             "type": "string",
             "deprecated": true
           },
@@ -299,11 +299,11 @@
             "format": "string"
           },
           "drainDuration": {
-            "description": "The time in seconds that Envoy will drain connections during a hot restart. MUST be \u003e=1s (e.g., _1s/1m/1h_)",
+            "description": "The time in seconds that Envoy will drain connections during a hot restart. MUST be \u003e=1s (e.g., _1s/1m/1h_) Default drain duration is 45s.",
             "type": "string"
           },
           "parentShutdownDuration": {
-            "description": "The time in seconds that Envoy will wait before shutting down the parent process during a hot restart. MUST be \u003e=1s (e.g., _1s/1m/1h_). MUST BE greater than _drain_duration_ parameter.",
+            "description": "The time in seconds that Envoy will wait before shutting down the parent process during a hot restart. MUST be \u003e=1s (e.g., _1s/1m/1h_). MUST BE greater than _drain_duration_ parameter. Default shutdown duration is 60s.",
             "type": "string"
           },
           "discoveryAddress": {
@@ -332,7 +332,7 @@
             "deprecated": true
           },
           "proxyAdminPort": {
-            "description": "Port on which Envoy should listen for administrative commands.",
+            "description": "Port on which Envoy should listen for administrative commands. Default port is 15000.",
             "type": "integer",
             "format": "int32"
           },
@@ -355,7 +355,7 @@
             "format": "int32"
           },
           "concurrency": {
-            "description": "The number of worker threads to run. If unset, this will be automatically determined based on CPU requests/limits. If set to 0, all cores on the machine will be used.",
+            "description": "The number of worker threads to run. If unset, this will be automatically determined based on CPU requests/limits. If set to 0, all cores on the machine will be used. Default is 2 worker threads.",
             "type": "integer",
             "nullable": true
           },
@@ -388,7 +388,7 @@
             }
           },
           "statusPort": {
-            "description": "Port on which the agent should listen for administrative commands such as readiness probe.",
+            "description": "Port on which the agent should listen for administrative commands such as readiness probe. Default is set to port 15020.",
             "type": "integer",
             "format": "int32"
           },

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -189,7 +189,8 @@ No
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
 <p>The time in seconds that Envoy will drain connections during a hot
-restart. MUST be &gt;=1s (e.g., <em>1s/1m/1h</em>)</p>
+restart. MUST be &gt;=1s (e.g., <em>1s/1m/1h</em>)
+Default drain duration is 45s.</p>
 
 </td>
 <td>
@@ -202,7 +203,8 @@ No
 <td>
 <p>The time in seconds that Envoy will wait before shutting down the
 parent process during a hot restart. MUST be &gt;=1s (e.g., <em>1s/1m/1h</em>).
-MUST BE greater than <em>drain</em>duration_ parameter.</p>
+MUST BE greater than <em>drain</em>duration_ parameter.
+Default shutdown duration is 60s.</p>
 
 </td>
 <td>
@@ -236,7 +238,8 @@ No
 <td><code>proxyAdminPort</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Port on which Envoy should listen for administrative commands.</p>
+<p>Port on which Envoy should listen for administrative commands.
+Default port is 15000.</p>
 
 </td>
 <td>
@@ -248,7 +251,8 @@ No
 <td><code><a href="#AuthenticationPolicy">AuthenticationPolicy</a></code></td>
 <td>
 <p>Authentication policy defines the global switch to control authentication
-for Envoy-to-Envoy communication for istio components Mixer and Pilot.</p>
+for Envoy-to-Envoy communication for istio components Mixer and Pilot.
+Default is set to NONE which means do not encrypt Envoy to Envoy traffic.</p>
 
 </td>
 <td>
@@ -288,7 +292,8 @@ No
 <td>
 <p>The number of worker threads to run.
 If unset, this will be automatically determined based on CPU requests/limits.
-If set to 0, all cores on the machine will be used.</p>
+If set to 0, all cores on the machine will be used.
+Default is 2 worker threads.</p>
 
 </td>
 <td>
@@ -370,7 +375,8 @@ No
 <td><code>statusPort</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Port on which the agent should listen for administrative commands such as readiness probe.</p>
+<p>Port on which the agent should listen for administrative commands such as readiness probe.
+Default is set to port 15020.</p>
 
 </td>
 <td>
@@ -626,7 +632,7 @@ tracing configuration).</p>
 <td><code>int32</code></td>
 <td>
 <p>Port on which Envoy should listen for incoming connections from
-other services.</p>
+other services. Default port is 15001.</p>
 
 </td>
 <td>
@@ -648,7 +654,8 @@ No
 <td><code>connectTimeout</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
-<p>Connection timeout used by Envoy. (MUST BE &gt;=1ms)</p>
+<p>Connection timeout used by Envoy. (MUST BE &gt;=1ms)
+Default timeout is 10s.</p>
 
 </td>
 <td>
@@ -664,11 +671,11 @@ determine whether the connection is using TLS or not (on the
 server side), as well as the application protocol being used
 (e.g., http vs tcp). These heuristics rely on the client sending
 the first bits of data. For server first protocols like MySQL,
-MongoDB, etc., Envoy will timeout on the protocol detection after
+MongoDB, etc. Envoy will timeout on the protocol detection after
 the specified period, defaulting to non mTLS plain TCP
 traffic. Set this field to tweak the period that Envoy will wait
 for the client to send the first bits of data. (MUST BE &gt;=1ms or
-0s to disable)</p>
+0s to disable). Default detection timeout is 5s.</p>
 
 </td>
 <td>
@@ -703,7 +710,8 @@ No
 <td><code>ingressService</code></td>
 <td><code>string</code></td>
 <td>
-<p>Name of the Kubernetes service used for the istio ingress controller.</p>
+<p>Name of the Kubernetes service used for the istio ingress controller.
+If no ingress controller is specified, the default value <code>istio-ingressgateway</code> is used.</p>
 
 </td>
 <td>
@@ -714,7 +722,8 @@ No
 <td><code>ingressControllerMode</code></td>
 <td><code><a href="#MeshConfig-IngressControllerMode">IngressControllerMode</a></code></td>
 <td>
-<p>Defines whether to use Istio ingress controller for annotated or all ingress resources.</p>
+<p>Defines whether to use Istio ingress controller for annotated or all ingress resources.
+Default mode is STRICT.</p>
 
 </td>
 <td>
@@ -790,7 +799,8 @@ No
 <td>
 <p>This flag enables Envoy&rsquo;s gRPC Access Log Service.
 See <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto">Access Log Service</a>
-for details about Envoy&rsquo;s gRPC Access Log Service API.</p>
+for details about Envoy&rsquo;s gRPC Access Log Service API.
+Default value is false.</p>
 
 </td>
 <td>
@@ -821,12 +831,13 @@ traffic from the application.  If your application uses one or
 more external services that are not known apriori, setting the
 policy to ALLOW<em>ANY will cause the sidecars to route any unknown
 traffic originating from the application to its requested
-destination.  Users are strongly encouraged to use ServiceEntries
+destination. Users are strongly encouraged to use ServiceEntries
 to explicitly declare any external dependencies, instead of using
 allow</em>any, so that traffic to these services can be
 monitored. Can be overridden at a Sidecar level by setting the
 OutboundTrafficPolicy in the <a href="https://istio.io/docs/reference/config/networking/sidecar/#OutboundTrafficPolicy">Sidecar
-API</a>.</p>
+API</a>.
+Default mode is ALLOW_ANY which means outbound traffic to unknown destinations will be allowed.</p>
 
 </td>
 <td>
@@ -1008,7 +1019,8 @@ No
 <td><code>dnsRefreshRate</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
-<p>Configures DNS refresh rate for Envoy clusters of type STRICT_DNS</p>
+<p>Configures DNS refresh rate for Envoy clusters of type STRICT_DNS
+Default refresh rate is 5s.</p>
 
 </td>
 <td>
@@ -1166,7 +1178,7 @@ No
 <td><code>bool</code></td>
 <td>
 <p>Disable policy checks by the Mixer service. Default
-is false, i.e. Mixer policy check is enabled by default.</p>
+is true, i.e. Mixer policy check is disabled by default.</p>
 
 </td>
 <td>
@@ -1191,7 +1203,7 @@ No
 <td><code>bool</code></td>
 <td>
 <p>Enable session affinity for Envoy Mixer reports so that calls from a proxy will
-always target the same Mixer instance.</p>
+always target the same Mixer instance. Default value is false.</p>
 
 </td>
 <td>
@@ -1216,7 +1228,7 @@ No
 <p>When disable<em>report</em>batch is false, this value specifies the maximum number
 of requests that are batched in report. If left unspecified, the default value
 of report<em>batch</em>max_entries == 0 will use the hardcoded defaults of
-istio::mixerclient::ReportOptions.</p>
+istio::mixerclient::ReportOptions. Default value is 100.</p>
 
 </td>
 <td>
@@ -1230,7 +1242,7 @@ No
 <p>When disable<em>report</em>batch is false, this value specifies the maximum elapsed
 time a batched report will be sent after a user request is processed. If left
 unspecified, the default report<em>batch</em>max_time == 0 will use the hardcoded
-defaults of istio::mixerclient::ReportOptions.</p>
+defaults of istio::mixerclient::ReportOptions. Default max time is 1s.</p>
 
 </td>
 <td>

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -252,7 +252,7 @@ No
 <td>
 <p>Authentication policy defines the global switch to control authentication
 for Envoy-to-Envoy communication for istio components Mixer and Pilot.
-Default is set to NONE which means do not encrypt Envoy to Envoy traffic.</p>
+Default is set to MUTUAL_TLS.</p>
 
 </td>
 <td>

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -1023,7 +1023,7 @@ type ProxyConfig struct {
 	AvailabilityZone string `protobuf:"bytes,12,opt,name=availability_zone,json=availabilityZone,proto3" json:"availabilityZone,omitempty"` // Deprecated: Do not use.
 	// Authentication policy defines the global switch to control authentication
 	// for Envoy-to-Envoy communication for istio components Mixer and Pilot.
-	// Default is set to NONE which means do not encrypt Envoy to Envoy traffic.
+	// Default is set to MUTUAL_TLS.
 	ControlPlaneAuthPolicy AuthenticationPolicy `protobuf:"varint,13,opt,name=control_plane_auth_policy,json=controlPlaneAuthPolicy,proto3,enum=istio.mesh.v1alpha1.AuthenticationPolicy" json:"controlPlaneAuthPolicy,omitempty"`
 	// File path of custom proxy configuration, currently used by proxies
 	// in front of Mixer and Pilot.

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -997,10 +997,12 @@ type ProxyConfig struct {
 	ServiceCluster string `protobuf:"bytes,3,opt,name=service_cluster,json=serviceCluster,proto3" json:"serviceCluster,omitempty"`
 	// The time in seconds that Envoy will drain connections during a hot
 	// restart. MUST be >=1s (e.g., _1s/1m/1h_)
+	// Default drain duration is 45s.
 	DrainDuration *types.Duration `protobuf:"bytes,4,opt,name=drain_duration,json=drainDuration,proto3" json:"drainDuration,omitempty"`
 	// The time in seconds that Envoy will wait before shutting down the
 	// parent process during a hot restart. MUST be >=1s (e.g., _1s/1m/1h_).
 	// MUST BE greater than _drain_duration_ parameter.
+	// Default shutdown duration is 60s.
 	ParentShutdownDuration *types.Duration `protobuf:"bytes,5,opt,name=parent_shutdown_duration,json=parentShutdownDuration,proto3" json:"parentShutdownDuration,omitempty"`
 	// Address of the discovery service exposing xDS with mTLS connection.
 	// The inject configuration may override this value.
@@ -1015,11 +1017,13 @@ type ProxyConfig struct {
 	// $hide_from_docs
 	EnvoyMetricsServiceAddress string `protobuf:"bytes,20,opt,name=envoy_metrics_service_address,json=envoyMetricsServiceAddress,proto3" json:"envoyMetricsServiceAddress,omitempty"` // Deprecated: Do not use.
 	// Port on which Envoy should listen for administrative commands.
+	// Default port is 15000.
 	ProxyAdminPort int32 `protobuf:"varint,11,opt,name=proxy_admin_port,json=proxyAdminPort,proto3" json:"proxyAdminPort,omitempty"`
 	// $hide_from_docs
 	AvailabilityZone string `protobuf:"bytes,12,opt,name=availability_zone,json=availabilityZone,proto3" json:"availabilityZone,omitempty"` // Deprecated: Do not use.
 	// Authentication policy defines the global switch to control authentication
 	// for Envoy-to-Envoy communication for istio components Mixer and Pilot.
+	// Default is set to NONE which means do not encrypt Envoy to Envoy traffic.
 	ControlPlaneAuthPolicy AuthenticationPolicy `protobuf:"varint,13,opt,name=control_plane_auth_policy,json=controlPlaneAuthPolicy,proto3,enum=istio.mesh.v1alpha1.AuthenticationPolicy" json:"controlPlaneAuthPolicy,omitempty"`
 	// File path of custom proxy configuration, currently used by proxies
 	// in front of Mixer and Pilot.
@@ -1033,6 +1037,7 @@ type ProxyConfig struct {
 	// The number of worker threads to run.
 	// If unset, this will be automatically determined based on CPU requests/limits.
 	// If set to 0, all cores on the machine will be used.
+	// Default is 2 worker threads.
 	Concurrency *types.Int32Value `protobuf:"bytes,16,opt,name=concurrency,proto3" json:"concurrency,omitempty"`
 	// Path to the proxy bootstrap template file
 	ProxyBootstrapTemplatePath string `protobuf:"bytes,17,opt,name=proxy_bootstrap_template_path,json=proxyBootstrapTemplatePath,proto3" json:"proxyBootstrapTemplatePath,omitempty"`
@@ -1056,6 +1061,7 @@ type ProxyConfig struct {
 	// Names starting with ISTIO_META_ will be included in the generated bootstrap and sent to the XDS server.
 	ProxyMetadata map[string]string `protobuf:"bytes,24,rep,name=proxy_metadata,json=proxyMetadata,proto3" json:"proxyMetadata,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Port on which the agent should listen for administrative commands such as readiness probe.
+	// Default is set to port 15020.
 	StatusPort int32 `protobuf:"varint,26,opt,name=status_port,json=statusPort,proto3" json:"statusPort,omitempty"`
 	// An additional list of tags to extract from the in-proxy Istio telemetry. These extra tags can be
 	// added by configuring the telemetry extension. Each additional tag needs to be present in this list.

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -272,11 +272,13 @@ message ProxyConfig {
 
   // The time in seconds that Envoy will drain connections during a hot
   // restart. MUST be >=1s (e.g., _1s/1m/1h_)
+  // Default drain duration is 45s.
   google.protobuf.Duration drain_duration = 4;
 
   // The time in seconds that Envoy will wait before shutting down the
   // parent process during a hot restart. MUST be >=1s (e.g., _1s/1m/1h_).
   // MUST BE greater than _drain_duration_ parameter.
+  // Default shutdown duration is 60s.
   google.protobuf.Duration parent_shutdown_duration = 5;
 
   // Address of the discovery service exposing xDS with mTLS connection.
@@ -300,6 +302,7 @@ message ProxyConfig {
   string envoy_metrics_service_address = 20 [deprecated=true];
 
   // Port on which Envoy should listen for administrative commands.
+  // Default port is 15000.
   int32 proxy_admin_port = 11;
 
   // $hide_from_docs
@@ -307,6 +310,7 @@ message ProxyConfig {
 
   // Authentication policy defines the global switch to control authentication
   // for Envoy-to-Envoy communication for istio components Mixer and Pilot.
+  // Default is set to NONE which means do not encrypt Envoy to Envoy traffic.
   AuthenticationPolicy control_plane_auth_policy = 13;
   // File path of custom proxy configuration, currently used by proxies
   // in front of Mixer and Pilot.
@@ -322,6 +326,7 @@ message ProxyConfig {
   // The number of worker threads to run.
   // If unset, this will be automatically determined based on CPU requests/limits.
   // If set to 0, all cores on the machine will be used.
+  // Default is 2 worker threads.
   google.protobuf.Int32Value concurrency = 16;
 
   // Path to the proxy bootstrap template file
@@ -367,6 +372,7 @@ message ProxyConfig {
   map<string,string> proxy_metadata = 24;
 
   // Port on which the agent should listen for administrative commands such as readiness probe.
+  // Default is set to port 15020.
   int32 status_port = 26;
 
   // An additional list of tags to extract from the in-proxy Istio telemetry. These extra tags can be

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -310,7 +310,7 @@ message ProxyConfig {
 
   // Authentication policy defines the global switch to control authentication
   // for Envoy-to-Envoy communication for istio components Mixer and Pilot.
-  // Default is set to NONE which means do not encrypt Envoy to Envoy traffic.
+  // Default is set to MUTUAL_TLS.
   AuthenticationPolicy control_plane_auth_policy = 13;
   // File path of custom proxy configuration, currently used by proxies
   // in front of Mixer and Pilot.


### PR DESCRIPTION
Follow up PR for https://github.com/istio/api/pull/1489

Based on @costinm https://github.com/istio/api/pull/1489#issuecomment-651142386  , I have updated all other defaults as per the latest [DefaultMeshConfigs](https://github.com/istio/istio/blob/master/pkg/config/mesh/mesh.go#L80). 

Suggestions are welcome to improve default value descriptions as it will reflect on [istio.io docs](https://preliminary.istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig). 

Ref: https://github.com/istio/istio/pull/22687