### PR TITLE
Fix inconsistent rendering of enum constant and code examples for ProxyConfig

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -228,16 +228,16 @@
             "format": "string"
           },
           "serviceCluster": {
-            "description": "Service cluster defines the name for the service_cluster that is shared by all Envoy instances. This setting corresponds to _--service-cluster_ flag in Envoy. In a typical Envoy deployment, the _service-cluster_ flag is used to identify the caller, for source-based routing scenarios.",
+            "description": "Service cluster defines the name for the `service_cluster` that is shared by all Envoy instances. This setting corresponds to `--service-cluster` flag in Envoy. In a typical Envoy deployment, the `service-cluster` flag is used to identify the caller, for source-based routing scenarios.",
             "type": "string",
             "format": "string"
           },
           "drainDuration": {
-            "description": "The time in seconds that Envoy will drain connections during a hot restart. MUST be \u003e=1s (e.g., _1s/1m/1h_) Default drain duration is 45s.",
+            "description": "The time in seconds that Envoy will drain connections during a hot restart. MUST be \u003e=1s (e.g., _1s/1m/1h_) Default drain duration is `45s`.",
             "type": "string"
           },
           "parentShutdownDuration": {
-            "description": "The time in seconds that Envoy will wait before shutting down the parent process during a hot restart. MUST be \u003e=1s (e.g., _1s/1m/1h_). MUST BE greater than _drain_duration_ parameter. Default shutdown duration is 60s.",
+            "description": "The time in seconds that Envoy will wait before shutting down the parent process during a hot restart. MUST be \u003e=1s (e.g., `1s/1m/1h`). MUST BE greater than `drain_duration` parameter. Default shutdown duration is `60s`.",
             "type": "string"
           },
           "discoveryAddress": {
@@ -256,7 +256,7 @@
             "deprecated": true
           },
           "statsdUdpAddress": {
-            "description": "IP Address and Port of a statsd UDP listener (e.g. _10.75.241.127:9125_).",
+            "description": "IP Address and Port of a statsd UDP listener (e.g. `10.75.241.127:9125`).",
             "type": "string",
             "format": "string"
           },
@@ -266,7 +266,7 @@
             "deprecated": true
           },
           "proxyAdminPort": {
-            "description": "Port on which Envoy should listen for administrative commands. Default port is 15000.",
+            "description": "Port on which Envoy should listen for administrative commands. Default port is `15000`.",
             "type": "integer",
             "format": "int32"
           },
@@ -322,7 +322,7 @@
             }
           },
           "statusPort": {
-            "description": "Port on which the agent should listen for administrative commands such as readiness probe. Default is set to port 15020.",
+            "description": "Port on which the agent should listen for administrative commands such as readiness probe. Default is set to port `15020`.",
             "type": "integer",
             "format": "int32"
           },
