### PR TITLE
Add allowed_trust_domains for the authn filter config.

### DIFF
--- a/envoy/config/filter/http/authn/v2alpha1/config.proto
+++ b/envoy/config/filter/http/authn/v2alpha1/config.proto
@@ -44,10 +44,10 @@ message FilterConfig {
   bool skip_validate_trust_domain = 3;
 
   // allowed_trust_domains contains a list of trust domains the authn
-  // filter should validate against. When configured, only the request with a
-  // peer from one of the trust domain can be allowed.
-  // An empty list means no verification on this regard.
-  // When this field is set, skip_validate_trust_domain field is ignored.
+  // filter should validate against. When configured, only requests with a
+  // peer from one of the allowed trust domain will be admitted.
+  // An empty list means all trust domains are allowed.
+  // When this field is set, the skip_validate_trust_domain field is ignored.
   // This field has no effect for plaintext traffic.
   repeated string allowed_trust_domains = 4;
 }

--- a/envoy/config/filter/http/authn/v2alpha1/config.proto
+++ b/envoy/config/filter/http/authn/v2alpha1/config.proto
@@ -20,7 +20,6 @@ import "authentication/v1alpha1/policy.proto";
 
 package istio.envoy.config.filter.http.authn.v2alpha1;
 
-
 option go_package = "istio.io/api/envoy/config/filter/http/authn/v2alpha1";
 
 // FilterConfig is the config for Istio-specific filter that is used to enforce
@@ -41,5 +40,14 @@ message FilterConfig {
   // trust domains.
   // Note, the istio authn filter only validates the trust domain when mTLS is
   // used, In other words, this field has no effect for plaintext traffic.
+  // TODO(incfly): deprecate this after trust_domain_validation_list is shipped.
   bool skip_validate_trust_domain = 3;
+
+  // trust_domain_validation_list contains a list of trust domains the authn
+  // filter should validate against. When configured, only the request with a
+  // peer from one of the trust domain can be allowed.
+  // An empty list means no verification on this regard.
+  // When this field is set, skip_validate_trust_domain field is ignored.
+  // This field has no effect for plaintext traffic.
+  repeated string trust_domain_validation_list = 4;
 }

--- a/envoy/config/filter/http/authn/v2alpha1/config.proto
+++ b/envoy/config/filter/http/authn/v2alpha1/config.proto
@@ -40,14 +40,14 @@ message FilterConfig {
   // trust domains.
   // Note, the istio authn filter only validates the trust domain when mTLS is
   // used, In other words, this field has no effect for plaintext traffic.
-  // TODO(incfly): deprecate this after trust_domain_validation_list is shipped.
+  // TODO(incfly): deprecate this after allowed_trust_domains is shipped.
   bool skip_validate_trust_domain = 3;
 
-  // trust_domain_validation_list contains a list of trust domains the authn
+  // allowed_trust_domains contains a list of trust domains the authn
   // filter should validate against. When configured, only the request with a
   // peer from one of the trust domain can be allowed.
   // An empty list means no verification on this regard.
   // When this field is set, skip_validate_trust_domain field is ignored.
   // This field has no effect for plaintext traffic.
-  repeated string trust_domain_validation_list = 4;
+  repeated string allowed_trust_domains = 4;
 }

--- a/python/istio_api/envoy/config/filter/http/authn/v2alpha1/config_pb2.py
+++ b/python/istio_api/envoy/config/filter/http/authn/v2alpha1/config_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='istio.envoy.config.filter.http.authn.v2alpha1',
   syntax='proto3',
   serialized_options=_b('Z4istio.io/api/envoy/config/filter/http/authn/v2alpha1'),
-  serialized_pb=_b('\n4envoy/config/filter/http/authn/v2alpha1/config.proto\x12-istio.envoy.config.filter.http.authn.v2alpha1\x1a$authentication/v1alpha1/policy.proto\"\xd4\x02\n\x0c\x46ilterConfig\x12\x35\n\x06policy\x18\x01 \x01(\x0b\x32%.istio.authentication.v1alpha1.Policy\x12\x80\x01\n\x1cjwt_output_payload_locations\x18\x02 \x03(\x0b\x32Z.istio.envoy.config.filter.http.authn.v2alpha1.FilterConfig.JwtOutputPayloadLocationsEntry\x12\"\n\x1askip_validate_trust_domain\x18\x03 \x01(\x08\x12$\n\x1ctrust_domain_validation_list\x18\x04 \x03(\t\x1a@\n\x1eJwtOutputPayloadLocationsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x36Z4istio.io/api/envoy/config/filter/http/authn/v2alpha1b\x06proto3')
+  serialized_pb=_b('\n4envoy/config/filter/http/authn/v2alpha1/config.proto\x12-istio.envoy.config.filter.http.authn.v2alpha1\x1a$authentication/v1alpha1/policy.proto\"\xcd\x02\n\x0c\x46ilterConfig\x12\x35\n\x06policy\x18\x01 \x01(\x0b\x32%.istio.authentication.v1alpha1.Policy\x12\x80\x01\n\x1cjwt_output_payload_locations\x18\x02 \x03(\x0b\x32Z.istio.envoy.config.filter.http.authn.v2alpha1.FilterConfig.JwtOutputPayloadLocationsEntry\x12\"\n\x1askip_validate_trust_domain\x18\x03 \x01(\x08\x12\x1d\n\x15\x61llowed_trust_domains\x18\x04 \x03(\t\x1a@\n\x1eJwtOutputPayloadLocationsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x36Z4istio.io/api/envoy/config/filter/http/authn/v2alpha1b\x06proto3')
   ,
   dependencies=[authentication_dot_v1alpha1_dot_policy__pb2.DESCRIPTOR,])
 
