### PR TITLE
Fix broken link for WorkloadSelector

### DIFF
--- a/security/v1beta1/authorization.pb.html
+++ b/security/v1beta1/authorization.pb.html
@@ -181,7 +181,7 @@ spec:
 <tbody>
 <tr id="AuthorizationPolicy-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>Optional. Workload selector decides where to apply the authorization policy.
 If not set, the authorization policy will be applied to all workloads in the

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -103,7 +103,7 @@ spec:
 <tbody>
 <tr id="PeerAuthentication-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>The selector determines the workloads to apply the ChannelAuthentication on.
 If not set, the policy will be applied to all workloads in the same namespace as the policy.</p>

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -126,7 +126,7 @@ spec:
 <tbody>
 <tr id="RequestAuthentication-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>The selector determines the workloads to apply the RequestAuthentication on.
 If not set, the policy will be applied to all workloads in the same namespace as the policy.</p>

--- a/type/v1beta1/selector.proto
+++ b/type/v1beta1/selector.proto
@@ -17,7 +17,7 @@ import "google/api/field_behavior.proto";
 
 // $title: Workload Selector
 // $description: Definition of a workload selector.
-// $location: https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector
+// $location: https://istio.io/latest/docs/reference/config/networking/sidecar/
 // $aliases: [https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html]
 
 package istio.type.v1beta1;


### PR DESCRIPTION
The original PR https://github.com/istio/api/pull/1540 appended `#WorkloadSelector` twice in the generated protobufs.

This PR removes it because `#WorkloadSelector` automatically gets appended in generated protobufs so no need to include it in `$location`.

Suggested by @brian-avery  https://github.com/istio/api/pull/1548#discussion_r458866256 
I think we can close cherry-pick https://github.com/istio/api/pull/1548 and the new one will be created once this is merged in master?
