### PR TITLE
Add preserveUnknownFields to EnvoyFilter

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -2872,6 +2872,7 @@ spec:
     listKind: EnvoyFilterList
     plural: envoyfilters
     singular: envoyfilter
+  preserveUnknownFields: true
   scope: Namespaced
   versions:
   - name: v1alpha3

--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -426,6 +426,7 @@ func (EnvoyFilter_Patch_Operation) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:EnvoyFilter:subresource:status
 // +cue-gen:EnvoyFilter:scope:Namespaced
 // +cue-gen:EnvoyFilter:resource:categories=istio-io,networking-istio-io
+// +cue-gen:EnvoyFilter:preserveUnknownFields:true
 // -->
 //
 // <!-- go code generation tags

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -219,6 +219,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:EnvoyFilter:subresource:status
 // +cue-gen:EnvoyFilter:scope:Namespaced
 // +cue-gen:EnvoyFilter:resource:categories=istio-io,networking-istio-io
+// +cue-gen:EnvoyFilter:preserveUnknownFields:true
 // -->
 //
 // <!-- go code generation tags


### PR DESCRIPTION
We need to keep to keep the unknown fields inside EnvoyFilter, as the current schema is not a comprehensive validation for the value field.