@@ -61,8 +61,8 @@ _FILTERCONFIG_JWTOUTPUTPAYLOADLOCATIONSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=418,
-  serialized_end=482,
+  serialized_start=411,
+  serialized_end=475,
 )
 
 _FILTERCONFIG = _descriptor.Descriptor(
@@ -94,7 +94,7 @@ _FILTERCONFIG = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='trust_domain_validation_list', full_name='istio.envoy.config.filter.http.authn.v2alpha1.FilterConfig.trust_domain_validation_list', index=3,
+      name='allowed_trust_domains', full_name='istio.envoy.config.filter.http.authn.v2alpha1.FilterConfig.allowed_trust_domains', index=3,
       number=4, type=9, cpp_type=9, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -113,7 +113,7 @@ _FILTERCONFIG = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=142,
-  serialized_end=482,
+  serialized_end=475,
 )
 
 _FILTERCONFIG_JWTOUTPUTPAYLOADLOCATIONSENTRY.containing_type = _FILTERCONFIG

--- a/python/istio_api/envoy/config/filter/http/authn/v2alpha1/config_pb2.py
+++ b/python/istio_api/envoy/config/filter/http/authn/v2alpha1/config_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='istio.envoy.config.filter.http.authn.v2alpha1',
   syntax='proto3',
   serialized_options=_b('Z4istio.io/api/envoy/config/filter/http/authn/v2alpha1'),
-  serialized_pb=_b('\n4envoy/config/filter/http/authn/v2alpha1/config.proto\x12-istio.envoy.config.filter.http.authn.v2alpha1\x1a$authentication/v1alpha1/policy.proto\"\xae\x02\n\x0c\x46ilterConfig\x12\x35\n\x06policy\x18\x01 \x01(\x0b\x32%.istio.authentication.v1alpha1.Policy\x12\x80\x01\n\x1cjwt_output_payload_locations\x18\x02 \x03(\x0b\x32Z.istio.envoy.config.filter.http.authn.v2alpha1.FilterConfig.JwtOutputPayloadLocationsEntry\x12\"\n\x1askip_validate_trust_domain\x18\x03 \x01(\x08\x1a@\n\x1eJwtOutputPayloadLocationsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x36Z4istio.io/api/envoy/config/filter/http/authn/v2alpha1b\x06proto3')
+  serialized_pb=_b('\n4envoy/config/filter/http/authn/v2alpha1/config.proto\x12-istio.envoy.config.filter.http.authn.v2alpha1\x1a$authentication/v1alpha1/policy.proto\"\xd4\x02\n\x0c\x46ilterConfig\x12\x35\n\x06policy\x18\x01 \x01(\x0b\x32%.istio.authentication.v1alpha1.Policy\x12\x80\x01\n\x1cjwt_output_payload_locations\x18\x02 \x03(\x0b\x32Z.istio.envoy.config.filter.http.authn.v2alpha1.FilterConfig.JwtOutputPayloadLocationsEntry\x12\"\n\x1askip_validate_trust_domain\x18\x03 \x01(\x08\x12$\n\x1ctrust_domain_validation_list\x18\x04 \x03(\t\x1a@\n\x1eJwtOutputPayloadLocationsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x36Z4istio.io/api/envoy/config/filter/http/authn/v2alpha1b\x06proto3')
   ,
   dependencies=[authentication_dot_v1alpha1_dot_policy__pb2.DESCRIPTOR,])
 
@@ -61,8 +61,8 @@ _FILTERCONFIG_JWTOUTPUTPAYLOADLOCATIONSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=380,
-  serialized_end=444,
+  serialized_start=418,
+  serialized_end=482,
 )
 
 _FILTERCONFIG = _descriptor.Descriptor(
@@ -93,6 +93,13 @@ _FILTERCONFIG = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='trust_domain_validation_list', full_name='istio.envoy.config.filter.http.authn.v2alpha1.FilterConfig.trust_domain_validation_list', index=3,
+      number=4, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -106,7 +113,7 @@ _FILTERCONFIG = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=142,
-  serialized_end=444,
+  serialized_end=482,
 )
 
 _FILTERCONFIG_JWTOUTPUTPAYLOADLOCATIONSENTRY.containing_type = _FILTERCONFIG


### PR DESCRIPTION
We add trust domain alias, in the mesh config. The authentication filter requires corresponding change to allow a list of TD's from peer request.

[Alias doc](https://docs.google.com/document/d/1ncrENtF6PBVZVjhYePbvZ6F1obbNApKJh5mUDRvwHMw/edit#heading=h.zccr9pxvbieb), approved, in 2019, section "Use of TrustDomainAliases in Authentication Filter Config" clearly document what needs to be done, what this PR is about.

