### PR TITLE
clarify http retry attempts

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -1913,6 +1913,23 @@ metadata:
     release: istio
   name: virtualservices.networking.istio.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.gateways
+    description: The names of gateways and sidecars that should apply these routes
+    name: Gateways
+    type: string
+  - JSONPath: .spec.hosts
+    description: The destination hosts to which traffic is being sent
+    name: Hosts
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
   group: networking.istio.io
   names:
     categories:
@@ -1927,424 +1944,264 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  versions:
-  - additionalPrinterColumns:
-    - JSONPath: .spec.gateways
-      description: The names of gateways and sidecars that should apply these routes
-      name: Gateways
-      type: string
-    - JSONPath: .spec.hosts
-      description: The destination hosts to which traffic is being sent
-      name: Hosts
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: 'CreationTimestamp is a timestamp representing the server time
-        when this object was created. It is not guaranteed to be set in happens-before
-        order across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting label/content routing, sni routing,
-              etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this virtual service is
-                  exported.
-                items:
-                  format: string
-                  type: string
-                type: array
-              gateways:
-                description: The names of gateways and sidecars that should apply
-                  these routes.
-                items:
-                  format: string
-                  type: string
-                type: array
-              hosts:
-                description: The destination hosts to which traffic is being sent.
-                items:
-                  format: string
-                  type: string
-                type: array
-              http:
-                description: An ordered list of route rules for HTTP traffic.
-                items:
-                  properties:
-                    corsPolicy:
-                      description: Cross-Origin Resource Sharing policy (CORS).
-                      properties:
-                        allowCredentials:
-                          nullable: true
-                          type: boolean
-                        allowHeaders:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowMethods:
-                          description: List of HTTP methods allowed to access the
-                            resource.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowOrigin:
-                          description: The list of origins that are allowed to perform
-                            CORS requests.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowOrigins:
-                          description: String patterns that match allowed origins.
-                          items:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          type: array
-                        exposeHeaders:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        maxAge:
-                          type: string
-                      type: object
-                    delegate:
-                      properties:
-                        name:
-                          description: Name specifies the name of the delegate VirtualService.
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Configuration affecting label/content routing, sni routing,
+            etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+          properties:
+            exportTo:
+              description: A list of namespaces to which this virtual service is exported.
+              items:
+                format: string
+                type: string
+              type: array
+            gateways:
+              description: The names of gateways and sidecars that should apply these
+                routes.
+              items:
+                format: string
+                type: string
+              type: array
+            hosts:
+              description: The destination hosts to which traffic is being sent.
+              items:
+                format: string
+                type: string
+              type: array
+            http:
+              description: An ordered list of route rules for HTTP traffic.
+              items:
+                properties:
+                  corsPolicy:
+                    description: Cross-Origin Resource Sharing policy (CORS).
+                    properties:
+                      allowCredentials:
+                        nullable: true
+                        type: boolean
+                      allowHeaders:
+                        items:
                           format: string
                           type: string
-                        namespace:
-                          description: Namespace specifies the namespace where the
-                            delegate VirtualService resides.
+                        type: array
+                      allowMethods:
+                        description: List of HTTP methods allowed to access the resource.
+                        items:
                           format: string
                           type: string
-                      type: object
-                    fault:
-                      description: Fault injection policy to apply on HTTP traffic
-                        at the client side.
-                      properties:
-                        abort:
+                        type: array
+                      allowOrigin:
+                        description: The list of origins that are allowed to perform
+                          CORS requests.
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      allowOrigins:
+                        description: String patterns that match allowed origins.
+                        items:
                           oneOf:
                           - not:
                               anyOf:
                               - required:
-                                - httpStatus
+                                - exact
                               - required:
-                                - grpcStatus
+                                - prefix
                               - required:
-                                - http2Error
+                                - regex
                           - required:
-                            - httpStatus
+                            - exact
                           - required:
-                            - grpcStatus
+                            - prefix
                           - required:
-                            - http2Error
+                            - regex
                           properties:
-                            grpcStatus:
+                            exact:
                               format: string
                               type: string
-                            http2Error:
+                            prefix:
                               format: string
                               type: string
-                            httpStatus:
-                              description: HTTP status code to use to abort the Http
-                                request.
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests to be aborted with
-                                the error code provided.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
-                          type: object
-                        delay:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - fixedDelay
-                              - required:
-                                - exponentialDelay
-                          - required:
-                            - fixedDelay
-                          - required:
-                            - exponentialDelay
-                          properties:
-                            exponentialDelay:
+                            regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              format: string
                               type: string
-                            fixedDelay:
-                              description: Add a fixed delay before forwarding the
-                                request.
-                              type: string
-                            percent:
-                              description: Percentage of requests on which the delay
-                                will be injected (0-100).
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests on which the delay
-                                will be injected.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
                           type: object
-                      type: object
-                    headers:
-                      properties:
-                        request:
-                          properties:
-                            add:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                          type: object
-                        response:
-                          properties:
-                            add:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                          type: object
-                      type: object
-                    match:
-                      items:
+                        type: array
+                      exposeHeaders:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      maxAge:
+                        type: string
+                    type: object
+                  delegate:
+                    properties:
+                      name:
+                        description: Name specifies the name of the delegate VirtualService.
+                        format: string
+                        type: string
+                      namespace:
+                        description: Namespace specifies the namespace where the delegate
+                          VirtualService resides.
+                        format: string
+                        type: string
+                    type: object
+                  fault:
+                    description: Fault injection policy to apply on HTTP traffic at
+                      the client side.
+                    properties:
+                      abort:
+                        oneOf:
+                        - not:
+                            anyOf:
+                            - required:
+                              - httpStatus
+                            - required:
+                              - grpcStatus
+                            - required:
+                              - http2Error
+                        - required:
+                          - httpStatus
+                        - required:
+                          - grpcStatus
+                        - required:
+                          - http2Error
                         properties:
-                          authority:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
+                          grpcStatus:
+                            format: string
+                            type: string
+                          http2Error:
+                            format: string
+                            type: string
+                          httpStatus:
+                            description: HTTP status code to use to abort the Http
+                              request.
+                            format: int32
+                            type: integer
+                          percentage:
+                            description: Percentage of requests to be aborted with
+                              the error code provided.
                             properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
+                              value:
+                                format: double
+                                type: number
                             type: object
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
+                        type: object
+                      delay:
+                        oneOf:
+                        - not:
+                            anyOf:
+                            - required:
+                              - fixedDelay
+                            - required:
+                              - exponentialDelay
+                        - required:
+                          - fixedDelay
+                        - required:
+                          - exponentialDelay
+                        properties:
+                          exponentialDelay:
+                            type: string
+                          fixedDelay:
+                            description: Add a fixed delay before forwarding the request.
+                            type: string
+                          percent:
+                            description: Percentage of requests on which the delay
+                              will be injected (0-100).
+                            format: int32
+                            type: integer
+                          percentage:
+                            description: Percentage of requests on which the delay
+                              will be injected.
+                            properties:
+                              value:
+                                format: double
+                                type: number
+                            type: object
+                        type: object
+                    type: object
+                  headers:
+                    properties:
+                      request:
+                        properties:
+                          add:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          remove:
                             items:
                               format: string
                               type: string
                             type: array
-                          headers:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            type: object
-                          ignoreUriCase:
-                            description: Flag to specify whether the URI matching
-                              should be case-insensitive.
-                            type: boolean
-                          method:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          name:
-                            description: The name assigned to a match.
-                            format: string
-                            type: string
-                          port:
-                            description: Specifies the ports on the host that is being
-                              addressed.
-                            type: integer
-                          queryParams:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            description: Query parameters for matching.
-                            type: object
-                          scheme:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          sourceLabels:
+                          set:
                             additionalProperties:
                               format: string
                               type: string
                             type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
