### PR TITLE
Explicitly document the root namespace behavior

### DIFF
--- a/security/v1beta1/authorization.pb.go
+++ b/security/v1beta1/authorization.pb.go
@@ -159,6 +159,15 @@
 //    matchLabels:
 //      version: v1
 // ```
+//
+// When designing authorization policies, you can use the
+// `rootNamespace` option for default network behavior.
+// If you set `rootNamespace` in your `MeshConfig` resource, Istio defaults to
+// using authorization policies set in the root namespace when you create no
+// other policy in your namespace.
+//
+// This configuration is useful when configuring a deny-by-default network
+// behavior in your Istio service mesh.
 
 package v1beta1
 

--- a/security/v1beta1/authorization.pb.html
+++ b/security/v1beta1/authorization.pb.html
@@ -169,6 +169,15 @@ spec:
      version: v1
 </code></pre>
 
+<p>When designing authorization policies, you can use the
+<code>rootNamespace</code> option for default network behavior.
+If you set <code>rootNamespace</code> in your <code>MeshConfig</code> resource, Istio defaults to
+using authorization policies set in the root namespace when you create no
+other policy in your namespace.</p>
+
+<p>This configuration is useful when configuring a deny-by-default network
+behavior in your Istio service mesh.</p>
+
 <h2 id="AuthorizationPolicy">AuthorizationPolicy</h2>
 <section>
 <p>AuthorizationPolicy enables access control on workloads.</p>

--- a/security/v1beta1/authorization.proto
+++ b/security/v1beta1/authorization.proto
@@ -39,13 +39,13 @@ import "type/v1beta1/selector.proto";
 // Requests will be allowed or denied based solely on ALLOW and DENY policies.
 //
 // A request will be internally marked that it should be audited if there is an AUDIT policy on the workload that matches the request.
-// A separate plugin must be configured and enabled to actually fulfill the audit decision and complete the audit behavior. 
+// A separate plugin must be configured and enabled to actually fulfill the audit decision and complete the audit behavior.
 // The request will not be audited if there are no such supporting plugins enabled.
 // Currently, the only supported plugin is the [Telemetry v2 Stackdriver](https://istio.io/latest/docs/reference/config/proxy_extensions/stackdriver/) plugin.
-// 
+//
 // Here is an example of Istio Authorization Policy:
 //
-// It sets the `action` to "ALLOW" to create an allow policy. The default action is "ALLOW" 
+// It sets the `action` to "ALLOW" to create an allow policy. The default action is "ALLOW"
 // but it is useful to be explicit in the policy.
 //
 // It allows requests from:
@@ -109,9 +109,9 @@ import "type/v1beta1/selector.proto";
 //        methods: ["POST"]
 // ```
 //
-// The following authorization policy sets the `action` to "AUDIT". It will audit any GET requests to the path with the 
-// prefix "/user/profile". 
-// 
+// The following authorization policy sets the `action` to "AUDIT". It will audit any GET requests to the path with the
+// prefix "/user/profile".
+//
 // ```yaml
 // apiVersion: security.istio.io/v1beta1
 // kind: AuthorizationPolicy
@@ -181,6 +181,15 @@ import "type/v1beta1/selector.proto";
 //    matchLabels:
 //      version: v1
 // ```
+//
+// When designing authorization policies, you can use the
+// `rootNamespace` option for default network behavior.
+// If you set `rootNamespace` in your `MeshConfig` resource, Istio defaults to
+// using authorization policies set in the root namespace when you create no
+// other policy in your namespace.
+//
+// This configuration is useful when configuring a deny-by-default network
+// behavior in your Istio service mesh.
 package istio.security.v1beta1;
 
 option go_package="istio.io/api/security/v1beta1";

--- a/security/v1beta1/authorization_deepcopy.gen.go
+++ b/security/v1beta1/authorization_deepcopy.gen.go
@@ -159,6 +159,15 @@
 //    matchLabels:
 //      version: v1
 // ```
+//
+// When designing authorization policies, you can use the
+// `rootNamespace` option for default network behavior.
+// If you set `rootNamespace` in your `MeshConfig` resource, Istio defaults to
+// using authorization policies set in the root namespace when you create no
+// other policy in your namespace.
+//
+// This configuration is useful when configuring a deny-by-default network
+// behavior in your Istio service mesh.
 
 package v1beta1
 

--- a/security/v1beta1/authorization_json.gen.go
+++ b/security/v1beta1/authorization_json.gen.go
@@ -159,6 +159,15 @@
 //    matchLabels:
 //      version: v1
 // ```
+//
+// When designing authorization policies, you can use the
+// `rootNamespace` option for default network behavior.
+// If you set `rootNamespace` in your `MeshConfig` resource, Istio defaults to
+// using authorization policies set in the root namespace when you create no
+// other policy in your namespace.
+//
+// This configuration is useful when configuring a deny-by-default network
+// behavior in your Istio service mesh.
 
 package v1beta1
 


### PR DESCRIPTION
In this PR, I wanted to provide a small additional bit of documentation.

The concept of root namespace is quite important for the authz policies yet it is very easily missed, mentioned only once in the whole text.

This PR adds two small paras explaining why readers should care about authz policies. 

WDYT?