### PR TITLE
Fix typo in  request authn v1beta1

### DIFF
--- a/security/v1beta1/request_authentication.gen.json
+++ b/security/v1beta1/request_authentication.gen.json
@@ -76,7 +76,7 @@
         }
       },
       "istio.security.v1beta1.RequestAuthentication": {
-        "description": "RequestAuthentication defines what request authentication methods are supported by a workload. If will reject a request if the request contains invalid authentication information, based on the configured authentication rules. A request that does not contain any authentication credentials will be accepted but will not have any authenticated identity. To restrict access to authenticated requests only, this should be accompanied by an authorization rule. Examples: - Require JWT for all request for workloads that have label `app:httpbin`",
+        "description": "RequestAuthentication defines what request authentication methods are supported by a workload. It will reject a request if the request contains invalid authentication information, based on the configured authentication rules. A request that does not contain any authentication credentials will be accepted but will not have any authenticated identity. To restrict access to authenticated requests only, this should be accompanied by an authorization rule. Examples: - Require JWT for all request for workloads that have label `app:httpbin`",
         "type": "object",
         "properties": {
           "selector": {

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // RequestAuthentication defines what request authentication methods are supported by a workload.
-// If will reject a request if the request contains invalid authentication information, based on the
+// It will reject a request if the request contains invalid authentication information, based on the
 // configured authentication rules. A request that does not contain any authentication credentials
 // will be accepted but will not have any authenticated identity. To restrict access to authenticated
 // requests only, this should be accompanied by an authorization rule.

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -11,7 +11,7 @@ number_of_entries: 1
 <h2 id="RequestAuthentication">RequestAuthentication</h2>
 <section>
 <p>RequestAuthentication defines what request authentication methods are supported by a workload.
-If will reject a request if the request contains invalid authentication information, based on the
+It will reject a request if the request contains invalid authentication information, based on the
 configured authentication rules. A request that does not contain any authentication credentials
 will be accepted but will not have any authenticated identity. To restrict access to authenticated
 requests only, this should be accompanied by an authorization rule.

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -27,7 +27,7 @@ package istio.security.v1beta1;
 option go_package="istio.io/api/security/v1beta1";
 
 // RequestAuthentication defines what request authentication methods are supported by a workload.
-// If will reject a request if the request contains invalid authentication information, based on the
+// It will reject a request if the request contains invalid authentication information, based on the
 // configured authentication rules. A request that does not contain any authentication credentials
 // will be accepted but will not have any authenticated identity. To restrict access to authenticated
 // requests only, this should be accompanied by an authorization rule.


### PR DESCRIPTION
Fix typo in request authn v1beta1.
From
`If will reject a request if the request contains invalid authentication information`
To
`It will reject a request if the request contains invalid authentication information`