+                        type: object
+                      response:
+                        properties:
+                          add:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          remove:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          set:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                        type: object
+                    type: object
+                  match:
+                    items:
+                      properties:
+                        authority:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                          - required:
+                            - exact
+                          - required:
+                            - prefix
+                          - required:
+                            - regex
+                          properties:
+                            exact:
+                              format: string
+                              type: string
+                            prefix:
+                              format: string
+                              type: string
+                            regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              format: string
+                              type: string
+                          type: object
+                        gateways:
+                          description: Names of gateways where the rule should be
+                            applied.
+                          items:
                             format: string
                             type: string
-                          uri:
+                          type: array
+                        headers:
+                          additionalProperties:
                             oneOf:
                             - not:
                                 anyOf:
@@ -2372,1142 +2229,492 @@ spec:
                                 format: string
                                 type: string
                             type: object
-                          withoutHeaders:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
+                          type: object
+                        ignoreUriCase:
+                          description: Flag to specify whether the URI matching should
+                            be case-insensitive.
+                          type: boolean
+                        method:
+                          oneOf:
+                          - not:
+                              anyOf:
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            description: withoutHeader has the same syntax with the
-                              header, but has opposite meaning.
-                            type: object
-                        type: object
-                      type: array
-                    mirror:
-                      properties:
-                        host:
-                          description: The name of a service from the service registry.
+                          - required:
+                            - exact
+                          - required:
+                            - prefix
+                          - required:
+                            - regex
+                          properties:
+                            exact:
+                              format: string
+                              type: string
+                            prefix:
+                              format: string
+                              type: string
+                            regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              format: string
+                              type: string
+                          type: object
+                        name:
+                          description: The name assigned to a match.
                           format: string
                           type: string
                         port:
-                          description: Specifies the port on the host that is being
+                          description: Specifies the ports on the host that is being
                             addressed.
-                          properties:
-                            number:
-                              type: integer
-                          type: object
-                        subset:
-                          description: The name of a subset within the service.
-                          format: string
-                          type: string
-                      type: object
-                    mirror_percent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercentage:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      properties:
-                        value:
-                          format: double
-                          type: number
-                      type: object
-                    name:
-                      description: The name assigned to the route for debugging purposes.
-                      format: string
-                      type: string
-                    redirect:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
-                      properties:
-                        authority:
-                          format: string
-                          type: string
-                        redirectCode:
                           type: integer
-                        uri:
+                        queryParams:
+                          additionalProperties:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          description: Query parameters for matching.
+                          type: object
+                        scheme:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                          - required:
+                            - exact
+                          - required:
+                            - prefix
+                          - required:
+                            - regex
+                          properties:
+                            exact:
+                              format: string
+                              type: string
+                            prefix:
+                              format: string
+                              type: string
+                            regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              format: string
+                              type: string
+                          type: object
+                        sourceLabels:
+                          additionalProperties:
+                            format: string
+                            type: string
+                          type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
                           format: string
                           type: string
+                        uri:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                          - required:
+                            - exact
+                          - required:
+                            - prefix
+                          - required:
+                            - regex
+                          properties:
+                            exact:
+                              format: string
+                              type: string
+                            prefix:
+                              format: string
+                              type: string
+                            regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              format: string
+                              type: string
+                          type: object
+                        withoutHeaders:
+                          additionalProperties:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          description: withoutHeader has the same syntax with the
+                            header, but has opposite meaning.
+                          type: object
                       type: object
-                    retries:
-                      description: Retry policy for HTTP requests.
+                    type: array
+                  mirror:
+                    properties:
+                      host:
+                        description: The name of a service from the service registry.
+                        format: string
+                        type: string
+                      port:
+                        description: Specifies the port on the host that is being
+                          addressed.
+                        properties:
+                          number:
+                            type: integer
+                        type: object
+                      subset:
+                        description: The name of a subset within the service.
+                        format: string
+                        type: string
+                    type: object
+                  mirror_percent:
+                    description: Percentage of the traffic to be mirrored by the `mirror`
+                      field.
+                    nullable: true
+                    type: integer
+                  mirrorPercent:
+                    description: Percentage of the traffic to be mirrored by the `mirror`
+                      field.
+                    nullable: true
+                    type: integer
+                  mirrorPercentage:
+                    description: Percentage of the traffic to be mirrored by the `mirror`
+                      field.
+                    properties:
+                      value:
+                        format: double
+                        type: number
+                    type: object
+                  name:
+                    description: The name assigned to the route for debugging purposes.
+                    format: string
+                    type: string
+                  redirect:
+                    description: A HTTP rule can either redirect or forward (default)
+                      traffic.
+                    properties:
+                      authority:
+                        format: string
+                        type: string
+                      redirectCode:
+                        type: integer
+                      uri:
+                        format: string
+                        type: string
+                    type: object
+                  retries:
+                    description: Retry policy for HTTP requests.
+                    properties:
+                      attempts:
+                        description: Number of retries to be allowed for a given request.
+                        format: int32
+                        type: integer
+                      perTryTimeout:
+                        description: Timeout per retry attempt for a given request.
+                        type: string
+                      retryOn:
+                        description: Specifies the conditions under which retry takes
+                          place.
+                        format: string
+                        type: string
+                      retryRemoteLocalities:
+                        description: Flag to specify whether the retries should retry
+                          to other localities.
+                        nullable: true
+                        type: boolean
+                    type: object
+                  rewrite:
+                    description: Rewrite HTTP URIs and Authority headers.
+                    properties:
+                      authority:
+                        description: rewrite the Authority/Host header with this value.
+                        format: string
+                        type: string
+                      uri:
+                        format: string
+                        type: string
+                    type: object
+                  route:
+                    description: A HTTP rule can either redirect or forward (default)
+                      traffic.
+                    items:
                       properties:
-                        attempts:
-                          description: Number of retries to be allowed for a given
-                            request.
+                        destination:
+                          properties:
+                            host:
+                              description: The name of a service from the service
+                                registry.
+                              format: string
+                              type: string
+                            port:
+                              description: Specifies the port on the host that is
+                                being addressed.
+                              properties:
+                                number:
+                                  type: integer
+                              type: object
+                            subset:
+                              description: The name of a subset within the service.
+                              format: string
+                              type: string
+                          type: object
+                        headers:
+                          properties:
+                            request:
+                              properties:
+                                add:
+                                  additionalProperties:
+                                    format: string
+                                    type: string
+                                  type: object
+                                remove:
+                                  items:
+                                    format: string
+                                    type: string
+                                  type: array
+                                set:
+                                  additionalProperties:
+                                    format: string
+                                    type: string
+                                  type: object
+                              type: object
+                            response:
+                              properties:
+                                add:
+                                  additionalProperties:
+                                    format: string
+                                    type: string
+                                  type: object
+                                remove:
+                                  items:
+                                    format: string
+                                    type: string
+                                  type: array
+                                set:
+                                  additionalProperties:
+                                    format: string
+                                    type: string
+                                  type: object
+                              type: object
+                          type: object
+                        weight:
                           format: int32
                           type: integer
-                        perTryTimeout:
-                          description: Timeout per retry attempt for a given request.
-                          type: string
-                        retryOn:
-                          description: Specifies the conditions under which retry
-                            takes place.
-                          format: string
-                          type: string
-                        retryRemoteLocalities:
-                          description: Flag to specify whether the retries should
-                            retry to other localities.
-                          nullable: true
-                          type: boolean
                       type: object
-                    rewrite:
-                      description: Rewrite HTTP URIs and Authority headers.
+                    type: array
+                  timeout:
+                    description: Timeout for HTTP requests, default is disabled.
+                    type: string
+                type: object
+              type: array
+            tcp:
+              description: An ordered list of route rules for opaque TCP traffic.
+              items:
+                properties:
+                  match:
+                    items:
                       properties:
-                        authority:
-                          description: rewrite the Authority/Host header with this
-                            value.
+                        destinationSubnets:
+                          description: IPv4 or IPv6 ip addresses of destination with
+                            optional subnet.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        gateways:
+                          description: Names of gateways where the rule should be
+                            applied.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        port:
+                          description: Specifies the port on the host that is being
+                            addressed.
+                          type: integer
+                        sourceLabels:
+                          additionalProperties:
+                            format: string
+                            type: string
+                          type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
                           format: string
                           type: string
