### PR TITLE
add TunnelType label

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -37,4 +37,8 @@ const (
 
 	// IstioOperatorVersion is the Istio operator version that installed the resource, e.g. "1.6.0"
 	IstioOperatorVersion = "operator.istio.io/version"
+
+	// TunnelType is the name of the label to service instance to determine whether support tunnel.
+	// The valid values are tunnel-none, tunnel-h2-http, tunnel-h2-full.
+	TunnelType = "traffic.istio.io/tunnelType"
 )

--- a/proto.lock
+++ b/proto.lock
@@ -13049,13 +13049,7 @@
                         "value": "/v1/services/{service_name}/configs/{config_id}"
                       },
                       {
-                        "name": "additional_bindings",
-                        "aggregated": [
-                          {
-                            "name": "get",
-                            "value": "/v1/services/{service_name}/config"
-                          }
-                        ]
+                        "name": "additional_bindings"
                       }
                     ]
                   }
@@ -45992,6 +45986,60 @@
           {
             "name": "go_package",
             "value": "istio.io/api/policy/v1beta1"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "security:/:v1alpha1:/:ca.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "IstioCertificateRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "csr",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "validity_duration",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "IstioCertificateResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cert_chain",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "IstioCertificateService",
+            "rpcs": [
+              {
+                "name": "CreateCertificate",
+                "in_type": "IstioCertificateRequest",
+                "out_type": "IstioCertificateResponse"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "istio.v1.auth"
+        },
+        "options": [
+          {
+            "name": "go_package",
+            "value": "istio.io/api/security/v1alpha1"
           }
         ]
       }


### PR DESCRIPTION
istio-auto-inject will set the label to "tunnel-h2-http"

pilot has individual flag to decide whether the tunnel feature is used.

Part of https://github.com/istio/istio/issues/24540

Signed-off-by: Yuchen Dai <silentdai@gmail.com>