@@ -338,7 +338,7 @@
             "$ref": "#/components/schemas/istio.mesh.v1alpha1.Topology"
           },
           "terminationDrainDuration": {
-            "description": "The amount of time allowed for connections to complete on proxy shutdown. On receiving SIGTERM or SIGINT, istio-agent tells the active Envoy to start draining, preventing any new connections and allowing existing connections to complete. It then sleeps for the termination_drain_duration and then kills any remaining active Envoy processes. If not set, a default of 5s will be applied.",
+            "description": "The amount of time allowed for connections to complete on proxy shutdown. On receiving `SIGTERM` or `SIGINT`, `istio-agent` tells the active Envoy to start draining, preventing any new connections and allowing existing connections to complete. It then sleeps for the `termination_drain_duration` and then kills any remaining active Envoy processes. If not set, a default of `5s` will be applied.",
             "type": "string"
           },
           "meshId": {
@@ -1037,7 +1037,7 @@
         ]
       },
       "istio.mesh.v1alpha1.ProxyConfig.InboundInterceptionMode": {
-        "description": "The mode used to redirect inbound traffic to Envoy. This setting has no effect on outbound traffic: iptables REDIRECT is always used for outbound connections.",
+        "description": "The mode used to redirect inbound traffic to Envoy. This setting has no effect on outbound traffic: iptables `REDIRECT` is always used for outbound connections.",
         "type": "string",
         "enum": [
           "REDIRECT",
@@ -1061,7 +1061,7 @@
         }
       },
       "istio.networking.v1alpha3.ClientTLSSettings": {
-        "description": "Use the tls_settings to specify the tls mode to use. If the remote service uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS mode as `ISTIO_MUTUAL`.",
+        "description": "Use the `tls_settings` to specify the tls mode to use. If the remote service uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS mode as `ISTIO_MUTUAL`.",
         "type": "object",
         "properties": {
           "mode": {
@@ -1103,7 +1103,7 @@
         }
       },
       "istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.TcpKeepalive": {
-        "description": "If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.",
+        "description": "If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.",
         "type": "object",
         "properties": {
           "time": {

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -176,17 +176,17 @@ No
 <td><code>serviceCluster</code></td>
 <td><code>string</code></td>
 <td>
-<p>Service cluster defines the name for the service_cluster that is
+<p>Service cluster defines the name for the <code>service_cluster</code> that is
 shared by all Envoy instances. This setting corresponds to
-<em>&ndash;service-cluster</em> flag in Envoy.  In a typical Envoy deployment, the
-<em>service-cluster</em> flag is used to identify the caller, for
+<code>--service-cluster</code> flag in Envoy.  In a typical Envoy deployment, the
+<code>service-cluster</code> flag is used to identify the caller, for
 source-based routing scenarios.</p>
 
-<p>Since Istio does not assign a local service/service version to each
+<p>Since Istio does not assign a local <code>service/service</code> version to each
 Envoy instance, the name is same for all of them.  However, the
 source/caller&rsquo;s identity (e.g., IP address) is encoded in the
-<em>&ndash;service-node</em> flag when launching Envoy.  When the RDS service
-receives API calls from Envoy, it uses the value of the <em>service-node</em>
+<code>--service-node</code> flag when launching Envoy.  When the RDS service
+receives API calls from Envoy, it uses the value of the <code>service-node</code>
 flag to compute routes that are relative to the service instances
 located at that IP address.</p>
 
@@ -201,7 +201,7 @@ No
 <td>
 <p>The time in seconds that Envoy will drain connections during a hot
 restart. MUST be &gt;=1s (e.g., <em>1s/1m/1h</em>)
-Default drain duration is 45s.</p>
+Default drain duration is <code>45s</code>.</p>
 
 </td>
 <td>
@@ -213,9 +213,9 @@ No
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
 <p>The time in seconds that Envoy will wait before shutting down the
-parent process during a hot restart. MUST be &gt;=1s (e.g., <em>1s/1m/1h</em>).
-MUST BE greater than <em>drain</em>duration_ parameter.
-Default shutdown duration is 60s.</p>
+parent process during a hot restart. MUST be &gt;=1s (e.g., <code>1s/1m/1h</code>).
+MUST BE greater than <code>drain_duration</code> parameter.
+Default shutdown duration is <code>60s</code>.</p>
 
 </td>
 <td>
@@ -238,7 +238,7 @@ No
 <td><code>statsdUdpAddress</code></td>
 <td><code>string</code></td>
 <td>
-<p>IP Address and Port of a statsd UDP listener (e.g. <em>10.75.241.127:9125</em>).</p>
+<p>IP Address and Port of a statsd UDP listener (e.g. <code>10.75.241.127:9125</code>).</p>
 
 </td>
 <td>
@@ -250,7 +250,7 @@ No
 <td><code>int32</code></td>
 <td>
 <p>Port on which Envoy should listen for administrative commands.
-Default port is 15000.</p>
+Default port is <code>15000</code>.</p>
 
 </td>
 <td>
@@ -262,7 +262,7 @@ No
 <td><code><a href="#AuthenticationPolicy">AuthenticationPolicy</a></code></td>
 <td>
 <p>AuthenticationPolicy defines how the proxy is authenticated when it connects to the control plane.
-Default is set to MUTUAL_TLS.</p>
+Default is set to <code>MUTUAL_TLS</code>.</p>
 
 </td>
 <td>
@@ -347,7 +347,7 @@ No
 <td><code>sds</code></td>
 <td><code><a href="#SDS">SDS</a></code></td>
 <td>
-<p>secret discovery service(SDS) configuration to be used by the proxy.</p>
+<p>Secret Discovery Service(SDS) configuration to be used by the proxy.</p>
 
 </td>
 <td>
@@ -359,7 +359,7 @@ No
 <td><code><a href="#RemoteService">RemoteService</a></code></td>
 <td>
 <p>Address of the service to which access logs from Envoys should be
-sent. (e.g. accesslog-service:15000). See <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto">Access Log
+sent. (e.g. <code>accesslog-service:15000</code>). See <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto">Access Log
 Service</a>
 for details about Envoy&rsquo;s gRPC Access Log Service API.</p>
 
@@ -372,7 +372,7 @@ No
 <td><code>envoyMetricsService</code></td>
 <td><code><a href="#RemoteService">RemoteService</a></code></td>
 <td>
-<p>Address of the Envoy Metrics Service implementation (e.g. metrics-service:15000).
+<p>Address of the Envoy Metrics Service implementation (e.g. <code>metrics-service:15000</code>).
 See <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/metrics/v2/metrics_service.proto">Metric Service</a>
 for details about Envoy&rsquo;s Metrics Service API.</p>
 
@@ -386,7 +386,7 @@ No
 <td><code>int32</code></td>
 <td>
 <p>Port on which the agent should listen for administrative commands such as readiness probe.
-Default is set to port 15020.</p>
+Default is set to port <code>15020</code>.</p>
 
 </td>
 <td>
@@ -412,10 +412,10 @@ No
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
 <p>The amount of time allowed for connections to complete on proxy shutdown.
-On receiving SIGTERM or SIGINT, istio-agent tells the active Envoy to start draining,
+On receiving <code>SIGTERM</code> or <code>SIGINT</code>, <code>istio-agent</code> tells the active Envoy to start draining,
 preventing any new connections and allowing existing connections to complete. It then
-sleeps for the termination<em>drain</em>duration and then kills any remaining active Envoy processes.
-If not set, a default of 5s will be applied.</p>
+sleeps for the <code>termination_drain_duration</code> and then kills any remaining active Envoy processes.
+If not set, a default of <code>5s</code> will be applied.</p>
 
 </td>
 <td>
@@ -492,7 +492,7 @@ No
 <td><code>tlsSettings</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/networking/destination-rule.html#ClientTLSSettings">ClientTLSSettings</a></code></td>
 <td>
-<p>Use the tls_settings to specify the tls mode to use. If the remote service
+<p>Use the <code>tls_settings</code> to specify the tls mode to use. If the remote service
 uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS
 mode as <code>ISTIO_MUTUAL</code>.</p>
 
@@ -505,7 +505,7 @@ No
 <td><code>tcpKeepalive</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/networking/destination-rule.html#ConnectionPoolSettings-TCPSettings-TcpKeepalive">TcpKeepalive</a></code></td>
 <td>
-<p>If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.</p>
+<p>If set then set <code>SO_KEEPALIVE</code> on the socket to enable TCP Keepalives.</p>
 
 </td>
 <td>
@@ -1811,7 +1811,7 @@ for details.</p>
 <h2 id="ProxyConfig-InboundInterceptionMode">ProxyConfig.InboundInterceptionMode</h2>
 <section>
 <p>The mode used to redirect inbound traffic to Envoy.
-This setting has no effect on outbound traffic: iptables REDIRECT is always used for
+This setting has no effect on outbound traffic: iptables <code>REDIRECT</code> is always used for
 outbound connections.</p>
 
 <table class="enum-values">
@@ -1825,7 +1825,7 @@ outbound connections.</p>
 <tr id="ProxyConfig-InboundInterceptionMode-REDIRECT">
 <td><code>REDIRECT</code></td>
 <td>
-<p>The REDIRECT mode uses iptables REDIRECT to NAT and redirect to Envoy. This mode loses
+<p>The <code>REDIRECT</code> mode uses iptables <code>REDIRECT</code> to <code>NAT</code> and redirect to Envoy. This mode loses
 source IP addresses during redirection.</p>
 
 </td>
@@ -1833,10 +1833,10 @@ source IP addresses during redirection.</p>
 <tr id="ProxyConfig-InboundInterceptionMode-TPROXY">
 <td><code>TPROXY</code></td>
 <td>
-<p>The TPROXY mode uses iptables TPROXY to redirect to Envoy. This mode preserves both the
+<p>The <code>TPROXY</code> mode uses iptables <code>TPROXY</code> to redirect to Envoy. This mode preserves both the
 source and destination IP addresses and ports, so that they can be used for advanced
 filtering and manipulation. This mode also configures the sidecar to run with the
-CAP<em>NET</em>ADMIN capability, which is required to use TPROXY.</p>
+<code>CAP_NET_ADMIN</code> capability, which is required to use <code>TPROXY</code>.</p>
 
 </td>
 </tr>

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -162,18 +162,18 @@ func (Topology_ForwardClientCertDetails) EnumDescriptor() ([]byte, []int) {
 }
 
 // The mode used to redirect inbound traffic to Envoy.
-// This setting has no effect on outbound traffic: iptables REDIRECT is always used for
+// This setting has no effect on outbound traffic: iptables `REDIRECT` is always used for
 // outbound connections.
 type ProxyConfig_InboundInterceptionMode int32
 
 const (
-	// The REDIRECT mode uses iptables REDIRECT to NAT and redirect to Envoy. This mode loses
+	// The `REDIRECT` mode uses iptables `REDIRECT` to `NAT` and redirect to Envoy. This mode loses
 	// source IP addresses during redirection.
 	ProxyConfig_REDIRECT ProxyConfig_InboundInterceptionMode = 0
-	// The TPROXY mode uses iptables TPROXY to redirect to Envoy. This mode preserves both the
+	// The `TPROXY` mode uses iptables `TPROXY` to redirect to Envoy. This mode preserves both the
 	// source and destination IP addresses and ports, so that they can be used for advanced
 	// filtering and manipulation. This mode also configures the sidecar to run with the
-	// CAP_NET_ADMIN capability, which is required to use TPROXY.
+	// `CAP_NET_ADMIN` capability, which is required to use `TPROXY`.
 	ProxyConfig_TPROXY ProxyConfig_InboundInterceptionMode = 1
 )
 
@@ -1113,28 +1113,28 @@ type ProxyConfig struct {
 	ConfigPath string `protobuf:"bytes,1,opt,name=config_path,json=configPath,proto3" json:"configPath,omitempty"`
 	// Path to the proxy binary
 	BinaryPath string `protobuf:"bytes,2,opt,name=binary_path,json=binaryPath,proto3" json:"binaryPath,omitempty"`
-	// Service cluster defines the name for the service_cluster that is
+	// Service cluster defines the name for the `service_cluster` that is
 	// shared by all Envoy instances. This setting corresponds to
-	// _--service-cluster_ flag in Envoy.  In a typical Envoy deployment, the
-	// _service-cluster_ flag is used to identify the caller, for
+	// `--service-cluster` flag in Envoy.  In a typical Envoy deployment, the
+	// `service-cluster` flag is used to identify the caller, for
 	// source-based routing scenarios.
 	//
-	// Since Istio does not assign a local service/service version to each
+	// Since Istio does not assign a local `service/service` version to each
 	// Envoy instance, the name is same for all of them.  However, the
 	// source/caller's identity (e.g., IP address) is encoded in the
-	// _--service-node_ flag when launching Envoy.  When the RDS service
-	// receives API calls from Envoy, it uses the value of the _service-node_
+	// `--service-node` flag when launching Envoy.  When the RDS service
+	// receives API calls from Envoy, it uses the value of the `service-node`
 	// flag to compute routes that are relative to the service instances
 	// located at that IP address.
 	ServiceCluster string `protobuf:"bytes,3,opt,name=service_cluster,json=serviceCluster,proto3" json:"serviceCluster,omitempty"`
 	// The time in seconds that Envoy will drain connections during a hot
 	// restart. MUST be >=1s (e.g., _1s/1m/1h_)
-	// Default drain duration is 45s.
+	// Default drain duration is `45s`.
 	DrainDuration *types.Duration `protobuf:"bytes,4,opt,name=drain_duration,json=drainDuration,proto3" json:"drainDuration,omitempty"`
 	// The time in seconds that Envoy will wait before shutting down the
-	// parent process during a hot restart. MUST be >=1s (e.g., _1s/1m/1h_).
-	// MUST BE greater than _drain_duration_ parameter.
-	// Default shutdown duration is 60s.
+	// parent process during a hot restart. MUST be >=1s (e.g., `1s/1m/1h`).
+	// MUST BE greater than `drain_duration` parameter.
+	// Default shutdown duration is `60s`.
 	ParentShutdownDuration *types.Duration `protobuf:"bytes,5,opt,name=parent_shutdown_duration,json=parentShutdownDuration,proto3" json:"parentShutdownDuration,omitempty"`
 	// Address of the discovery service exposing xDS with mTLS connection.
 	// The inject configuration may override this value.
@@ -1144,17 +1144,17 @@ type ProxyConfig struct {
 	// Address of the Zipkin service (e.g. _zipkin:9411_).
 	// DEPRECATED: Use [tracing][istio.mesh.v1alpha1.ProxyConfig.tracing] instead.
 	ZipkinAddress string `protobuf:"bytes,8,opt,name=zipkin_address,json=zipkinAddress,proto3" json:"zipkinAddress,omitempty"` // Deprecated: Do not use.
-	// IP Address and Port of a statsd UDP listener (e.g. _10.75.241.127:9125_).
+	// IP Address and Port of a statsd UDP listener (e.g. `10.75.241.127:9125`).
 	StatsdUdpAddress string `protobuf:"bytes,10,opt,name=statsd_udp_address,json=statsdUdpAddress,proto3" json:"statsdUdpAddress,omitempty"`
 	// $hide_from_docs
 	EnvoyMetricsServiceAddress string `protobuf:"bytes,20,opt,name=envoy_metrics_service_address,json=envoyMetricsServiceAddress,proto3" json:"envoyMetricsServiceAddress,omitempty"` // Deprecated: Do not use.
 	// Port on which Envoy should listen for administrative commands.
-	// Default port is 15000.
+	// Default port is `15000`.
 	ProxyAdminPort int32 `protobuf:"varint,11,opt,name=proxy_admin_port,json=proxyAdminPort,proto3" json:"proxyAdminPort,omitempty"`
 	// $hide_from_docs
 	AvailabilityZone string `protobuf:"bytes,12,opt,name=availability_zone,json=availabilityZone,proto3" json:"availabilityZone,omitempty"` // Deprecated: Do not use.
 	// AuthenticationPolicy defines how the proxy is authenticated when it connects to the control plane.
-	// Default is set to MUTUAL_TLS.
+	// Default is set to `MUTUAL_TLS`.
 	ControlPlaneAuthPolicy AuthenticationPolicy `protobuf:"varint,13,opt,name=control_plane_auth_policy,json=controlPlaneAuthPolicy,proto3,enum=istio.mesh.v1alpha1.AuthenticationPolicy" json:"controlPlaneAuthPolicy,omitempty"`
 	// File path of custom proxy configuration, currently used by proxies
 	// in front of Mixer and Pilot.
@@ -1176,14 +1176,14 @@ type ProxyConfig struct {
 	InterceptionMode ProxyConfig_InboundInterceptionMode `protobuf:"varint,18,opt,name=interception_mode,json=interceptionMode,proto3,enum=istio.mesh.v1alpha1.ProxyConfig_InboundInterceptionMode" json:"interceptionMode,omitempty"`
 	// Tracing configuration to be used by the proxy.
 	Tracing *Tracing `protobuf:"bytes,19,opt,name=tracing,proto3" json:"tracing,omitempty"`
-	// secret discovery service(SDS) configuration to be used by the proxy.
+	// Secret Discovery Service(SDS) configuration to be used by the proxy.
 	Sds *SDS `protobuf:"bytes,21,opt,name=sds,proto3" json:"sds,omitempty"`
 	// Address of the service to which access logs from Envoys should be
-	// sent. (e.g. accesslog-service:15000). See [Access Log
+	// sent. (e.g. `accesslog-service:15000`). See [Access Log
 	// Service](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto)
 	// for details about Envoy's gRPC Access Log Service API.
 	EnvoyAccessLogService *RemoteService `protobuf:"bytes,22,opt,name=envoy_access_log_service,json=envoyAccessLogService,proto3" json:"envoyAccessLogService,omitempty"`
-	// Address of the Envoy Metrics Service implementation (e.g. metrics-service:15000).
+	// Address of the Envoy Metrics Service implementation (e.g. `metrics-service:15000`).
 	// See [Metric Service](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/metrics/v2/metrics_service.proto)
 	// for details about Envoy's Metrics Service API.
 	EnvoyMetricsService *RemoteService `protobuf:"bytes,23,opt,name=envoy_metrics_service,json=envoyMetricsService,proto3" json:"envoyMetricsService,omitempty"`
@@ -1192,7 +1192,7 @@ type ProxyConfig struct {
 	// Names starting with ISTIO_META_ will be included in the generated bootstrap and sent to the XDS server.
 	ProxyMetadata map[string]string `protobuf:"bytes,24,rep,name=proxy_metadata,json=proxyMetadata,proto3" json:"proxyMetadata,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Port on which the agent should listen for administrative commands such as readiness probe.
-	// Default is set to port 15020.
+	// Default is set to port `15020`.
 	StatusPort int32 `protobuf:"varint,26,opt,name=status_port,json=statusPort,proto3" json:"statusPort,omitempty"`
 	// An additional list of tags to extract from the in-proxy Istio telemetry. These extra tags can be
 	// added by configuring the telemetry extension. Each additional tag needs to be present in this list.
@@ -1207,10 +1207,10 @@ type ProxyConfig struct {
 	// gateway workloads.
 	GatewayTopology *Topology `protobuf:"bytes,28,opt,name=gateway_topology,json=gatewayTopology,proto3" json:"gatewayTopology,omitempty"`
 	// The amount of time allowed for connections to complete on proxy shutdown.
-	// On receiving SIGTERM or SIGINT, istio-agent tells the active Envoy to start draining,
+	// On receiving `SIGTERM` or `SIGINT`, `istio-agent` tells the active Envoy to start draining,
 	// preventing any new connections and allowing existing connections to complete. It then
-	// sleeps for the termination_drain_duration and then kills any remaining active Envoy processes.
-	// If not set, a default of 5s will be applied.
+	// sleeps for the `termination_drain_duration` and then kills any remaining active Envoy processes.
+	// If not set, a default of `5s` will be applied.
 	TerminationDrainDuration *types.Duration `protobuf:"bytes,29,opt,name=termination_drain_duration,json=terminationDrainDuration,proto3" json:"terminationDrainDuration,omitempty"`
 	// The unique identifier for the [service mesh](https://istio.io/docs/reference/glossary/#service-mesh)
 	// All control planes running in the same service mesh should specify the same mesh ID.
@@ -1470,11 +1470,11 @@ type RemoteService struct {
 	// receiver, metrics receiver, etc.). Can be IP address or a fully
 	// qualified DNS name.
 	Address string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
-	// Use the tls_settings to specify the tls mode to use. If the remote service
+	// Use the `tls_settings` to specify the tls mode to use. If the remote service
 	// uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS
 	// mode as `ISTIO_MUTUAL`.
 	TlsSettings *v1alpha3.ClientTLSSettings `protobuf:"bytes,2,opt,name=tls_settings,json=tlsSettings,proto3" json:"tlsSettings,omitempty"`
-	// If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+	// If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.
 	TcpKeepalive         *v1alpha3.ConnectionPoolSettings_TCPSettings_TcpKeepalive `protobuf:"bytes,3,opt,name=tcp_keepalive,json=tcpKeepalive,proto3" json:"tcpKeepalive,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                                                  `json:"-"`
 	XXX_unrecognized     []byte                                                    `json:"-"`

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -302,30 +302,30 @@ message ProxyConfig {
   // Path to the proxy binary
   string binary_path = 2;
 
-  // Service cluster defines the name for the service_cluster that is
+  // Service cluster defines the name for the `service_cluster` that is
   // shared by all Envoy instances. This setting corresponds to
-  // _--service-cluster_ flag in Envoy.  In a typical Envoy deployment, the
-  // _service-cluster_ flag is used to identify the caller, for
+  // `--service-cluster` flag in Envoy.  In a typical Envoy deployment, the
+  // `service-cluster` flag is used to identify the caller, for
   // source-based routing scenarios.
   //
-  // Since Istio does not assign a local service/service version to each
+  // Since Istio does not assign a local `service/service` version to each
   // Envoy instance, the name is same for all of them.  However, the
   // source/caller's identity (e.g., IP address) is encoded in the
-  // _--service-node_ flag when launching Envoy.  When the RDS service
-  // receives API calls from Envoy, it uses the value of the _service-node_
+  // `--service-node` flag when launching Envoy.  When the RDS service
+  // receives API calls from Envoy, it uses the value of the `service-node`
   // flag to compute routes that are relative to the service instances
   // located at that IP address.
   string service_cluster = 3;
 
   // The time in seconds that Envoy will drain connections during a hot
   // restart. MUST be >=1s (e.g., _1s/1m/1h_)
-  // Default drain duration is 45s.
+  // Default drain duration is `45s`.
   google.protobuf.Duration drain_duration = 4;
 
   // The time in seconds that Envoy will wait before shutting down the
-  // parent process during a hot restart. MUST be >=1s (e.g., _1s/1m/1h_).
-  // MUST BE greater than _drain_duration_ parameter.
-  // Default shutdown duration is 60s.
+  // parent process during a hot restart. MUST be >=1s (e.g., `1s/1m/1h`).
+  // MUST BE greater than `drain_duration` parameter.
+  // Default shutdown duration is `60s`.
   google.protobuf.Duration parent_shutdown_duration = 5;
 
   // Address of the discovery service exposing xDS with mTLS connection.
@@ -342,21 +342,21 @@ message ProxyConfig {
   reserved "connect_timeout";
   reserved 9;
 
-  // IP Address and Port of a statsd UDP listener (e.g. _10.75.241.127:9125_).
+  // IP Address and Port of a statsd UDP listener (e.g. `10.75.241.127:9125`).
   string statsd_udp_address = 10;
 
   // $hide_from_docs
   string envoy_metrics_service_address = 20 [deprecated=true];
 
   // Port on which Envoy should listen for administrative commands.
-  // Default port is 15000.
+  // Default port is `15000`.
   int32 proxy_admin_port = 11;
 
   // $hide_from_docs
   string availability_zone = 12 [deprecated=true];
 
   // AuthenticationPolicy defines how the proxy is authenticated when it connects to the control plane.
-  // Default is set to MUTUAL_TLS.
+  // Default is set to `MUTUAL_TLS`.
   AuthenticationPolicy control_plane_auth_policy = 13;
   // File path of custom proxy configuration, currently used by proxies
   // in front of Mixer and Pilot.
@@ -379,16 +379,16 @@ message ProxyConfig {
   string proxy_bootstrap_template_path = 17;
 
   // The mode used to redirect inbound traffic to Envoy.
-  // This setting has no effect on outbound traffic: iptables REDIRECT is always used for
+  // This setting has no effect on outbound traffic: iptables `REDIRECT` is always used for
   // outbound connections.
   enum InboundInterceptionMode {
-    // The REDIRECT mode uses iptables REDIRECT to NAT and redirect to Envoy. This mode loses
+    // The `REDIRECT` mode uses iptables `REDIRECT` to `NAT` and redirect to Envoy. This mode loses
     // source IP addresses during redirection.
     REDIRECT = 0;
-    // The TPROXY mode uses iptables TPROXY to redirect to Envoy. This mode preserves both the
+    // The `TPROXY` mode uses iptables `TPROXY` to redirect to Envoy. This mode preserves both the
     // source and destination IP addresses and ports, so that they can be used for advanced
     // filtering and manipulation. This mode also configures the sidecar to run with the
-    // CAP_NET_ADMIN capability, which is required to use TPROXY.
+    // `CAP_NET_ADMIN` capability, which is required to use `TPROXY`.
     TPROXY = 1;
   }
 
@@ -398,16 +398,16 @@ message ProxyConfig {
   // Tracing configuration to be used by the proxy.
   Tracing tracing = 19;
 
-  // secret discovery service(SDS) configuration to be used by the proxy.
+  // Secret Discovery Service(SDS) configuration to be used by the proxy.
   SDS sds = 21;
 
   // Address of the service to which access logs from Envoys should be
-  // sent. (e.g. accesslog-service:15000). See [Access Log
+  // sent. (e.g. `accesslog-service:15000`). See [Access Log
   // Service](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto)
   // for details about Envoy's gRPC Access Log Service API.
   RemoteService envoy_access_log_service = 22;
 
-  // Address of the Envoy Metrics Service implementation (e.g. metrics-service:15000).
+  // Address of the Envoy Metrics Service implementation (e.g. `metrics-service:15000`).
   // See [Metric Service](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/metrics/v2/metrics_service.proto)
   // for details about Envoy's Metrics Service API.
   RemoteService envoy_metrics_service = 23;
@@ -418,7 +418,7 @@ message ProxyConfig {
   map<string,string> proxy_metadata = 24;
 
   // Port on which the agent should listen for administrative commands such as readiness probe.
-  // Default is set to port 15020.
+  // Default is set to port `15020`.
   int32 status_port = 26;
 
   // An additional list of tags to extract from the in-proxy Istio telemetry. These extra tags can be
@@ -436,10 +436,10 @@ message ProxyConfig {
   Topology gateway_topology = 28;
 
   // The amount of time allowed for connections to complete on proxy shutdown.
-	// On receiving SIGTERM or SIGINT, istio-agent tells the active Envoy to start draining,
+	// On receiving `SIGTERM` or `SIGINT`, `istio-agent` tells the active Envoy to start draining,
 	// preventing any new connections and allowing existing connections to complete. It then
-  // sleeps for the termination_drain_duration and then kills any remaining active Envoy processes.
-  // If not set, a default of 5s will be applied.
+  // sleeps for the `termination_drain_duration` and then kills any remaining active Envoy processes.
+  // If not set, a default of `5s` will be applied.
   google.protobuf.Duration  termination_drain_duration = 29;
 
   // The unique identifier for the [service mesh](https://istio.io/docs/reference/glossary/#service-mesh)
@@ -459,11 +459,11 @@ message RemoteService {
   // qualified DNS name.
   string address = 1;
 
-  // Use the tls_settings to specify the tls mode to use. If the remote service
+  // Use the `tls_settings` to specify the tls mode to use. If the remote service
   // uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS
   // mode as `ISTIO_MUTUAL`.
   istio.networking.v1alpha3.ClientTLSSettings tls_settings = 2;
 
-  // If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+  // If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.
   istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.TcpKeepalive tcp_keepalive = 3;
 }


### PR DESCRIPTION
Ref: https://preliminary.istio.io/latest/docs/reference/config/istio.mesh.v1alpha1#ProxyConfig
Some of the inconsistencies.

drainduration_ 
terminationdrainduration
–service-cluster
–service-node

Related:
https://github.com/istio/api/pull/1642
https://github.com/istio/api/pull/1641