-                        uri:
+                        sourceSubnet:
+                          description: IPv4 or IPv6 ip address of source with optional
+                            subnet.
                           format: string
                           type: string
                       type: object
-                    route:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          headers:
-                            properties:
-                              request:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      format: string
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                type: object
-                              response:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      format: string
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                type: object
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                    timeout:
-                      description: Timeout for HTTP requests, default is disabled.
-                      type: string
-                  type: object
-                type: array
-              tcp:
-                description: An ordered list of route rules for opaque TCP traffic.
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination
-                              with optional subnet.
-                            items:
+                    type: array
+                  route:
+                    description: The destination to which the connection should be
+                      forwarded to.
+                    items:
+                      properties:
+                        destination:
+                          properties:
+                            host:
+                              description: The name of a service from the service
+                                registry.
                               format: string
                               type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
-                            items:
+                            port:
+                              description: Specifies the port on the host that is
+                                being addressed.
+                              properties:
+                                number:
+                                  type: integer
+                              type: object
+                            subset:
+                              description: The name of a subset within the service.
                               format: string
                               type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being
-                              addressed.
-                            type: integer
-                          sourceLabels:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
+                          type: object
+                        weight:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: array
+                type: object
+              type: array
+            tls:
+              items:
+                properties:
+                  match:
+                    items:
+                      properties:
+                        destinationSubnets:
+                          description: IPv4 or IPv6 ip addresses of destination with
+                            optional subnet.
+                          items:
                             format: string
                             type: string
-                          sourceSubnet:
-                            description: IPv4 or IPv6 ip address of source with optional
-                              subnet.
+                          type: array
+                        gateways:
+                          description: Names of gateways where the rule should be
+                            applied.
+                          items:
                             format: string
                             type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should
-                        be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-              tls:
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination
-                              with optional subnet.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being
-                              addressed.
-                            type: integer
-                          sniHosts:
-                            description: SNI (server name indicator) to match on.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          sourceLabels:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
+                          type: array
+                        port:
+                          description: Specifies the port on the host that is being
+                            addressed.
+                          type: integer
+                        sniHosts:
+                          description: SNI (server name indicator) to match on.
+                          items:
                             format: string
                             type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should
-                        be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+                          type: array
+                        sourceLabels:
+                          additionalProperties:
+                            format: string
+                            type: string
+                          type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
+                          format: string
+                          type: string
+                      type: object
+                    type: array
+                  route:
+                    description: The destination to which the connection should be
+                      forwarded to.
+                    items:
+                      properties:
+                        destination:
+                          properties:
+                            host:
+                              description: The name of a service from the service
+                                registry.
+                              format: string
+                              type: string
+                            port:
+                              description: Specifies the port on the host that is
+                                being addressed.
+                              properties:
+                                number:
+                                  type: integer
+                              type: object
+                            subset:
+                              description: The name of a subset within the service.
+                              format: string
+                              type: string
+                          type: object
+                        weight:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: array
+                type: object
+              type: array
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-  - additionalPrinterColumns:
-    - JSONPath: .spec.gateways
-      description: The names of gateways and sidecars that should apply these routes
-      name: Gateways
-      type: string
-    - JSONPath: .spec.hosts
-      description: The destination hosts to which traffic is being sent
-      name: Hosts
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: 'CreationTimestamp is a timestamp representing the server time
-        when this object was created. It is not guaranteed to be set in happens-before
-        order across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting label/content routing, sni routing,
-              etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this virtual service is
-                  exported.
-                items:
-                  format: string
-                  type: string
-                type: array
-              gateways:
-                description: The names of gateways and sidecars that should apply
-                  these routes.
-                items:
-                  format: string
-                  type: string
-                type: array
-              hosts:
-                description: The destination hosts to which traffic is being sent.
-                items:
-                  format: string
-                  type: string
-                type: array
-              http:
-                description: An ordered list of route rules for HTTP traffic.
-                items:
-                  properties:
-                    corsPolicy:
-                      description: Cross-Origin Resource Sharing policy (CORS).
-                      properties:
-                        allowCredentials:
-                          nullable: true
-                          type: boolean
-                        allowHeaders:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowMethods:
-                          description: List of HTTP methods allowed to access the
-                            resource.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowOrigin:
-                          description: The list of origins that are allowed to perform
-                            CORS requests.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowOrigins:
-                          description: String patterns that match allowed origins.
-                          items:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          type: array
-                        exposeHeaders:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        maxAge:
-                          type: string
-                      type: object
-                    delegate:
-                      properties:
-                        name:
-                          description: Name specifies the name of the delegate VirtualService.
-                          format: string
-                          type: string
-                        namespace:
-                          description: Namespace specifies the namespace where the
-                            delegate VirtualService resides.
-                          format: string
-                          type: string
-                      type: object
-                    fault:
-                      description: Fault injection policy to apply on HTTP traffic
-                        at the client side.
-                      properties:
-                        abort:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - httpStatus
-                              - required:
-                                - grpcStatus
-                              - required:
-                                - http2Error
-                          - required:
-                            - httpStatus
-                          - required:
-                            - grpcStatus
-                          - required:
-                            - http2Error
-                          properties:
-                            grpcStatus:
-                              format: string
-                              type: string
-                            http2Error:
-                              format: string
-                              type: string
-                            httpStatus:
-                              description: HTTP status code to use to abort the Http
-                                request.
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests to be aborted with
-                                the error code provided.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
-                          type: object
-                        delay:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - fixedDelay
-                              - required:
-                                - exponentialDelay
-                          - required:
-                            - fixedDelay
-                          - required:
-                            - exponentialDelay
-                          properties:
-                            exponentialDelay:
-                              type: string
-                            fixedDelay:
-                              description: Add a fixed delay before forwarding the
-                                request.
-                              type: string
-                            percent:
-                              description: Percentage of requests on which the delay
-                                will be injected (0-100).
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests on which the delay
-                                will be injected.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
-                          type: object
-                      type: object
-                    headers:
-                      properties:
-                        request:
-                          properties:
-                            add:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                          type: object
-                        response:
-                          properties:
-                            add:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                          type: object
-                      type: object
-                    match:
-                      items:
-                        properties:
-                          authority:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          headers:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            type: object
-                          ignoreUriCase:
-                            description: Flag to specify whether the URI matching
-                              should be case-insensitive.
-                            type: boolean
-                          method:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          name:
-                            description: The name assigned to a match.
-                            format: string
-                            type: string
-                          port:
-                            description: Specifies the ports on the host that is being
-                              addressed.
-                            type: integer
-                          queryParams:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            description: Query parameters for matching.
-                            type: object
-                          scheme:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          sourceLabels:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
-                            format: string
-                            type: string
-                          uri:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          withoutHeaders:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            description: withoutHeader has the same syntax with the
-                              header, but has opposite meaning.
-                            type: object
-                        type: object
-                      type: array
-                    mirror:
-                      properties:
-                        host:
-                          description: The name of a service from the service registry.
-                          format: string
-                          type: string
-                        port:
-                          description: Specifies the port on the host that is being
-                            addressed.
-                          properties:
-                            number:
-                              type: integer
-                          type: object
-                        subset:
-                          description: The name of a subset within the service.
-                          format: string
-                          type: string
-                      type: object
-                    mirror_percent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercent:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercentage:
-                      description: Percentage of the traffic to be mirrored by the
-                        `mirror` field.
-                      properties:
-                        value:
-                          format: double
-                          type: number
-                      type: object
-                    name:
-                      description: The name assigned to the route for debugging purposes.
-                      format: string
-                      type: string
-                    redirect:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
-                      properties:
-                        authority:
-                          format: string
-                          type: string
-                        redirectCode:
-                          type: integer
-                        uri:
-                          format: string
-                          type: string
-                      type: object
-                    retries:
-                      description: Retry policy for HTTP requests.
-                      properties:
-                        attempts:
-                          description: Number of retries to be attempted for a given
-                            request.
-                          format: int32
-                          type: integer
-                        perTryTimeout:
-                          description: Timeout per retry attempt for a given request.
-                          type: string
-                        retryOn:
-                          description: Specifies the conditions under which retry
-                            takes place.
-                          format: string
-                          type: string
-                        retryRemoteLocalities:
-                          description: Flag to specify whether the retries should
-                            retry to other localities.
-                          nullable: true
-                          type: boolean
-                      type: object
-                    rewrite:
-                      description: Rewrite HTTP URIs and Authority headers.
-                      properties:
-                        authority:
-                          description: rewrite the Authority/Host header with this
-                            value.
-                          format: string
-                          type: string
-                        uri:
-                          format: string
-                          type: string
-                      type: object
-                    route:
-                      description: A HTTP rule can either redirect or forward (default)
-                        traffic.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          headers:
-                            properties:
-                              request:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      format: string
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                type: object
-                              response:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      format: string
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                type: object
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                    timeout:
-                      description: Timeout for HTTP requests, default is disabled.
-                      type: string
-                  type: object
-                type: array
-              tcp:
-                description: An ordered list of route rules for opaque TCP traffic.
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination
-                              with optional subnet.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being
-                              addressed.
-                            type: integer
-                          sourceLabels:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
-                            format: string
-                            type: string
-                          sourceSubnet:
-                            description: IPv4 or IPv6 ip address of source with optional
-                              subnet.
-                            format: string
-                            type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should
-                        be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-              tls:
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination
-                              with optional subnet.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be
-                              applied.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being
-                              addressed.
-                            type: integer
-                          sniHosts:
-                            description: SNI (server name indicator) to match on.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          sourceLabels:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability
-                              of a rule to workloads in that namespace.
-                            format: string
-                            type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should
-                        be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service
-                                  registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is
-                                  being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+  - name: v1beta1
     served: true
     storage: false
 

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -2458,7 +2458,8 @@ spec:
                     description: Retry policy for HTTP requests.
                     properties:
                       attempts:
-                        description: Number of retries for a given request.
+                        description: Number of retries for a given request, default
+                          is 2.
                         format: int32
                         type: integer
                       perTryTimeout:

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -1913,23 +1913,6 @@ metadata:
     release: istio
   name: virtualservices.networking.istio.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.gateways
-    description: The names of gateways and sidecars that should apply these routes
-    name: Gateways
-    type: string
-  - JSONPath: .spec.hosts
-    description: The destination hosts to which traffic is being sent
-    name: Hosts
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
   group: networking.istio.io
   names:
     categories:
@@ -1944,264 +1927,84 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting label/content routing, sni routing,
-            etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
-          properties:
-            exportTo:
-              description: A list of namespaces to which this virtual service is exported.
-              items:
-                format: string
-                type: string
-              type: array
-            gateways:
-              description: The names of gateways and sidecars that should apply these
-                routes.
-              items:
-                format: string
-                type: string
-              type: array
-            hosts:
-              description: The destination hosts to which traffic is being sent.
-              items:
-                format: string
-                type: string
-              type: array
-            http:
-              description: An ordered list of route rules for HTTP traffic.
-              items:
-                properties:
-                  corsPolicy:
-                    description: Cross-Origin Resource Sharing policy (CORS).
-                    properties:
-                      allowCredentials:
-                        nullable: true
-                        type: boolean
-                      allowHeaders:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowMethods:
-                        description: List of HTTP methods allowed to access the resource.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowOrigin:
-                        description: The list of origins that are allowed to perform
-                          CORS requests.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowOrigins:
-                        description: String patterns that match allowed origins.
-                        items:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        type: array
-                      exposeHeaders:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      maxAge:
-                        type: string
-                    type: object
-                  delegate:
-                    properties:
-                      name:
-                        description: Name specifies the name of the delegate VirtualService.
-                        format: string
-                        type: string
-                      namespace:
-                        description: Namespace specifies the namespace where the delegate
-                          VirtualService resides.
-                        format: string
-                        type: string
-                    type: object
-                  fault:
-                    description: Fault injection policy to apply on HTTP traffic at
-                      the client side.
-                    properties:
-                      abort:
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - httpStatus
-                            - required:
-                              - grpcStatus
-                            - required:
-                              - http2Error
-                        - required:
-                          - httpStatus
-                        - required:
-                          - grpcStatus
-                        - required:
-                          - http2Error
-                        properties:
-                          grpcStatus:
-                            format: string
-                            type: string
-                          http2Error:
-                            format: string
-                            type: string
-                          httpStatus:
-                            description: HTTP status code to use to abort the Http
-                              request.
-                            format: int32
-                            type: integer
-                          percentage:
-                            description: Percentage of requests to be aborted with
-                              the error code provided.
-                            properties:
-                              value:
-                                format: double
-                                type: number
-                            type: object
-                        type: object
-                      delay:
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - fixedDelay
-                            - required:
-                              - exponentialDelay
-                        - required:
-                          - fixedDelay
-                        - required:
-                          - exponentialDelay
-                        properties:
-                          exponentialDelay:
-                            type: string
-                          fixedDelay:
-                            description: Add a fixed delay before forwarding the request.
-                            type: string
-                          percent:
-                            description: Percentage of requests on which the delay
-                              will be injected (0-100).
-                            format: int32
-                            type: integer
-                          percentage:
-                            description: Percentage of requests on which the delay
-                              will be injected.
-                            properties:
-                              value:
-                                format: double
-                                type: number
-                            type: object
-                        type: object
-                    type: object
-                  headers:
-                    properties:
-                      request:
-                        properties:
-                          add:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          remove:
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          set:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                        type: object
-                      response:
-                        properties:
-                          add:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          remove:
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          set:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                        type: object
-                    type: object
-                  match:
-                    items:
+  versions:
+  - additionalPrinterColumns:
+    - JSONPath: .spec.gateways
+      description: The names of gateways and sidecars that should apply these routes
+      name: Gateways
+      type: string
+    - JSONPath: .spec.hosts
+      description: The destination hosts to which traffic is being sent
+      name: Hosts
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting label/content routing, sni routing,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this virtual service is
+                  exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              gateways:
+                description: The names of gateways and sidecars that should apply
+                  these routes.
+                items:
+                  format: string
+                  type: string
+                type: array
+              hosts:
+                description: The destination hosts to which traffic is being sent.
+                items:
+                  format: string
+                  type: string
+                type: array
+              http:
+                description: An ordered list of route rules for HTTP traffic.
+                items:
+                  properties:
+                    corsPolicy:
+                      description: Cross-Origin Resource Sharing policy (CORS).
                       properties:
-                        authority:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        gateways:
-                          description: Names of gateways where the rule should be
-                            applied.
+                        allowCredentials:
+                          nullable: true
+                          type: boolean
+                        allowHeaders:
                           items:
                             format: string
                             type: string
                           type: array
-                        headers:
-                          additionalProperties:
+                        allowMethods:
+                          description: List of HTTP methods allowed to access the
+                            resource.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigin:
+                          description: The list of origins that are allowed to perform
+                            CORS requests.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigins:
+                          description: String patterns that match allowed origins.
+                          items:
                             oneOf:
                             - not:
                                 anyOf:
@@ -2229,146 +2032,770 @@ spec:
                                 format: string
                                 type: string
                             type: object
-                          type: object
-                        ignoreUriCase:
-                          description: Flag to specify whether the URI matching should
-                            be case-insensitive.
-                          type: boolean
-                        method:
+                          type: array
+                        exposeHeaders:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        maxAge:
+                          type: string
+                      type: object
+                    delegate:
+                      properties:
+                        name:
+                          description: Name specifies the name of the delegate VirtualService.
+                          format: string
+                          type: string
+                        namespace:
+                          description: Namespace specifies the namespace where the
+                            delegate VirtualService resides.
+                          format: string
+                          type: string
+                      type: object
+                    fault:
+                      description: Fault injection policy to apply on HTTP traffic
+                        at the client side.
+                      properties:
+                        abort:
                           oneOf:
                           - not:
                               anyOf:
