### PR TITLE
Fix broken link for WorkloadSelector

### DIFF
--- a/security/v1beta1/authorization.pb.html
+++ b/security/v1beta1/authorization.pb.html
@@ -181,7 +181,7 @@ spec:
 <tbody>
 <tr id="AuthorizationPolicy-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>Optional. Workload selector decides where to apply the authorization policy.
 If not set, the authorization policy will be applied to all workloads in the

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -103,7 +103,7 @@ spec:
 <tbody>
 <tr id="PeerAuthentication-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>The selector determines the workloads to apply the ChannelAuthentication on.
 If not set, the policy will be applied to all workloads in the same namespace as the policy.</p>

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -126,7 +126,7 @@ spec:
 <tbody>
 <tr id="RequestAuthentication-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>The selector determines the workloads to apply the RequestAuthentication on.
 If not set, the policy will be applied to all workloads in the same namespace as the policy.</p>

--- a/type/v1beta1/selector.proto
+++ b/type/v1beta1/selector.proto
@@ -17,7 +17,7 @@ import "google/api/field_behavior.proto";
 
 // $title: Workload Selector
 // $description: Definition of a workload selector.
-// $location: https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html
+// $location: https://istio.io/docs/reference/config/networking/sidecar/#WorkloadSelector
 
 package istio.type.v1beta1;
 


### PR DESCRIPTION
Currently various link for WorkloadSelector is broken in the istio
page. Example page where it's currently broken: https://istio.io/latest/docs/reference/config/security/peer_authentication/#PeerAuthentication