### PR TITLE
Fix link so istio.io linter passes (remove latest)

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -408,7 +408,7 @@
             "type": "string"
           },
           "meshId": {
-            "description": "The unique identifier for the [service mesh](https://istio.io/latest/docs/reference/glossary/#service-mesh) All control planes running in the same service mesh should specify the same mesh ID. Mesh ID is used to label telemetry reports for cases where telemetry from multiple meshes is mixed together.",
+            "description": "The unique identifier for the [service mesh](https://istio.io/docs/reference/glossary/#service-mesh) All control planes running in the same service mesh should specify the same mesh ID. Mesh ID is used to label telemetry reports for cases where telemetry from multiple meshes is mixed together.",
             "type": "integer",
             "format": "int32"
           }

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -415,7 +415,7 @@ No
 <td><code>meshId</code></td>
 <td><code>int32</code></td>
 <td>
-<p>The unique identifier for the <a href="https://istio.io/latest/docs/reference/glossary/#service-mesh">service mesh</a>
+<p>The unique identifier for the <a href="https://istio.io/docs/reference/glossary/#service-mesh">service mesh</a>
 All control planes running in the same service mesh should specify the same mesh ID.
 Mesh ID is used to label telemetry reports for cases where telemetry from multiple meshes is mixed together.</p>
 

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -1079,7 +1079,7 @@ type ProxyConfig struct {
 	// sleeps for the termination_drain_duration and then kills any remaining active Envoy processes.
 	// If not set, a default of 5s will be applied.
 	TerminationDrainDuration *types.Duration `protobuf:"bytes,29,opt,name=termination_drain_duration,json=terminationDrainDuration,proto3" json:"terminationDrainDuration,omitempty"`
-	// The unique identifier for the [service mesh](https://istio.io/latest/docs/reference/glossary/#service-mesh)
+	// The unique identifier for the [service mesh](https://istio.io/docs/reference/glossary/#service-mesh)
 	// All control planes running in the same service mesh should specify the same mesh ID.
 	// Mesh ID is used to label telemetry reports for cases where telemetry from multiple meshes is mixed together.
 	MeshId               int32    `protobuf:"varint,30,opt,name=mesh_id,json=meshId,proto3" json:"meshId,omitempty"`

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -394,7 +394,7 @@ message ProxyConfig {
   // If not set, a default of 5s will be applied.
   google.protobuf.Duration  termination_drain_duration = 29;
 
-  // The unique identifier for the [service mesh](https://istio.io/latest/docs/reference/glossary/#service-mesh)
+  // The unique identifier for the [service mesh](https://istio.io/docs/reference/glossary/#service-mesh)
   // All control planes running in the same service mesh should specify the same mesh ID.
   // Mesh ID is used to label telemetry reports for cases where telemetry from multiple meshes is mixed together.
   int32 mesh_id = 30;


### PR DESCRIPTION
None of the other links use latest so this is making this link like the others. There is code in istio.io that adds the `latest` into the link at a later point.