### PR TITLE
Fix portNumber typo in EnvoyFilter example

### DIFF
--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -51,8 +51,8 @@
 //   - applyTo: NETWORK_FILTER
 //     match:
 //       context: SIDECAR_OUTBOUND # will match outbound listeners in all sidecars
+//       portNumber: 9307
 //       listener:
-//         portNumber: 9307
 //         filterChain:
 //           filter:
 //             name: "envoy.tcp_proxy"
@@ -102,8 +102,8 @@
 //   - applyTo: HTTP_FILTER
 //     match:
 //       context: SIDECAR_INBOUND
+//       portNumber: 8080
 //       listener:
-//         portNumber: 8080
 //         filterChain:
 //           filter:
 //             name: "envoy.http_connection_manager"

--- a/networking/v1alpha3/envoy_filter.pb.html
+++ b/networking/v1alpha3/envoy_filter.pb.html
@@ -57,8 +57,8 @@ spec:
   - applyTo: NETWORK_FILTER
     match:
       context: SIDECAR_OUTBOUND # will match outbound listeners in all sidecars
+      portNumber: 9307
       listener:
-        portNumber: 9307
         filterChain:
           filter:
             name: &quot;envoy.tcp_proxy&quot;
@@ -107,8 +107,8 @@ spec:
   - applyTo: HTTP_FILTER
     match:
       context: SIDECAR_INBOUND
+      portNumber: 8080
       listener:
-        portNumber: 8080
         filterChain:
           filter:
             name: &quot;envoy.http_connection_manager&quot;

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -74,8 +74,8 @@ import "networking/v1alpha3/sidecar.proto";
 //   - applyTo: NETWORK_FILTER
 //     match:
 //       context: SIDECAR_OUTBOUND # will match outbound listeners in all sidecars
+//       portNumber: 9307
 //       listener:
-//         portNumber: 9307
 //         filterChain:
 //           filter:
 //             name: "envoy.tcp_proxy"
@@ -125,8 +125,8 @@ import "networking/v1alpha3/sidecar.proto";
 //   - applyTo: HTTP_FILTER
 //     match:
 //       context: SIDECAR_INBOUND
+//       portNumber: 8080
 //       listener:
-//         portNumber: 8080
 //         filterChain:
 //           filter:
 //             name: "envoy.http_connection_manager"

--- a/networking/v1alpha3/envoy_filter_deepcopy.gen.go
+++ b/networking/v1alpha3/envoy_filter_deepcopy.gen.go
@@ -51,8 +51,8 @@
 //   - applyTo: NETWORK_FILTER
 //     match:
 //       context: SIDECAR_OUTBOUND # will match outbound listeners in all sidecars
+//       portNumber: 9307
 //       listener:
-//         portNumber: 9307
 //         filterChain:
 //           filter:
 //             name: "envoy.tcp_proxy"
@@ -102,8 +102,8 @@
 //   - applyTo: HTTP_FILTER
 //     match:
 //       context: SIDECAR_INBOUND
+//       portNumber: 8080
 //       listener:
-//         portNumber: 8080
 //         filterChain:
 //           filter:
 //             name: "envoy.http_connection_manager"

--- a/networking/v1alpha3/envoy_filter_json.gen.go
+++ b/networking/v1alpha3/envoy_filter_json.gen.go
@@ -51,8 +51,8 @@
 //   - applyTo: NETWORK_FILTER
 //     match:
 //       context: SIDECAR_OUTBOUND # will match outbound listeners in all sidecars
+//       portNumber: 9307
 //       listener:
-//         portNumber: 9307
 //         filterChain:
 //           filter:
 //             name: "envoy.tcp_proxy"
@@ -102,8 +102,8 @@
 //   - applyTo: HTTP_FILTER
 //     match:
 //       context: SIDECAR_INBOUND
+//       portNumber: 8080
 //       listener:
-//         portNumber: 8080
 //         filterChain:
 //           filter:
 //             name: "envoy.http_connection_manager"

--- a/proto.lock
+++ b/proto.lock
@@ -36835,6 +36835,11 @@
                 "id": 29,
                 "name": "termination_drain_duration",
                 "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 30,
+                "name": "mesh_id",
+                "type": "int32"
               }
             ],
             "maps": [
@@ -44667,6 +44672,9 @@
           },
           {
             "path": "k8s.io/apimachinery/pkg/api/resource/generated.proto"
+          },
+          {
+            "path": "gogoproto/gogo.proto"
           }
         ],
         "package": {
@@ -44676,6 +44684,18 @@
           {
             "name": "go_package",
             "value": "istio.io/api/operator/v1alpha1"
+          },
+          {
+            "name": "(gogoproto.marshaler_all)",
+            "value": "false"
+          },
+          {
+            "name": "(gogoproto.unmarshaler_all)",
+            "value": "false"
+          },
+          {
+            "name": "(gogoproto.sizer_all)",
+            "value": "false"
           }
         ]
       }


### PR DESCRIPTION
I spend 2 days figuring why EnvoyFilter is not working but the example is broken.

According to this issue: https://github.com/istio/istio/issues/20640
also, the upstream example still is broken: https://istio.io/latest/docs/reference/config/networking/envoy-filter/#EnvoyFilter