### PR TITLE
Add Comment to CredentialName explaining use with Gateway Proxy only

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -2872,7 +2872,6 @@ spec:
     listKind: EnvoyFilterList
     plural: envoyfilters
     singular: envoyfilter
-  preserveUnknownFields: true
   scope: Namespaced
   versions:
   - name: v1alpha3

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -2872,6 +2872,7 @@ spec:
     listKind: EnvoyFilterList
     plural: envoyfilters
     singular: envoyfilter
+  preserveUnknownFields: true
   scope: Namespaced
   versions:
   - name: v1alpha3

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -1076,7 +1076,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from Gateway proxy and is applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from the Gateway proxy and is applicable only on Kubernetes. The secret must exist in the same namespace as the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -1076,7 +1076,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from the Gateway proxy and is applicable only on Kubernetes. The secret must exist in the same namespace as the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified. `This field is currently in alpha and is partially implemented.` Istio 1.7 implementation only supports it for Kubernetes secrets, used in Gateway.",
             "type": "string",
             "format": "string"
           },

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -1076,7 +1076,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified. `This field is currently in alpha and is partially implemented.` Istio 1.7 implementation only supports it for Kubernetes secrets, used in Gateway.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -1076,7 +1076,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from Gateway proxy and is applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -214,7 +214,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified. `This field is currently in alpha and is partially implemented.` Istio 1.7 implementation only supports it for Kubernetes secrets, used in Gateway.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -214,7 +214,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from Gateway proxy and is applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from the Gateway proxy and is applicable only on Kubernetes. The secret must exist in the same namespace as the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -214,7 +214,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from Gateway proxy and is applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -214,7 +214,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from the Gateway proxy and is applicable only on Kubernetes. The secret must exist in the same namespace as the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified. `This field is currently in alpha and is partially implemented.` Istio 1.7 implementation only supports it for Kubernetes secrets, used in Gateway.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1800,9 +1800,9 @@ type ClientTLSSettings struct {
 	CaCertificates string `protobuf:"bytes,4,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// The name of the secret that holds the TLS certs for the
 	// client including the CA certificates. Can only be used
-	// for traffic originating from Gateway proxy and is
-	// applicable only on Kubernetes. Secret must exist in the
-	// same namespace with the proxy using the certificates.
+	// for traffic originating from the Gateway proxy and is
+	// applicable only on Kubernetes. The secret must exist in the
+	// same namespace as the proxy using the certificates.
 	// The secret (of type `generic`)should contain the
 	// following keys and values: `key: <privateKey>`,
 	// `cert: <serverCert>`, `cacert: <CACertificate>`.

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1808,9 +1808,9 @@ type ClientTLSSettings struct {
 	// ca.crt key for CA certificates is also supported.
 	// Only one of client certificates and CA certificate
 	// or credentialName can be specified.
-	// `This field is currently in alpha and is partially implemented.`
-	// Istio 1.7 implementation only supports it for Kubernetes
-	// secrets, used in Gateway.
+	//
+	// **NOTE:** This field is currently applicable only at gateways.
+	// Sidecars will continue to use the certificate paths.
 	CredentialName string `protobuf:"bytes,7,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`
 	// A list of alternate names to verify the subject identity in the
 	// certificate. If specified, the proxy will verify that the server

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1799,10 +1799,8 @@ type ClientTLSSettings struct {
 	// Should be empty if mode is `ISTIO_MUTUAL`.
 	CaCertificates string `protobuf:"bytes,4,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// The name of the secret that holds the TLS certs for the
-	// client including the CA certificates. Can only be used
-	// for traffic originating from the Gateway proxy and is
-	// applicable only on Kubernetes. The secret must exist in the
-	// same namespace as the proxy using the certificates.
+	// client including the CA certificates. Secret must exist in the
+	// same namespace with the proxy using the certificates.
 	// The secret (of type `generic`)should contain the
 	// following keys and values: `key: <privateKey>`,
 	// `cert: <serverCert>`, `cacert: <CACertificate>`.
@@ -1810,6 +1808,9 @@ type ClientTLSSettings struct {
 	// ca.crt key for CA certificates is also supported.
 	// Only one of client certificates and CA certificate
 	// or credentialName can be specified.
+	// `This field is currently in alpha and is partially implemented.`
+	// Istio 1.7 implementation only supports it for Kubernetes
+	// secrets, used in Gateway.
 	CredentialName string `protobuf:"bytes,7,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`
 	// A list of alternate names to verify the subject identity in the
 	// certificate. If specified, the proxy will verify that the server

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1799,9 +1799,10 @@ type ClientTLSSettings struct {
 	// Should be empty if mode is `ISTIO_MUTUAL`.
 	CaCertificates string `protobuf:"bytes,4,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// The name of the secret that holds the TLS certs for the
-	// client including the CA certificates. Applicable
-	// only on Kubernetes. Secret must exist in the same
-	// namespace with the proxy using the certificates.
+	// client including the CA certificates. Can only be used
+	// for traffic originating from Gateway proxy and is
+	// applicable only on Kubernetes. Secret must exist in the
+	// same namespace with the proxy using the certificates.
 	// The secret (of type `generic`)should contain the
 	// following keys and values: `key: <privateKey>`,
 	// `cert: <serverCert>`, `cacert: <CACertificate>`.

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1021,17 +1021,18 @@ No
 <td><code>string</code></td>
 <td>
 <p>The name of the secret that holds the TLS certs for the
-client including the CA certificates. Can only be used
-for traffic originating from the Gateway proxy and is
-applicable only on Kubernetes. The secret must exist in the
-same namespace as the proxy using the certificates.
+client including the CA certificates. Secret must exist in the
+same namespace with the proxy using the certificates.
 The secret (of type <code>generic</code>)should contain the
 following keys and values: <code>key: &lt;privateKey&gt;</code>,
 <code>cert: &lt;serverCert&gt;</code>, <code>cacert: &lt;CACertificate&gt;</code>.
 Secret of type tls for client certificates along with
 ca.crt key for CA certificates is also supported.
 Only one of client certificates and CA certificate
-or credentialName can be specified.</p>
+or credentialName can be specified.
+<code>This field is currently in alpha and is partially implemented.</code>
+Istio 1.7 implementation only supports it for Kubernetes
+secrets, used in Gateway.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1029,10 +1029,10 @@ following keys and values: <code>key: &lt;privateKey&gt;</code>,
 Secret of type tls for client certificates along with
 ca.crt key for CA certificates is also supported.
 Only one of client certificates and CA certificate
-or credentialName can be specified.
-<code>This field is currently in alpha and is partially implemented.</code>
-Istio 1.7 implementation only supports it for Kubernetes
-secrets, used in Gateway.</p>
+or credentialName can be specified.</p>
+
+<p><strong>NOTE:</strong> This field is currently applicable only at gateways.
+Sidecars will continue to use the certificate paths.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1022,9 +1022,9 @@ No
 <td>
 <p>The name of the secret that holds the TLS certs for the
 client including the CA certificates. Can only be used
-for traffic originating from Gateway proxy and is
-applicable only on Kubernetes. Secret must exist in the
-same namespace with the proxy using the certificates.
+for traffic originating from the Gateway proxy and is
+applicable only on Kubernetes. The secret must exist in the
+same namespace as the proxy using the certificates.
 The secret (of type <code>generic</code>)should contain the
 following keys and values: <code>key: &lt;privateKey&gt;</code>,
 <code>cert: &lt;serverCert&gt;</code>, <code>cacert: &lt;CACertificate&gt;</code>.

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1021,9 +1021,10 @@ No
 <td><code>string</code></td>
 <td>
 <p>The name of the secret that holds the TLS certs for the
-client including the CA certificates. Applicable
-only on Kubernetes. Secret must exist in the same
-namespace with the proxy using the certificates.
+client including the CA certificates. Can only be used
+for traffic originating from Gateway proxy and is
+applicable only on Kubernetes. Secret must exist in the
+same namespace with the proxy using the certificates.
 The secret (of type <code>generic</code>)should contain the
 following keys and values: <code>key: &lt;privateKey&gt;</code>,
 <code>cert: &lt;serverCert&gt;</code>, <code>cacert: &lt;CACertificate&gt;</code>.

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -929,9 +929,9 @@ message ClientTLSSettings {
   // ca.crt key for CA certificates is also supported.
   // Only one of client certificates and CA certificate
   // or credentialName can be specified.
-  // `This field is currently in alpha and is partially implemented.`
-  // Istio 1.7 implementation only supports it for Kubernetes
-  // secrets, used in Gateway.
+  //
+  // **NOTE:** This field is currently applicable only at gateways.
+  // Sidecars will continue to use the certificate paths.
   string credential_name = 7;
 
   // A list of alternate names to verify the subject identity in the

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -920,9 +920,10 @@ message ClientTLSSettings {
   string ca_certificates = 4;
 
   // The name of the secret that holds the TLS certs for the
-  // client including the CA certificates. Applicable
-  // only on Kubernetes. Secret must exist in the same
-  // namespace with the proxy using the certificates.
+  // client including the CA certificates. Can only be used
+  // for traffic originating from Gateway proxy and is
+  // applicable only on Kubernetes. Secret must exist in the
+  // same namespace with the proxy using the certificates.
   // The secret (of type `generic`)should contain the
   // following keys and values: `key: <privateKey>`,
   // `cert: <serverCert>`, `cacert: <CACertificate>`.

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -923,7 +923,7 @@ message ClientTLSSettings {
   // client including the CA certificates. Can only be used
   // for traffic originating from Gateway proxy and is
   // applicable only on Kubernetes. Secret must exist in the
-  // same namespace with the proxy using the certificates.
+  // same namespace as the proxy using the certificates.
   // The secret (of type `generic`)should contain the
   // following keys and values: `key: <privateKey>`,
   // `cert: <serverCert>`, `cacert: <CACertificate>`.

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -922,7 +922,7 @@ message ClientTLSSettings {
   // The name of the secret that holds the TLS certs for the
   // client including the CA certificates. Can only be used
   // for traffic originating from the Gateway proxy and is
-  // applicable only on Kubernetes. Secret must exist in the
+  // applicable only on Kubernetes. The secret must exist in the
   // same namespace as the proxy using the certificates.
   // The secret (of type `generic`)should contain the
   // following keys and values: `key: <privateKey>`,

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -920,10 +920,8 @@ message ClientTLSSettings {
   string ca_certificates = 4;
 
   // The name of the secret that holds the TLS certs for the
-  // client including the CA certificates. Can only be used
-  // for traffic originating from the Gateway proxy and is
-  // applicable only on Kubernetes. The secret must exist in the
-  // same namespace as the proxy using the certificates.
+  // client including the CA certificates. Secret must exist in the
+  // same namespace with the proxy using the certificates.
   // The secret (of type `generic`)should contain the
   // following keys and values: `key: <privateKey>`,
   // `cert: <serverCert>`, `cacert: <CACertificate>`.
@@ -931,6 +929,9 @@ message ClientTLSSettings {
   // ca.crt key for CA certificates is also supported.
   // Only one of client certificates and CA certificate
   // or credentialName can be specified.
+  // `This field is currently in alpha and is partially implemented.`
+  // Istio 1.7 implementation only supports it for Kubernetes
+  // secrets, used in Gateway.
   string credential_name = 7;
 
   // A list of alternate names to verify the subject identity in the

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -921,7 +921,7 @@ message ClientTLSSettings {
 
   // The name of the secret that holds the TLS certs for the
   // client including the CA certificates. Can only be used
-  // for traffic originating from Gateway proxy and is
+  // for traffic originating from the Gateway proxy and is
   // applicable only on Kubernetes. Secret must exist in the
   // same namespace as the proxy using the certificates.
   // The secret (of type `generic`)should contain the

--- a/networking/v1alpha3/sidecar.gen.json
+++ b/networking/v1alpha3/sidecar.gen.json
@@ -29,7 +29,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from Gateway proxy and is applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1alpha3/sidecar.gen.json
+++ b/networking/v1alpha3/sidecar.gen.json
@@ -29,7 +29,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from Gateway proxy and is applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from the Gateway proxy and is applicable only on Kubernetes. The secret must exist in the same namespace as the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1alpha3/sidecar.gen.json
+++ b/networking/v1alpha3/sidecar.gen.json
@@ -29,7 +29,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from the Gateway proxy and is applicable only on Kubernetes. The secret must exist in the same namespace as the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified. `This field is currently in alpha and is partially implemented.` Istio 1.7 implementation only supports it for Kubernetes secrets, used in Gateway.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1alpha3/sidecar.gen.json
+++ b/networking/v1alpha3/sidecar.gen.json
@@ -29,7 +29,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified. `This field is currently in alpha and is partially implemented.` Istio 1.7 implementation only supports it for Kubernetes secrets, used in Gateway.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -214,7 +214,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified. `This field is currently in alpha and is partially implemented.` Istio 1.7 implementation only supports it for Kubernetes secrets, used in Gateway.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -214,7 +214,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from Gateway proxy and is applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified. `This field is currently in alpha and is partially implemented.` Istio 1.7 implementation only supports it for Kubernetes secrets, used in Gateway.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -214,7 +214,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from Gateway proxy and is applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1797,9 +1797,10 @@ type ClientTLSSettings struct {
 	// Should be empty if mode is `ISTIO_MUTUAL`.
 	CaCertificates string `protobuf:"bytes,4,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// The name of the secret that holds the TLS certs for the
-	// client including the CA certificates. Applicable
-	// only on Kubernetes. Secret must exist in the same
-	// namespace with the proxy using the certificates.
+	// client including the CA certificates. Can only be used
+	// for traffic originating from Gateway proxy and is
+	// applicable only on Kubernetes. Secret must exist in the
+	// same namespace with the proxy using the certificates.
 	// The secret (of type `generic`)should contain the
 	// following keys and values: `key: <privateKey>`,
 	// `cert: <serverCert>`, `cacert: <CACertificate>`.

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1806,9 +1806,9 @@ type ClientTLSSettings struct {
 	// ca.crt key for CA certificates is also supported.
 	// Only one of client certificates and CA certificate
 	// or credentialName can be specified.
-	// `This field is currently in alpha and is partially implemented.`
-	// Istio 1.7 implementation only supports it for Kubernetes
-	// secrets, used in Gateway.
+	//
+	// **NOTE:** This field is currently applicable only at gateways.
+	// Sidecars will continue to use the certificate paths.
 	CredentialName string `protobuf:"bytes,7,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`
 	// A list of alternate names to verify the subject identity in the
 	// certificate. If specified, the proxy will verify that the server

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1797,9 +1797,7 @@ type ClientTLSSettings struct {
 	// Should be empty if mode is `ISTIO_MUTUAL`.
 	CaCertificates string `protobuf:"bytes,4,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// The name of the secret that holds the TLS certs for the
-	// client including the CA certificates. Can only be used
-	// for traffic originating from Gateway proxy and is
-	// applicable only on Kubernetes. Secret must exist in the
+	// client including the CA certificates. Secret must exist in the
 	// same namespace with the proxy using the certificates.
 	// The secret (of type `generic`)should contain the
 	// following keys and values: `key: <privateKey>`,
@@ -1808,6 +1806,9 @@ type ClientTLSSettings struct {
 	// ca.crt key for CA certificates is also supported.
 	// Only one of client certificates and CA certificate
 	// or credentialName can be specified.
+	// `This field is currently in alpha and is partially implemented.`
+	// Istio 1.7 implementation only supports it for Kubernetes
+	// secrets, used in Gateway.
 	CredentialName string `protobuf:"bytes,7,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`
 	// A list of alternate names to verify the subject identity in the
 	// certificate. If specified, the proxy will verify that the server

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -918,9 +918,7 @@ message ClientTLSSettings {
   string ca_certificates = 4;
 
   // The name of the secret that holds the TLS certs for the
-  // client including the CA certificates. Can only be used
-  // for traffic originating from Gateway proxy and is
-  // applicable only on Kubernetes. Secret must exist in the
+  // client including the CA certificates. Secret must exist in the
   // same namespace with the proxy using the certificates.
   // The secret (of type `generic`)should contain the
   // following keys and values: `key: <privateKey>`,
@@ -929,6 +927,9 @@ message ClientTLSSettings {
   // ca.crt key for CA certificates is also supported.
   // Only one of client certificates and CA certificate
   // or credentialName can be specified.
+  // `This field is currently in alpha and is partially implemented.`
+  // Istio 1.7 implementation only supports it for Kubernetes
+  // secrets, used in Gateway.
   string credential_name = 7;
 
   // A list of alternate names to verify the subject identity in the

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -927,9 +927,9 @@ message ClientTLSSettings {
   // ca.crt key for CA certificates is also supported.
   // Only one of client certificates and CA certificate
   // or credentialName can be specified.
-  // `This field is currently in alpha and is partially implemented.`
-  // Istio 1.7 implementation only supports it for Kubernetes
-  // secrets, used in Gateway.
+  //
+  // **NOTE:** This field is currently applicable only at gateways.
+  // Sidecars will continue to use the certificate paths.
   string credential_name = 7;
 
   // A list of alternate names to verify the subject identity in the

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -918,9 +918,10 @@ message ClientTLSSettings {
   string ca_certificates = 4;
 
   // The name of the secret that holds the TLS certs for the
-  // client including the CA certificates. Applicable
-  // only on Kubernetes. Secret must exist in the same
-  // namespace with the proxy using the certificates.
+  // client including the CA certificates. Can only be used
+  // for traffic originating from Gateway proxy and is
+  // applicable only on Kubernetes. Secret must exist in the
+  // same namespace with the proxy using the certificates.
   // The secret (of type `generic`)should contain the
   // following keys and values: `key: <privateKey>`,
   // `cert: <serverCert>`, `cacert: <CACertificate>`.

--- a/networking/v1beta1/sidecar.gen.json
+++ b/networking/v1beta1/sidecar.gen.json
@@ -29,7 +29,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from Gateway proxy and is applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1beta1/sidecar.gen.json
+++ b/networking/v1beta1/sidecar.gen.json
@@ -29,7 +29,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified. `This field is currently in alpha and is partially implemented.` Istio 1.7 implementation only supports it for Kubernetes secrets, used in Gateway.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1beta1/sidecar.gen.json
+++ b/networking/v1beta1/sidecar.gen.json
@@ -29,7 +29,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Can only be used for traffic originating from Gateway proxy and is applicable only on Kubernetes. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified. `This field is currently in alpha and is partially implemented.` Istio 1.7 implementation only supports it for Kubernetes secrets, used in Gateway.",
             "type": "string",
             "format": "string"
           },

--- a/proto.lock
+++ b/proto.lock
@@ -36835,6 +36835,11 @@
                 "id": 29,
                 "name": "termination_drain_duration",
                 "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 30,
+                "name": "mesh_id",
+                "type": "int32"
               }
             ],
             "maps": [
@@ -44667,6 +44672,9 @@
           },
           {
             "path": "k8s.io/apimachinery/pkg/api/resource/generated.proto"
+          },
+          {
+            "path": "gogoproto/gogo.proto"
           }
         ],
         "package": {
@@ -44676,6 +44684,18 @@
           {
             "name": "go_package",
             "value": "istio.io/api/operator/v1alpha1"
+          },
+          {
+            "name": "(gogoproto.marshaler_all)",
+            "value": "false"
+          },
+          {
+            "name": "(gogoproto.unmarshaler_all)",
+            "value": "false"
+          },
+          {
+            "name": "(gogoproto.sizer_all)",
+            "value": "false"
           }
         ]
       }


### PR DESCRIPTION
Updates the comment for CredentialName in DestinationRule API to clearly specify use case is for originating traffic from gateway proxy type only.

Ref: https://github.com/istio/istio/issues/14039