### PR TITLE
Fix escape in gateway docs

### DIFF
--- a/networking/v1alpha3/gateway.gen.json
+++ b/networking/v1alpha3/gateway.gen.json
@@ -18,7 +18,7 @@
             }
           },
           "selector": {
-            "description": "One or more labels that indicate a specific set of pods/VMs on which this gateway configuration should be applied. By default workloads are searched across all namespaces based on label selectors. This implies that a gateway resource in the namespace \"foo\" can select pods in the namespace \"bar\" based on labels. This behavior can be controlled via the PILOT_SCOPE_GATEWAY_TO_NAMESPACE environment variable in istiod. If this variable is set to true, the scope of label search is restricted to the configuration namespace in which the the resource is present. In other words, the Gateway resource must reside in the same namespace as the gateway workload instance. If selector is nil, the Gateway will be applied to all workloads.",
+            "description": "One or more labels that indicate a specific set of pods/VMs on which this gateway configuration should be applied. By default workloads are searched across all namespaces based on label selectors. This implies that a gateway resource in the namespace \"foo\" can select pods in the namespace \"bar\" based on labels. This behavior can be controlled via the `PILOT_SCOPE_GATEWAY_TO_NAMESPACE` environment variable in istiod. If this variable is set to true, the scope of label search is restricted to the configuration namespace in which the the resource is present. In other words, the Gateway resource must reside in the same namespace as the gateway workload instance. If selector is nil, the Gateway will be applied to all workloads.",
             "type": "object",
             "additionalProperties": {
               "type": "string",

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -477,7 +477,7 @@ type Gateway struct {
 	// By default workloads are searched across all namespaces based on label selectors.
 	// This implies that a gateway resource in the namespace "foo" can select pods in
 	// the namespace "bar" based on labels.
-	// This behavior can be controlled via the PILOT_SCOPE_GATEWAY_TO_NAMESPACE
+	// This behavior can be controlled via the `PILOT_SCOPE_GATEWAY_TO_NAMESPACE`
 	// environment variable in istiod. If this variable is set
 	// to true, the scope of label search is restricted to the configuration
 	// namespace in which the the resource is present. In other words, the Gateway

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -378,7 +378,7 @@ on which this gateway configuration should be applied.
 By default workloads are searched across all namespaces based on label selectors.
 This implies that a gateway resource in the namespace &ldquo;foo&rdquo; can select pods in
 the namespace &ldquo;bar&rdquo; based on labels.
-This behavior can be controlled via the PILOT<em>SCOPE</em>GATEWAY<em>TO</em>NAMESPACE
+This behavior can be controlled via the <code>PILOT_SCOPE_GATEWAY_TO_NAMESPACE</code>
 environment variable in istiod. If this variable is set
 to true, the scope of label search is restricted to the configuration
 namespace in which the the resource is present. In other words, the Gateway

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -382,7 +382,7 @@ message Gateway {
   // By default workloads are searched across all namespaces based on label selectors.
   // This implies that a gateway resource in the namespace "foo" can select pods in
   // the namespace "bar" based on labels.
-  // This behavior can be controlled via the PILOT_SCOPE_GATEWAY_TO_NAMESPACE
+  // This behavior can be controlled via the `PILOT_SCOPE_GATEWAY_TO_NAMESPACE`
   // environment variable in istiod. If this variable is set
   // to true, the scope of label search is restricted to the configuration
   // namespace in which the the resource is present. In other words, the Gateway

--- a/networking/v1beta1/gateway.gen.json
+++ b/networking/v1beta1/gateway.gen.json
@@ -18,7 +18,7 @@
             }
           },
           "selector": {
-            "description": "One or more labels that indicate a specific set of pods/VMs on which this gateway configuration should be applied. By default workloads are searched across all namespaces based on label selectors. This implies that a gateway resource in the namespace \"foo\" can select pods in the namespace \"bar\" based on labels. This behavior can be controlled via the PILOT_SCOPE_GATEWAY_TO_NAMESPACE environment variable in istiod. If this variable is set to true, the scope of label search is restricted to the configuration namespace in which the the resource is present. In other words, the Gateway resource must reside in the same namespace as the gateway workload instance. If selector is nil, the Gateway will be applied to all workloads.",
+            "description": "One or more labels that indicate a specific set of pods/VMs on which this gateway configuration should be applied. By default workloads are searched across all namespaces based on label selectors. This implies that a gateway resource in the namespace \"foo\" can select pods in the namespace \"bar\" based on labels. This behavior can be controlled via the `PILOT_SCOPE_GATEWAY_TO_NAMESPACE` environment variable in istiod. If this variable is set to true, the scope of label search is restricted to the configuration namespace in which the the resource is present. In other words, the Gateway resource must reside in the same namespace as the gateway workload instance. If selector is nil, the Gateway will be applied to all workloads.",
             "type": "object",
             "additionalProperties": {
               "type": "string",

--- a/networking/v1beta1/gateway.pb.go
+++ b/networking/v1beta1/gateway.pb.go
@@ -478,7 +478,7 @@ type Gateway struct {
 	// By default workloads are searched across all namespaces based on label selectors.
 	// This implies that a gateway resource in the namespace "foo" can select pods in
 	// the namespace "bar" based on labels.
-	// This behavior can be controlled via the PILOT_SCOPE_GATEWAY_TO_NAMESPACE
+	// This behavior can be controlled via the `PILOT_SCOPE_GATEWAY_TO_NAMESPACE`
 	// environment variable in istiod. If this variable is set
 	// to true, the scope of label search is restricted to the configuration
 	// namespace in which the the resource is present. In other words, the Gateway

--- a/networking/v1beta1/gateway.proto
+++ b/networking/v1beta1/gateway.proto
@@ -383,7 +383,7 @@ message Gateway {
   // By default workloads are searched across all namespaces based on label selectors.
   // This implies that a gateway resource in the namespace "foo" can select pods in
   // the namespace "bar" based on labels.
-  // This behavior can be controlled via the PILOT_SCOPE_GATEWAY_TO_NAMESPACE
+  // This behavior can be controlled via the `PILOT_SCOPE_GATEWAY_TO_NAMESPACE`
   // environment variable in istiod. If this variable is set
   // to true, the scope of label search is restricted to the configuration
   // namespace in which the the resource is present. In other words, the Gateway


### PR DESCRIPTION
Shows up wrong today: https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway