### PR TITLE
Revert "Gateway CA certs can be stored in secret-cacert"

### DIFF
--- a/networking/v1alpha3/gateway.gen.json
+++ b/networking/v1alpha3/gateway.gen.json
@@ -103,7 +103,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. The secret (of type `generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. The secret (of type`generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -906,11 +906,9 @@ type ServerTLSSettings struct {
 	CaCertificates string `protobuf:"bytes,5,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// For gateways running on Kubernetes, the name of the secret that
 	// holds the TLS certs including the CA certificates. Applicable
-	// only on Kubernetes. The secret (of type `generic`) should
+	// only on Kubernetes. The secret (of type`generic`) should
 	// contain the following keys and values: `key:
-	// <privateKey>` and `cert: <serverCert>`. For mutual TLS,
-	// `cacert: <CACertificate>` can be provided in the same secret or
-	// a separate secret named `<secret>-cacert`.
+	// <privateKey>`, `cert: <serverCert>`, `cacert: <CACertificate>`.
 	// Secret of type tls for server certificates along with
 	// ca.crt key for CA certificates is also supported.
 	// Only one of server certificates and CA certificate

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -772,11 +772,9 @@ No
 <td>
 <p>For gateways running on Kubernetes, the name of the secret that
 holds the TLS certs including the CA certificates. Applicable
-only on Kubernetes. The secret (of type <code>generic</code>) should
+only on Kubernetes. The secret (of type<code>generic</code>) should
 contain the following keys and values: <code>key:
-&lt;privateKey&gt;</code> and <code>cert: &lt;serverCert&gt;</code>. For mutual TLS,
-<code>cacert: &lt;CACertificate&gt;</code> can be provided in the same secret or
-a separate secret named <code>&lt;secret&gt;-cacert</code>.
+&lt;privateKey&gt;</code>, <code>cert: &lt;serverCert&gt;</code>, <code>cacert: &lt;CACertificate&gt;</code>.
 Secret of type tls for server certificates along with
 ca.crt key for CA certificates is also supported.
 Only one of server certificates and CA certificate

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -668,11 +668,9 @@ message ServerTLSSettings {
 
   // For gateways running on Kubernetes, the name of the secret that
   // holds the TLS certs including the CA certificates. Applicable
-  // only on Kubernetes. The secret (of type `generic`) should
+  // only on Kubernetes. The secret (of type`generic`) should
   // contain the following keys and values: `key:
-  // <privateKey>` and `cert: <serverCert>`. For mutual TLS, 
-  // `cacert: <CACertificate>` can be provided in the same secret or 
-  // a separate secret named `<secret>-cacert`.
+  // <privateKey>`, `cert: <serverCert>`, `cacert: <CACertificate>`.
   // Secret of type tls for server certificates along with
   // ca.crt key for CA certificates is also supported.
   // Only one of server certificates and CA certificate


### PR DESCRIPTION
Reverts istio/api#1537

The updates have to be made in both versions.. Otherwise, we have postsubmit failures and inconsistencies. 