### PR TITLE
Update virtual_service.proto

### DIFF
--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -597,6 +597,7 @@ message HTTPRoute {
 
   // Rewrite HTTP URIs and Authority headers. Rewrite cannot be used with
   // Redirect primitive. Rewrite will be performed before forwarding.
+  // Downstream sidecars log the URI as it was before it was rewritten.
   HTTPRewrite rewrite = 4;
 
   reserved 5;


### PR DESCRIPTION
Existing documentation for `HTTPRewrite rewrite` can lead to wasted hours during debugging, trying to figure out why envoy sidecars are not logging the rewritten URI.
See https://stackoverflow.com/questions/56924639/istio-virtualservice-httprewrite-being-ignored-completely/56925344#56925344 and ensuing commentary.