### PR TITLE
Gateway CA certs can be stored in secret-cacert. Take 2

### DIFF
--- a/networking/v1alpha3/gateway.gen.json
+++ b/networking/v1alpha3/gateway.gen.json
@@ -103,7 +103,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. The secret (of type`generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. The secret (of type `generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -906,9 +906,11 @@ type ServerTLSSettings struct {
 	CaCertificates string `protobuf:"bytes,5,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// For gateways running on Kubernetes, the name of the secret that
 	// holds the TLS certs including the CA certificates. Applicable
-	// only on Kubernetes. The secret (of type`generic`) should
+	// only on Kubernetes. The secret (of type `generic`) should
 	// contain the following keys and values: `key:
-	// <privateKey>`, `cert: <serverCert>`, `cacert: <CACertificate>`.
+	// <privateKey>` and `cert: <serverCert>`. For mutual TLS,
+	// `cacert: <CACertificate>` can be provided in the same secret or
+	// a separate secret named `<secret>-cacert`.
 	// Secret of type tls for server certificates along with
 	// ca.crt key for CA certificates is also supported.
 	// Only one of server certificates and CA certificate

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -772,9 +772,11 @@ No
 <td>
 <p>For gateways running on Kubernetes, the name of the secret that
 holds the TLS certs including the CA certificates. Applicable
-only on Kubernetes. The secret (of type<code>generic</code>) should
+only on Kubernetes. The secret (of type <code>generic</code>) should
 contain the following keys and values: <code>key:
-&lt;privateKey&gt;</code>, <code>cert: &lt;serverCert&gt;</code>, <code>cacert: &lt;CACertificate&gt;</code>.
+&lt;privateKey&gt;</code> and <code>cert: &lt;serverCert&gt;</code>. For mutual TLS,
+<code>cacert: &lt;CACertificate&gt;</code> can be provided in the same secret or
+a separate secret named <code>&lt;secret&gt;-cacert</code>.
 Secret of type tls for server certificates along with
 ca.crt key for CA certificates is also supported.
 Only one of server certificates and CA certificate

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -668,9 +668,11 @@ message ServerTLSSettings {
 
   // For gateways running on Kubernetes, the name of the secret that
   // holds the TLS certs including the CA certificates. Applicable
-  // only on Kubernetes. The secret (of type`generic`) should
+  // only on Kubernetes. The secret (of type `generic`) should
   // contain the following keys and values: `key:
-  // <privateKey>`, `cert: <serverCert>`, `cacert: <CACertificate>`.
+  // <privateKey>` and `cert: <serverCert>`. For mutual TLS, 
+  // `cacert: <CACertificate>` can be provided in the same secret or 
+  // a separate secret named `<secret>-cacert`.
   // Secret of type tls for server certificates along with
   // ca.crt key for CA certificates is also supported.
   // Only one of server certificates and CA certificate

--- a/networking/v1beta1/gateway.gen.json
+++ b/networking/v1beta1/gateway.gen.json
@@ -103,7 +103,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. The secret (of type `generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes, and only if the dynamic credential fetching feature is enabled in the proxy by setting `ISTIO_META_USER_SDS` metadata variable. The secret (of type `generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1beta1/gateway.gen.json
+++ b/networking/v1beta1/gateway.gen.json
@@ -103,7 +103,7 @@
             "format": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes, and only if the dynamic credential fetching feature is enabled in the proxy by setting `ISTIO_META_USER_SDS` metadata variable. The secret (of type `generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cserverCert\u003e`, `cacert: \u003cCACertificate\u003e`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. The secret (of type `generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1beta1/gateway.pb.go
+++ b/networking/v1beta1/gateway.pb.go
@@ -908,11 +908,11 @@ type ServerTLSSettings struct {
 	CaCertificates string `protobuf:"bytes,5,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// For gateways running on Kubernetes, the name of the secret that
 	// holds the TLS certs including the CA certificates. Applicable
-	// only on Kubernetes, and only if the dynamic credential fetching
-	// feature is enabled in the proxy by setting
-	// `ISTIO_META_USER_SDS` metadata variable.  The secret (of type
-	// `generic`) should contain the following keys and values: `key:
-	// <privateKey>`, `cert: <serverCert>`, `cacert: <CACertificate>`.
+	// only on Kubernetes. The secret (of type `generic`) should
+	// contain the following keys and values: `key:
+	// <privateKey>` and `cert: <serverCert>`. For mutual TLS,
+	// `cacert: <CACertificate>` can be provided in the same secret or
+	// a separate secret named `<secret>-cacert`.
 	// Secret of type tls for server certificates along with
 	// ca.crt key for CA certificates is also supported.
 	// Only one of server certificates and CA certificate

--- a/networking/v1beta1/gateway.pb.go
+++ b/networking/v1beta1/gateway.pb.go
@@ -908,8 +908,10 @@ type ServerTLSSettings struct {
 	CaCertificates string `protobuf:"bytes,5,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// For gateways running on Kubernetes, the name of the secret that
 	// holds the TLS certs including the CA certificates. Applicable
-	// only on Kubernetes. The secret (of type `generic`) should
-	// contain the following keys and values: `key:
+	// only on Kubernetes, and only if the dynamic credential fetching
+	// feature is enabled in the proxy by setting
+	// `ISTIO_META_USER_SDS` metadata variable.  The secret (of type
+	// `generic`) should contain the following keys and values: `key:
 	// <privateKey>` and `cert: <serverCert>`. For mutual TLS,
 	// `cacert: <CACertificate>` can be provided in the same secret or
 	// a separate secret named `<secret>-cacert`.

--- a/networking/v1beta1/gateway.proto
+++ b/networking/v1beta1/gateway.proto
@@ -670,11 +670,11 @@ message ServerTLSSettings {
 
   // For gateways running on Kubernetes, the name of the secret that
   // holds the TLS certs including the CA certificates. Applicable
-  // only on Kubernetes, and only if the dynamic credential fetching
-  // feature is enabled in the proxy by setting
-  // `ISTIO_META_USER_SDS` metadata variable.  The secret (of type
-  // `generic`) should contain the following keys and values: `key:
-  // <privateKey>`, `cert: <serverCert>`, `cacert: <CACertificate>`.
+  // only on Kubernetes. The secret (of type `generic`) should
+  // contain the following keys and values: `key:
+  // <privateKey>` and `cert: <serverCert>`. For mutual TLS, 
+  // `cacert: <CACertificate>` can be provided in the same secret or 
+  // a separate secret named `<secret>-cacert`.
   // Secret of type tls for server certificates along with
   // ca.crt key for CA certificates is also supported.
   // Only one of server certificates and CA certificate

--- a/networking/v1beta1/gateway.proto
+++ b/networking/v1beta1/gateway.proto
@@ -670,8 +670,10 @@ message ServerTLSSettings {
 
   // For gateways running on Kubernetes, the name of the secret that
   // holds the TLS certs including the CA certificates. Applicable
-  // only on Kubernetes. The secret (of type `generic`) should
-  // contain the following keys and values: `key:
+  // only on Kubernetes, and only if the dynamic credential fetching
+  // feature is enabled in the proxy by setting
+  // `ISTIO_META_USER_SDS` metadata variable.  The secret (of type
+  // `generic`) should contain the following keys and values: `key:
   // <privateKey>` and `cert: <serverCert>`. For mutual TLS, 
   // `cacert: <CACertificate>` can be provided in the same secret or 
   // a separate secret named `<secret>-cacert`.


### PR DESCRIPTION
Sending PR https://github.com/istio/api/pull/1537 again with both versions updated.