+                              - required:
+                                - httpStatus
+                              - required:
+                                - grpcStatus
+                              - required:
+                                - http2Error
+                          - required:
+                            - httpStatus
+                          - required:
+                            - grpcStatus
+                          - required:
+                            - http2Error
+                          properties:
+                            grpcStatus:
+                              format: string
+                              type: string
+                            http2Error:
+                              format: string
+                              type: string
+                            httpStatus:
+                              description: HTTP status code to use to abort the Http
+                                request.
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests to be aborted with
+                                the error code provided.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        delay:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - fixedDelay
+                              - required:
+                                - exponentialDelay
+                          - required:
+                            - fixedDelay
+                          - required:
+                            - exponentialDelay
+                          properties:
+                            exponentialDelay:
+                              type: string
+                            fixedDelay:
+                              description: Add a fixed delay before forwarding the
+                                request.
+                              type: string
+                            percent:
+                              description: Percentage of requests on which the delay
+                                will be injected (0-100).
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests on which the delay
+                                will be injected.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                      type: object
+                    headers:
+                      properties:
+                        request:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                        response:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                      type: object
+                    match:
+                      items:
+                        properties:
+                          authority:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          headers:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            type: object
+                          ignoreUriCase:
+                            description: Flag to specify whether the URI matching
+                              should be case-insensitive.
+                            type: boolean
+                          method:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          name:
+                            description: The name assigned to a match.
+                            format: string
+                            type: string
+                          port:
+                            description: Specifies the ports on the host that is being
+                              addressed.
+                            type: integer
+                          queryParams:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: Query parameters for matching.
+                            type: object
+                          scheme:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          sourceLabels:
+                            additionalProperties:
                               format: string
                               type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        name:
-                          description: The name assigned to a match.
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          uri:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          withoutHeaders:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: withoutHeader has the same syntax with the
+                              header, but has opposite meaning.
+                            type: object
+                        type: object
+                      type: array
+                    mirror:
+                      properties:
+                        host:
+                          description: The name of a service from the service registry.
                           format: string
                           type: string
                         port:
-                          description: Specifies the ports on the host that is being
+                          description: Specifies the port on the host that is being
                             addressed.
-                          type: integer
-                        queryParams:
-                          additionalProperties:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          description: Query parameters for matching.
-                          type: object
-                        scheme:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
                           properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
+                            number:
+                              type: integer
                           type: object
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability
-                            of a rule to workloads in that namespace.
+                        subset:
+                          description: The name of a subset within the service.
+                          format: string
+                          type: string
+                      type: object
+                    mirror_percent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercentage:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      properties:
+                        value:
+                          format: double
+                          type: number
+                      type: object
+                    name:
+                      description: The name assigned to the route for debugging purposes.
+                      format: string
+                      type: string
+                    redirect:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      properties:
+                        authority:
+                          format: string
+                          type: string
+                        redirectCode:
+                          type: integer
+                        uri:
+                          format: string
+                          type: string
+                      type: object
+                    retries:
+                      description: Retry policy for HTTP requests.
+                      properties:
+                        attempts:
+                          description: Number of retries to be allowed for a given
+                            request.
+                          format: int32
+                          type: integer
+                        perTryTimeout:
+                          description: Timeout per retry attempt for a given request.
+                          type: string
+                        retryOn:
+                          description: Specifies the conditions under which retry
+                            takes place.
+                          format: string
+                          type: string
+                        retryRemoteLocalities:
+                          description: Flag to specify whether the retries should
+                            retry to other localities.
+                          nullable: true
+                          type: boolean
+                      type: object
+                    rewrite:
+                      description: Rewrite HTTP URIs and Authority headers.
+                      properties:
+                        authority:
+                          description: rewrite the Authority/Host header with this
+                            value.
                           format: string
                           type: string
                         uri:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
+                          format: string
+                          type: string
+                      type: object
+                    route:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          headers:
+                            properties:
+                              request:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                              response:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                    timeout:
+                      description: Timeout for HTTP requests, default is disabled.
+                      type: string
+                  type: object
+                type: array
+              tcp:
+                description: An ordered list of route rules for opaque TCP traffic.
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
                               format: string
                               type: string
-                            prefix:
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
                               format: string
                               type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sourceLabels:
+                            additionalProperties:
                               format: string
                               type: string
-                          type: object
-                        withoutHeaders:
-                          additionalProperties:
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          sourceSubnet:
+                            description: IPv4 or IPv6 ip address of source with optional
+                              subnet.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              tls:
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sniHosts:
+                            description: SNI (server name indicator) to match on.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+  - additionalPrinterColumns:
+    - JSONPath: .spec.gateways
+      description: The names of gateways and sidecars that should apply these routes
+      name: Gateways
+      type: string
+    - JSONPath: .spec.hosts
+      description: The destination hosts to which traffic is being sent
+      name: Hosts
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting label/content routing, sni routing,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this virtual service is
+                  exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              gateways:
+                description: The names of gateways and sidecars that should apply
+                  these routes.
+                items:
+                  format: string
+                  type: string
+                type: array
+              hosts:
+                description: The destination hosts to which traffic is being sent.
+                items:
+                  format: string
+                  type: string
+                type: array
+              http:
+                description: An ordered list of route rules for HTTP traffic.
+                items:
+                  properties:
+                    corsPolicy:
+                      description: Cross-Origin Resource Sharing policy (CORS).
+                      properties:
+                        allowCredentials:
+                          nullable: true
+                          type: boolean
+                        allowHeaders:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowMethods:
+                          description: List of HTTP methods allowed to access the
+                            resource.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigin:
+                          description: The list of origins that are allowed to perform
+                            CORS requests.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigins:
+                          description: String patterns that match allowed origins.
+                          items:
                             oneOf:
                             - not:
                                 anyOf:
@@ -2396,326 +2823,691 @@ spec:
                                 format: string
                                 type: string
                             type: object
-                          description: withoutHeader has the same syntax with the
-                            header, but has opposite meaning.
+                          type: array
+                        exposeHeaders:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        maxAge:
+                          type: string
+                      type: object
+                    delegate:
+                      properties:
+                        name:
+                          description: Name specifies the name of the delegate VirtualService.
+                          format: string
+                          type: string
+                        namespace:
+                          description: Namespace specifies the namespace where the
+                            delegate VirtualService resides.
+                          format: string
+                          type: string
+                      type: object
+                    fault:
+                      description: Fault injection policy to apply on HTTP traffic
+                        at the client side.
+                      properties:
+                        abort:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpStatus
+                              - required:
+                                - grpcStatus
+                              - required:
+                                - http2Error
+                          - required:
+                            - httpStatus
+                          - required:
+                            - grpcStatus
+                          - required:
+                            - http2Error
+                          properties:
+                            grpcStatus:
+                              format: string
+                              type: string
+                            http2Error:
+                              format: string
+                              type: string
+                            httpStatus:
+                              description: HTTP status code to use to abort the Http
+                                request.
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests to be aborted with
+                                the error code provided.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        delay:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - fixedDelay
+                              - required:
+                                - exponentialDelay
+                          - required:
+                            - fixedDelay
+                          - required:
+                            - exponentialDelay
+                          properties:
+                            exponentialDelay:
+                              type: string
+                            fixedDelay:
+                              description: Add a fixed delay before forwarding the
+                                request.
+                              type: string
+                            percent:
+                              description: Percentage of requests on which the delay
+                                will be injected (0-100).
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests on which the delay
+                                will be injected.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
                           type: object
                       type: object
