### PR TITLE
remove hide from docs instruction in meta/status

### DIFF
--- a/meta/v1alpha1/status.pb.html
+++ b/meta/v1alpha1/status.pb.html
@@ -4,7 +4,6 @@ description: Common status field for all istio collections.
 location: https://istio.io/docs/reference/config/meta/v1beta1/istio-status.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
-hide_from_docs
 number_of_entries: 3
 ---
 <h2 id="IstioStatus">IstioStatus</h2>

--- a/meta/v1alpha1/status.proto
+++ b/meta/v1alpha1/status.proto
@@ -19,7 +19,6 @@ import "k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto";
 
 import "google/api/field_behavior.proto";
 
-// $hide_from_docs
 // $title: Istio Status
 // $description: Common status field for all istio collections.
 // $location: https://istio.io/docs/reference/config/meta/v1beta1/istio-status.html


### PR DESCRIPTION
This instruction is causing test failures for the docs folks.