### PR TITLE
Fix invalid link for WorkloadSelector

### DIFF
--- a/security/v1beta1/authorization.pb.html
+++ b/security/v1beta1/authorization.pb.html
@@ -181,7 +181,7 @@ spec:
 <tbody>
 <tr id="AuthorizationPolicy-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>Optional. Workload selector decides where to apply the authorization policy.
 If not set, the authorization policy will be applied to all workloads in the

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -103,7 +103,7 @@ spec:
 <tbody>
 <tr id="PeerAuthentication-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>The selector determines the workloads to apply the ChannelAuthentication on.
 If not set, the policy will be applied to all workloads in the same namespace as the policy.</p>

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -126,7 +126,7 @@ spec:
 <tbody>
 <tr id="RequestAuthentication-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>The selector determines the workloads to apply the RequestAuthentication on.
 If not set, the policy will be applied to all workloads in the same namespace as the policy.</p>

--- a/type/v1beta1/istio.type.v1beta1.pb.html
+++ b/type/v1beta1/istio.type.v1beta1.pb.html
@@ -2,6 +2,7 @@
 title: istio.type.v1beta1
 layout: protoc-gen-docs
 generator: protoc-gen-docs
+aliases: [https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html]
 number_of_entries: 1
 ---
 <h2 id="WorkloadSelector">WorkloadSelector</h2>

--- a/type/v1beta1/selector.proto
+++ b/type/v1beta1/selector.proto
@@ -17,7 +17,8 @@ import "google/api/field_behavior.proto";
 
 // $title: Workload Selector
 // $description: Definition of a workload selector.
-// $location: https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html
+// $location: https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector
+// $aliases: [https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html]
 
 package istio.type.v1beta1;
 


### PR DESCRIPTION

This was reported multiple times on istio.io docs. This PR fixes the workload selector to redirect it to a valid link. 

Related issues:
https://github.com/istio/api/issues/1511
https://github.com/istio/istio.io/issues/7203
https://github.com/istio/istio.io/issues/6877
https://github.com/istio/istio.io/issues/6921