-                    type: array
-                  mirror:
-                    properties:
-                      host:
-                        description: The name of a service from the service registry.
-                        format: string
-                        type: string
-                      port:
-                        description: Specifies the port on the host that is being
-                          addressed.
+                    headers:
+                      properties:
+                        request:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                        response:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                      type: object
+                    match:
+                      items:
                         properties:
-                          number:
+                          authority:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          headers:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            type: object
+                          ignoreUriCase:
+                            description: Flag to specify whether the URI matching
+                              should be case-insensitive.
+                            type: boolean
+                          method:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          name:
+                            description: The name assigned to a match.
+                            format: string
+                            type: string
+                          port:
+                            description: Specifies the ports on the host that is being
+                              addressed.
+                            type: integer
+                          queryParams:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: Query parameters for matching.
+                            type: object
+                          scheme:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          uri:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          withoutHeaders:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: withoutHeader has the same syntax with the
+                              header, but has opposite meaning.
+                            type: object
+                        type: object
+                      type: array
+                    mirror:
+                      properties:
+                        host:
+                          description: The name of a service from the service registry.
+                          format: string
+                          type: string
+                        port:
+                          description: Specifies the port on the host that is being
+                            addressed.
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        subset:
+                          description: The name of a subset within the service.
+                          format: string
+                          type: string
+                      type: object
+                    mirror_percent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercentage:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      properties:
+                        value:
+                          format: double
+                          type: number
+                      type: object
+                    name:
+                      description: The name assigned to the route for debugging purposes.
+                      format: string
+                      type: string
+                    redirect:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      properties:
+                        authority:
+                          format: string
+                          type: string
+                        redirectCode:
+                          type: integer
+                        uri:
+                          format: string
+                          type: string
+                      type: object
+                    retries:
+                      description: Retry policy for HTTP requests.
+                      properties:
+                        attempts:
+                          description: Number of retries to be attempted for a given
+                            request.
+                          format: int32
+                          type: integer
+                        perTryTimeout:
+                          description: Timeout per retry attempt for a given request.
+                          type: string
+                        retryOn:
+                          description: Specifies the conditions under which retry
+                            takes place.
+                          format: string
+                          type: string
+                        retryRemoteLocalities:
+                          description: Flag to specify whether the retries should
+                            retry to other localities.
+                          nullable: true
+                          type: boolean
+                      type: object
+                    rewrite:
+                      description: Rewrite HTTP URIs and Authority headers.
+                      properties:
+                        authority:
+                          description: rewrite the Authority/Host header with this
+                            value.
+                          format: string
+                          type: string
+                        uri:
+                          format: string
+                          type: string
+                      type: object
+                    route:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          headers:
+                            properties:
+                              request:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                              response:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                            type: object
+                          weight:
+                            format: int32
                             type: integer
                         type: object
-                      subset:
-                        description: The name of a subset within the service.
-                        format: string
-                        type: string
-                    type: object
-                  mirror_percent:
-                    description: Percentage of the traffic to be mirrored by the `mirror`
-                      field.
-                    nullable: true
-                    type: integer
-                  mirrorPercent:
-                    description: Percentage of the traffic to be mirrored by the `mirror`
-                      field.
-                    nullable: true
-                    type: integer
-                  mirrorPercentage:
-                    description: Percentage of the traffic to be mirrored by the `mirror`
-                      field.
-                    properties:
-                      value:
-                        format: double
-                        type: number
-                    type: object
-                  name:
-                    description: The name assigned to the route for debugging purposes.
-                    format: string
-                    type: string
-                  redirect:
-                    description: A HTTP rule can either redirect or forward (default)
-                      traffic.
-                    properties:
-                      authority:
-                        format: string
-                        type: string
-                      redirectCode:
-                        type: integer
-                      uri:
-                        format: string
-                        type: string
-                    type: object
-                  retries:
-                    description: Retry policy for HTTP requests.
-                    properties:
-                      attempts:
-                        description: Number of retries for a given request, default
-                          is 2.
-                        format: int32
-                        type: integer
-                      perTryTimeout:
-                        description: Timeout per retry attempt for a given request.
-                        type: string
-                      retryOn:
-                        description: Specifies the conditions under which retry takes
-                          place.
-                        format: string
-                        type: string
-                      retryRemoteLocalities:
-                        description: Flag to specify whether the retries should retry
-                          to other localities.
-                        nullable: true
-                        type: boolean
-                    type: object
-                  rewrite:
-                    description: Rewrite HTTP URIs and Authority headers.
-                    properties:
-                      authority:
-                        description: rewrite the Authority/Host header with this value.
-                        format: string
-                        type: string
-                      uri:
-                        format: string
-                        type: string
-                    type: object
-                  route:
-                    description: A HTTP rule can either redirect or forward (default)
-                      traffic.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service
-                                registry.
+                      type: array
+                    timeout:
+                      description: Timeout for HTTP requests, default is disabled.
+                      type: string
+                  type: object
+                type: array
+              tcp:
+                description: An ordered list of route rules for opaque TCP traffic.
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
                               format: string
                               type: string
-                            port:
-                              description: Specifies the port on the host that is
-                                being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
                               format: string
                               type: string
-                          type: object
-                        headers:
-                          properties:
-                            request:
-                              properties:
-                                add:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                                remove:
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                                set:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                              type: object
-                            response:
-                              properties:
-                                add:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                                remove:
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                                set:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                              type: object
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                  timeout:
-                    description: Timeout for HTTP requests, default is disabled.
-                    type: string
-                type: object
-              type: array
-            tcp:
-              description: An ordered list of route rules for opaque TCP traffic.
-              items:
-                properties:
-                  match:
-                    items:
-                      properties:
-                        destinationSubnets:
-                          description: IPv4 or IPv6 ip addresses of destination with
-                            optional subnet.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        gateways:
-                          description: Names of gateways where the rule should be
-                            applied.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        port:
-                          description: Specifies the port on the host that is being
-                            addressed.
-                          type: integer
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability
-                            of a rule to workloads in that namespace.
-                          format: string
-                          type: string
-                        sourceSubnet:
-                          description: IPv4 or IPv6 ip address of source with optional
-                            subnet.
-                          format: string
-                          type: string
-                      type: object
-                    type: array
-                  route:
-                    description: The destination to which the connection should be
-                      forwarded to.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service
-                                registry.
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sourceLabels:
+                            additionalProperties:
                               format: string
                               type: string
-                            port:
-                              description: Specifies the port on the host that is
-                                being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          sourceSubnet:
+                            description: IPv4 or IPv6 ip address of source with optional
+                              subnet.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              tls:
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
                               format: string
                               type: string
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
-            tls:
-              items:
-                properties:
-                  match:
-                    items:
-                      properties:
-                        destinationSubnets:
-                          description: IPv4 or IPv6 ip addresses of destination with
-                            optional subnet.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        gateways:
-                          description: Names of gateways where the rule should be
-                            applied.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        port:
-                          description: Specifies the port on the host that is being
-                            addressed.
-                          type: integer
-                        sniHosts:
-                          description: SNI (server name indicator) to match on.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability
-                            of a rule to workloads in that namespace.
-                          format: string
-                          type: string
-                      type: object
-                    type: array
-                  route:
-                    description: The destination to which the connection should be
-                      forwarded to.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service
-                                registry.
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
                               format: string
                               type: string
-                            port:
-                              description: Specifies the port on the host that is
-                                being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sniHosts:
+                            description: SNI (server name indicator) to match on.
+                            items:
                               format: string
                               type: string
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
-  - name: v1beta1
+                            type: array
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: false
 

--- a/networking/v1alpha3/virtual_service.gen.json
+++ b/networking/v1alpha3/virtual_service.gen.json
@@ -335,7 +335,7 @@
         "type": "object",
         "properties": {
           "attempts": {
-            "description": "Number of retries for a given request, default is 2. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) is configured, the actual number of retries attempted also depends on the specified request `timeout` value.",
+            "description": "Number of retries for a given request, default is 2. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) is configured, the actual number of retries attempted also depends on the specified request `timeout` and `per_try_timeout` values.",
             "type": "integer",
             "format": "int32"
           },

--- a/networking/v1alpha3/virtual_service.gen.json
+++ b/networking/v1alpha3/virtual_service.gen.json
@@ -335,12 +335,12 @@
         "type": "object",
         "properties": {
           "attempts": {
-            "description": "Number of retries for a given request, default is 2. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) is configured, the actual number of retries attempted also depends on the specified request `timeout` and `per_try_timeout` values.",
+            "description": "Number of retries to be allowed for a given request. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) or `per_try_timeout` is configured, the actual number of retries attempted also depends on the specified request `timeout` and `per_try_timeout` values.",
             "type": "integer",
             "format": "int32"
           },
           "perTryTimeout": {
-            "description": "Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE \u003e=1ms.",
+            "description": "Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE \u003e=1ms. Default is same value as request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute), which means no timeout.",
             "type": "string"
           },
           "retryOn": {

--- a/networking/v1alpha3/virtual_service.gen.json
+++ b/networking/v1alpha3/virtual_service.gen.json
@@ -335,7 +335,7 @@
         "type": "object",
         "properties": {
           "attempts": {
-            "description": "Number of retries for a given request. The interval between retries will be determined automatically (25ms+). Actual number of retries attempted depends on the request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute).",
+            "description": "Number of retries for a given request, default is 2. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) is configured, the actual number of retries attempted also depends on the specified request `timeout` value.",
             "type": "integer",
             "format": "int32"
           },

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -2582,7 +2582,7 @@ type HTTPRetry struct {
 	// between retries will be determined automatically (25ms+). When request
 	// `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
 	// is configured, the actual number of retries attempted also depends on
-	// the specified request `timeout` value.
+	// the specified request `timeout` and `per_try_timeout` values.
 	Attempts int32 `protobuf:"varint,1,opt,name=attempts,proto3" json:"attempts,omitempty"`
 	// Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.
 	PerTryTimeout *types.Duration `protobuf:"bytes,2,opt,name=per_try_timeout,json=perTryTimeout,proto3" json:"per_try_timeout,omitempty"`

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -2578,13 +2578,16 @@ func (*StringMatch) XXX_OneofWrappers() []interface{} {
 // {{</tabset>}}
 //
 type HTTPRetry struct {
-	// Number of retries for a given request, default is 2. The interval
+	// Number of retries to be allowed for a given request. The interval
 	// between retries will be determined automatically (25ms+). When request
 	// `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
-	// is configured, the actual number of retries attempted also depends on
+	// or `per_try_timeout` is configured, the actual number of retries attempted also depends on
 	// the specified request `timeout` and `per_try_timeout` values.
 	Attempts int32 `protobuf:"varint,1,opt,name=attempts,proto3" json:"attempts,omitempty"`
 	// Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.
+	// Default is same value as request
+	// `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute),
+	// which means no timeout.
 	PerTryTimeout *types.Duration `protobuf:"bytes,2,opt,name=per_try_timeout,json=perTryTimeout,proto3" json:"per_try_timeout,omitempty"`
 	// Specifies the conditions under which retry takes place.
 	// One or more policies can be specified using a ‘,’ delimited list.

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -2578,10 +2578,11 @@ func (*StringMatch) XXX_OneofWrappers() []interface{} {
 // {{</tabset>}}
 //
 type HTTPRetry struct {
-	// Number of retries for a given request. The interval
-	// between retries will be determined automatically (25ms+). Actual
-	// number of retries attempted depends on the request `timeout` of the
-	// [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute).
+	// Number of retries for a given request, default is 2. The interval
+	// between retries will be determined automatically (25ms+). When request
+	// `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
+	// is configured, the actual number of retries attempted also depends on
+	// the specified request `timeout` value.
 	Attempts int32 `protobuf:"varint,1,opt,name=attempts,proto3" json:"attempts,omitempty"`
 	// Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.
 	PerTryTimeout *types.Duration `protobuf:"bytes,2,opt,name=per_try_timeout,json=perTryTimeout,proto3" json:"per_try_timeout,omitempty"`

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -2257,10 +2257,11 @@ spec:
 <td><code>attempts</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Number of retries for a given request. The interval
-between retries will be determined automatically (25ms+). Actual
-number of retries attempted depends on the request <code>timeout</code> of the
-<a href="https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute">HTTP route</a>.</p>
+<p>Number of retries for a given request, default is 2. The interval
+between retries will be determined automatically (25ms+). When request
+<code>timeout</code> of the <a href="https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute">HTTP route</a>
+is configured, the actual number of retries attempted also depends on
+the specified request <code>timeout</code> value.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -2257,10 +2257,10 @@ spec:
 <td><code>attempts</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Number of retries for a given request, default is 2. The interval
+<p>Number of retries to be allowed for a given request. The interval
 between retries will be determined automatically (25ms+). When request
 <code>timeout</code> of the <a href="https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute">HTTP route</a>
-is configured, the actual number of retries attempted also depends on
+or <code>per_try_timeout</code> is configured, the actual number of retries attempted also depends on
 the specified request <code>timeout</code> and <code>per_try_timeout</code> values.</p>
 
 </td>
@@ -2272,7 +2272,10 @@ Yes
 <td><code>perTryTimeout</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
-<p>Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE &gt;=1ms.</p>
+<p>Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE &gt;=1ms.
+Default is same value as request
+<code>timeout</code> of the <a href="https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute">HTTP route</a>,
+which means no timeout.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -2261,7 +2261,7 @@ spec:
 between retries will be determined automatically (25ms+). When request
 <code>timeout</code> of the <a href="https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute">HTTP route</a>
 is configured, the actual number of retries attempted also depends on
-the specified request <code>timeout</code> value.</p>
+the specified request <code>timeout</code> and <code>per_try_timeout</code> values.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -1536,10 +1536,11 @@ message StringMatch {
 // {{</tabset>}}
 //
 message HTTPRetry {
-  // Number of retries for a given request. The interval
+  // Number of retries for a given request, default is 2. The interval
   // between retries will be determined automatically (25ms+). Actual
   // number of retries attempted depends on the request `timeout` of the
-  // [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute).
+  // [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
+  // which is disabled by default.
   int32 attempts = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -1540,7 +1540,7 @@ message HTTPRetry {
   // between retries will be determined automatically (25ms+). When request 
   // `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) 
   // is configured, the actual number of retries attempted also depends on
-  // the specified request `timeout` value.
+  // the specified request `timeout` and `per_try_timeout` values.
   int32 attempts = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -1537,10 +1537,10 @@ message StringMatch {
 //
 message HTTPRetry {
   // Number of retries for a given request, default is 2. The interval
-  // between retries will be determined automatically (25ms+). Actual
-  // number of retries attempted depends on the request `timeout` of the
-  // [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
-  // which is disabled by default.
+  // between retries will be determined automatically (25ms+). When request 
+  // `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) 
+  // is configured, the actual number of retries attempted also depends on
+  // the specified request `timeout` value.
   int32 attempts = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -1536,14 +1536,17 @@ message StringMatch {
 // {{</tabset>}}
 //
 message HTTPRetry {
-  // Number of retries for a given request, default is 2. The interval
+  // Number of retries to be allowed for a given request. The interval
   // between retries will be determined automatically (25ms+). When request 
   // `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) 
-  // is configured, the actual number of retries attempted also depends on
+  // or `per_try_timeout` is configured, the actual number of retries attempted also depends on
   // the specified request `timeout` and `per_try_timeout` values.
   int32 attempts = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.
+  // Default is same value as request 
+  // `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute), 
+  // which means no timeout.
   google.protobuf.Duration per_try_timeout = 2;
 
   // Specifies the conditions under which retry takes place.

--- a/networking/v1beta1/virtual_service.gen.json
+++ b/networking/v1beta1/virtual_service.gen.json
@@ -335,7 +335,7 @@
         "type": "object",
         "properties": {
           "attempts": {
-            "description": "Number of retries for a given request, default is 2. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) is configured, the actual number of retries attempted also depends on the specified request `timeout` value.",
+            "description": "Number of retries for a given request, default is 2. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) is configured, the actual number of retries attempted also depends on the specified request `timeout` and `per_try_timeout` values.",
             "type": "integer",
             "format": "int32"
           },

--- a/networking/v1beta1/virtual_service.gen.json
+++ b/networking/v1beta1/virtual_service.gen.json
@@ -335,7 +335,7 @@
         "type": "object",
         "properties": {
           "attempts": {
-            "description": "Number of retries to be attempted for a given request. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) or `per_try_timeout` is configured, the actual number of retries attempted also depends on the specified request `timeout` and `per_try_timeout` values.",
+            "description": "Number of retries to be allowed for a given request. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) or `per_try_timeout` is configured, the actual number of retries attempted also depends on the specified request `timeout` and `per_try_timeout` values.",
             "type": "integer",
             "format": "int32"
           },

--- a/networking/v1beta1/virtual_service.gen.json
+++ b/networking/v1beta1/virtual_service.gen.json
@@ -335,12 +335,12 @@
         "type": "object",
         "properties": {
           "attempts": {
-            "description": "Number of retries for a given request, default is 2. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) is configured, the actual number of retries attempted also depends on the specified request `timeout` and `per_try_timeout` values.",
+            "description": "Number of retries to be attempted for a given request. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) or `per_try_timeout` is configured, the actual number of retries attempted also depends on the specified request `timeout` and `per_try_timeout` values.",
             "type": "integer",
             "format": "int32"
           },
           "perTryTimeout": {
-            "description": "Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE \u003e=1ms.",
+            "description": "Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE \u003e=1ms. Default is same value as request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute), which means no timeout.",
             "type": "string"
           },
           "retryOn": {

--- a/networking/v1beta1/virtual_service.gen.json
+++ b/networking/v1beta1/virtual_service.gen.json
@@ -335,7 +335,7 @@
         "type": "object",
         "properties": {
           "attempts": {
-            "description": "Number of retries for a given request. The interval between retries will be determined automatically (25ms+). Actual number of retries attempted depends on the request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute).",
+            "description": "Number of retries for a given request, default is 2. The interval between retries will be determined automatically (25ms+). When request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) is configured, the actual number of retries attempted also depends on the specified request `timeout` value.",
             "type": "integer",
             "format": "int32"
           },

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -2577,13 +2577,16 @@ func (*StringMatch) XXX_OneofWrappers() []interface{} {
 // {{</tabset>}}
 //
 type HTTPRetry struct {
-	// Number of retries for a given request, default is 2. The interval
+	// Number of retries to be attempted for a given request. The interval
 	// between retries will be determined automatically (25ms+). When request
 	// `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
-	// is configured, the actual number of retries attempted also depends on
+	// or `per_try_timeout` is configured, the actual number of retries attempted also depends on
 	// the specified request `timeout` and `per_try_timeout` values.
 	Attempts int32 `protobuf:"varint,1,opt,name=attempts,proto3" json:"attempts,omitempty"`
 	// Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.
+	// Default is same value as request
+	// `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute),
+	// which means no timeout.
 	PerTryTimeout *types.Duration `protobuf:"bytes,2,opt,name=per_try_timeout,json=perTryTimeout,proto3" json:"per_try_timeout,omitempty"`
 	// Specifies the conditions under which retry takes place.
 	// One or more policies can be specified using a ‘,’ delimited list.

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -2581,7 +2581,7 @@ type HTTPRetry struct {
 	// between retries will be determined automatically (25ms+). When request
 	// `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
 	// is configured, the actual number of retries attempted also depends on
-	// the specified request `timeout` value.
+	// the specified request `timeout` and `per_try_timeout` values.
 	Attempts int32 `protobuf:"varint,1,opt,name=attempts,proto3" json:"attempts,omitempty"`
 	// Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.
 	PerTryTimeout *types.Duration `protobuf:"bytes,2,opt,name=per_try_timeout,json=perTryTimeout,proto3" json:"per_try_timeout,omitempty"`

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -2577,10 +2577,11 @@ func (*StringMatch) XXX_OneofWrappers() []interface{} {
 // {{</tabset>}}
 //
 type HTTPRetry struct {
-	// Number of retries for a given request. The interval
-	// between retries will be determined automatically (25ms+). Actual
-	// number of retries attempted depends on the request `timeout` of the
-	// [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute).
+	// Number of retries for a given request, default is 2. The interval
+	// between retries will be determined automatically (25ms+). When request
+	// `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
+	// is configured, the actual number of retries attempted also depends on
+	// the specified request `timeout` value.
 	Attempts int32 `protobuf:"varint,1,opt,name=attempts,proto3" json:"attempts,omitempty"`
 	// Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.
 	PerTryTimeout *types.Duration `protobuf:"bytes,2,opt,name=per_try_timeout,json=perTryTimeout,proto3" json:"per_try_timeout,omitempty"`

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -2577,7 +2577,7 @@ func (*StringMatch) XXX_OneofWrappers() []interface{} {
 // {{</tabset>}}
 //
 type HTTPRetry struct {
-	// Number of retries to be attempted for a given request. The interval
+	// Number of retries to be allowed for a given request. The interval
 	// between retries will be determined automatically (25ms+). When request
 	// `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
 	// or `per_try_timeout` is configured, the actual number of retries attempted also depends on

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -1537,7 +1537,7 @@ message HTTPRetry {
   // between retries will be determined automatically (25ms+). When request 
   // `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) 
   // is configured, the actual number of retries attempted also depends on
-  // the specified request `timeout` value.
+  // the specified request `timeout` and `per_try_timeout` values.
   int32 attempts = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -1533,10 +1533,11 @@ message StringMatch {
 // {{</tabset>}}
 //
 message HTTPRetry {
-  // Number of retries for a given request. The interval
+  // Number of retries for a given request, default is 2. The interval
   // between retries will be determined automatically (25ms+). Actual
   // number of retries attempted depends on the request `timeout` of the
-  // [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute).
+  // [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
+  // which is disabled by default.
   int32 attempts = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -1533,14 +1533,17 @@ message StringMatch {
 // {{</tabset>}}
 //
 message HTTPRetry {
-  // Number of retries for a given request, default is 2. The interval
+  // Number of retries to be attempted for a given request. The interval
   // between retries will be determined automatically (25ms+). When request 
   // `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) 
-  // is configured, the actual number of retries attempted also depends on
+  // or `per_try_timeout` is configured, the actual number of retries attempted also depends on
   // the specified request `timeout` and `per_try_timeout` values.
   int32 attempts = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.
+  // Default is same value as request 
+  // `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute), 
+  // which means no timeout.
   google.protobuf.Duration per_try_timeout = 2;
 
   // Specifies the conditions under which retry takes place.

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -1533,7 +1533,7 @@ message StringMatch {
 // {{</tabset>}}
 //
 message HTTPRetry {
-  // Number of retries to be attempted for a given request. The interval
+  // Number of retries to be allowed for a given request. The interval
   // between retries will be determined automatically (25ms+). When request 
   // `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) 
   // or `per_try_timeout` is configured, the actual number of retries attempted also depends on

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -1534,10 +1534,10 @@ message StringMatch {
 //
 message HTTPRetry {
   // Number of retries for a given request, default is 2. The interval
-  // between retries will be determined automatically (25ms+). Actual
-  // number of retries attempted depends on the request `timeout` of the
-  // [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
-  // which is disabled by default.
+  // between retries will be determined automatically (25ms+). When request 
+  // `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) 
+  // is configured, the actual number of retries attempted also depends on
+  // the specified request `timeout` value.
   int32 attempts = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.


### PR DESCRIPTION
our default attempts is 2.  We didn't say it earlier because it depends on the value of http timeout.  Now timeout is disabled by default, the default retry attempts should be clear to our users.