### PR TITLE
Idletimeout clarification

### DIFF
--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -470,7 +470,7 @@
             "format": "int32"
           },
           "idleTimeout": {
-            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. If not set, the default is 1 hour. When the idle timeout is reached the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
+            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. The default is disabled. When the idle timeout is set and the timeout value is reached, the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
             "type": "string"
           },
           "h2UpgradePolicy": {

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -470,7 +470,7 @@
             "format": "int32"
           },
           "idleTimeout": {
-            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. The default is disabled which means no timeout. When the idle timeout is set and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2 connection a drain sequence will occur prior to closing the connection. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
+            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. If not set, the default is 1 hour. When the idle timeout is reached, the connection will be closed. If the connection is an HTTP/2 connection a drain sequence will occur prior to closing the connection. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
             "type": "string"
           },
           "h2UpgradePolicy": {

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -470,7 +470,7 @@
             "format": "int32"
           },
           "idleTimeout": {
-            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. The default is disabled. When the idle timeout is set and the timeout value is reached, the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
+            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. The default is disabled which means no timeout. When the idle timeout is set and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2 connection a drain sequence will occur prior to closing the connection. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
             "type": "string"
           },
           "h2UpgradePolicy": {

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1382,8 +1382,9 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	MaxRetries int32 `protobuf:"varint,4,opt,name=max_retries,json=maxRetries,proto3" json:"max_retries,omitempty"`
 	// The idle timeout for upstream connection pool connections. The idle timeout
 	// is defined as the period in which there are no active requests.
-	// The default is disabled. When the idle timeout is set and the timeout value
-	// is reached, the connection will be closed.
+	// The default is disabled which means no timeout. When the idle timeout is set
+	// and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2
+	// connection a drain sequence will occur prior to closing the connection.
 	// Note that request based timeouts mean that HTTP/2 PINGs will not
 	// keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
 	IdleTimeout *types.Duration `protobuf:"bytes,5,opt,name=idle_timeout,json=idleTimeout,proto3" json:"idle_timeout,omitempty"`

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1380,9 +1380,12 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	// Maximum number of retries that can be outstanding to all hosts in a
 	// cluster at a given time. Defaults to 2^32-1.
 	MaxRetries int32 `protobuf:"varint,4,opt,name=max_retries,json=maxRetries,proto3" json:"max_retries,omitempty"`
-	// The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests.
-	// If not set, the default is 1 hour. When the idle timeout is reached the connection will be closed.
-	// Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
+	// The idle timeout for upstream connection pool connections. The idle timeout
+	// is defined as the period in which there are no active requests.
+	// The default is disabled. When the idle timeout is set and the timeout value
+	// is reached, the connection will be closed.
+	// Note that request based timeouts mean that HTTP/2 PINGs will not
+	// keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
 	IdleTimeout *types.Duration `protobuf:"bytes,5,opt,name=idle_timeout,json=idleTimeout,proto3" json:"idle_timeout,omitempty"`
 	// Specify if http1.1 connection should be upgraded to http2 for the associated destination.
 	H2UpgradePolicy ConnectionPoolSettings_HTTPSettings_H2UpgradePolicy `protobuf:"varint,6,opt,name=h2_upgrade_policy,json=h2UpgradePolicy,proto3,enum=istio.networking.v1alpha3.ConnectionPoolSettings_HTTPSettings_H2UpgradePolicy" json:"h2_upgrade_policy,omitempty"`

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1382,8 +1382,8 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	MaxRetries int32 `protobuf:"varint,4,opt,name=max_retries,json=maxRetries,proto3" json:"max_retries,omitempty"`
 	// The idle timeout for upstream connection pool connections. The idle timeout
 	// is defined as the period in which there are no active requests.
-	// The default is disabled which means no timeout. When the idle timeout is set
-	// and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2
+	// If not set, the default is 1 hour. When the idle timeout is reached,
+	// the connection will be closed. If the connection is an HTTP/2
 	// connection a drain sequence will occur prior to closing the connection.
 	// Note that request based timeouts mean that HTTP/2 PINGs will not
 	// keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1494,8 +1494,8 @@ No
 <td>
 <p>The idle timeout for upstream connection pool connections. The idle timeout
 is defined as the period in which there are no active requests.
-The default is disabled which means no timeout. When the idle timeout is set
-and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2
+If not set, the default is 1 hour. When the idle timeout is reached,
+the connection will be closed. If the connection is an HTTP/2
 connection a drain sequence will occur prior to closing the connection.
 Note that request based timeouts mean that HTTP/2 PINGs will not
 keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.</p>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1494,8 +1494,9 @@ No
 <td>
 <p>The idle timeout for upstream connection pool connections. The idle timeout
 is defined as the period in which there are no active requests.
-The default is disabled. When the idle timeout is set and the timeout value
-is reached, the connection will be closed.
+The default is disabled which means no timeout. When the idle timeout is set
+and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2
+connection a drain sequence will occur prior to closing the connection.
 Note that request based timeouts mean that HTTP/2 PINGs will not
 keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.</p>
 

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1492,9 +1492,12 @@ No
 <td><code>idleTimeout</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
-<p>The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests.
-If not set, the default is 1 hour. When the idle timeout is reached the connection will be closed.
-Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.</p>
+<p>The idle timeout for upstream connection pool connections. The idle timeout
+is defined as the period in which there are no active requests.
+The default is disabled. When the idle timeout is set and the timeout value
+is reached, the connection will be closed.
+Note that request based timeouts mean that HTTP/2 PINGs will not
+keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -617,9 +617,12 @@ message ConnectionPoolSettings {
     // cluster at a given time. Defaults to 2^32-1.
     int32 max_retries = 4;
 
-    // The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests.
-    // If not set, the default is 1 hour. When the idle timeout is reached the connection will be closed.
-    // Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
+    // The idle timeout for upstream connection pool connections. The idle timeout 
+    // is defined as the period in which there are no active requests.
+    // The default is disabled. When the idle timeout is set and the timeout value 
+    // is reached, the connection will be closed. 
+    // Note that request based timeouts mean that HTTP/2 PINGs will not 
+    // keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections. 
     google.protobuf.Duration idle_timeout = 5;
 
     // Policy for upgrading http1.1 connections to http2.

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -619,8 +619,8 @@ message ConnectionPoolSettings {
 
     // The idle timeout for upstream connection pool connections. The idle timeout 
     // is defined as the period in which there are no active requests.
-    // The default is disabled which means no timeout. When the idle timeout is set 
-    // and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2 
+    // If not set, the default is 1 hour. When the idle timeout is reached, 
+    // the connection will be closed. If the connection is an HTTP/2 
     // connection a drain sequence will occur prior to closing the connection. 
     // Note that request based timeouts mean that HTTP/2 PINGs will not 
     // keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections. 

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -619,8 +619,9 @@ message ConnectionPoolSettings {
 
     // The idle timeout for upstream connection pool connections. The idle timeout 
     // is defined as the period in which there are no active requests.
-    // The default is disabled. When the idle timeout is set and the timeout value 
-    // is reached, the connection will be closed. 
+    // The default is disabled which means no timeout. When the idle timeout is set 
+    // and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2 
+    // connection a drain sequence will occur prior to closing the connection. 
     // Note that request based timeouts mean that HTTP/2 PINGs will not 
     // keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections. 
     google.protobuf.Duration idle_timeout = 5;

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -470,7 +470,7 @@
             "format": "int32"
           },
           "idleTimeout": {
-            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. If not set, the default is 1 hour. When the idle timeout is reached the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
+            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. The default is disabled. When the idle timeout is set and the timeout value is reached, the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
             "type": "string"
           },
           "h2UpgradePolicy": {

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -470,7 +470,7 @@
             "format": "int32"
           },
           "idleTimeout": {
-            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. The default is disabled which means no timeout. When the idle timeout is set and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2 connection a drain sequence will occur prior to closing the connection. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
+            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. If not set, the default is 1 hour. When the idle timeout is reached, the connection will be closed. If the connection is an HTTP/2 connection a drain sequence will occur prior to closing the connection. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
             "type": "string"
           },
           "h2UpgradePolicy": {

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -470,7 +470,7 @@
             "format": "int32"
           },
           "idleTimeout": {
-            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. The default is disabled. When the idle timeout is set and the timeout value is reached, the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
+            "description": "The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. The default is disabled which means no timeout. When the idle timeout is set and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2 connection a drain sequence will occur prior to closing the connection. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.",
             "type": "string"
           },
           "h2UpgradePolicy": {

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1377,8 +1377,9 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	MaxRetries int32 `protobuf:"varint,4,opt,name=max_retries,json=maxRetries,proto3" json:"max_retries,omitempty"`
 	// The idle timeout for upstream connection pool connections. The idle timeout
 	// is defined as the period in which there are no active requests.
-	// The default is disabled. When the idle timeout is set and the timeout value
-	// is reached, the connection will be closed.
+	// The default is disabled which means no timeout. When the idle timeout is set
+	// and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2
+	// connection a drain sequence will occur prior to closing the connection.
 	// Note that request based timeouts mean that HTTP/2 PINGs will not
 	// keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
 	IdleTimeout *types.Duration `protobuf:"bytes,5,opt,name=idle_timeout,json=idleTimeout,proto3" json:"idle_timeout,omitempty"`

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1375,9 +1375,12 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	// Maximum number of retries that can be outstanding to all hosts in a
 	// cluster at a given time. Defaults to 2^32-1.
 	MaxRetries int32 `protobuf:"varint,4,opt,name=max_retries,json=maxRetries,proto3" json:"max_retries,omitempty"`
-	// The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests.
-	// If not set, the default is 1 hour. When the idle timeout is reached the connection will be closed.
-	// Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
+	// The idle timeout for upstream connection pool connections. The idle timeout
+	// is defined as the period in which there are no active requests.
+	// The default is disabled. When the idle timeout is set and the timeout value
+	// is reached, the connection will be closed.
+	// Note that request based timeouts mean that HTTP/2 PINGs will not
+	// keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
 	IdleTimeout *types.Duration `protobuf:"bytes,5,opt,name=idle_timeout,json=idleTimeout,proto3" json:"idle_timeout,omitempty"`
 	// Specify if http1.1 connection should be upgraded to http2 for the associated destination.
 	H2UpgradePolicy ConnectionPoolSettings_HTTPSettings_H2UpgradePolicy `protobuf:"varint,6,opt,name=h2_upgrade_policy,json=h2UpgradePolicy,proto3,enum=istio.networking.v1beta1.ConnectionPoolSettings_HTTPSettings_H2UpgradePolicy" json:"h2_upgrade_policy,omitempty"`

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1377,8 +1377,8 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	MaxRetries int32 `protobuf:"varint,4,opt,name=max_retries,json=maxRetries,proto3" json:"max_retries,omitempty"`
 	// The idle timeout for upstream connection pool connections. The idle timeout
 	// is defined as the period in which there are no active requests.
-	// The default is disabled which means no timeout. When the idle timeout is set
-	// and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2
+	// If not set, the default is 1 hour. When the idle timeout is reached,
+	// the connection will be closed. If the connection is an HTTP/2
 	// connection a drain sequence will occur prior to closing the connection.
 	// Note that request based timeouts mean that HTTP/2 PINGs will not
 	// keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -612,9 +612,12 @@ message ConnectionPoolSettings {
     // cluster at a given time. Defaults to 2^32-1.
     int32 max_retries = 4;
 
-    // The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests.
-    // If not set, the default is 1 hour. When the idle timeout is reached the connection will be closed.
-    // Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
+    // The idle timeout for upstream connection pool connections. The idle timeout 
+    // is defined as the period in which there are no active requests.
+    // The default is disabled. When the idle timeout is set and the timeout value 
+    // is reached, the connection will be closed. 
+    // Note that request based timeouts mean that HTTP/2 PINGs will not 
+    // keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
     google.protobuf.Duration idle_timeout = 5;
 
     // Policy for upgrading http1.1 connections to http2.

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -614,10 +614,11 @@ message ConnectionPoolSettings {
 
     // The idle timeout for upstream connection pool connections. The idle timeout 
     // is defined as the period in which there are no active requests.
-    // The default is disabled. When the idle timeout is set and the timeout value 
-    // is reached, the connection will be closed. 
+    // The default is disabled which means no timeout. When the idle timeout is set 
+    // and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2 
+    // connection a drain sequence will occur prior to closing the connection. 
     // Note that request based timeouts mean that HTTP/2 PINGs will not 
-    // keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
+    // keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections. 
     google.protobuf.Duration idle_timeout = 5;
 
     // Policy for upgrading http1.1 connections to http2.

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -614,8 +614,8 @@ message ConnectionPoolSettings {
 
     // The idle timeout for upstream connection pool connections. The idle timeout 
     // is defined as the period in which there are no active requests.
-    // The default is disabled which means no timeout. When the idle timeout is set 
-    // and the timeout value is reached, the connection will be closed. If the connection is an HTTP/2 
+    // If not set, the default is 1 hour. When the idle timeout is reached, 
+    // the connection will be closed. If the connection is an HTTP/2 
     // connection a drain sequence will occur prior to closing the connection. 
     // Note that request based timeouts mean that HTTP/2 PINGs will not 
     // keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections. 


### PR DESCRIPTION
Updated:
Turned out doc is correct, our code comment is wrong, I'll open a PR to correct it.   A minor update on drain, thanks to @ramaraochavali for helping me clarify things.

--------
We are having it disabled by default:


https://github.com/istio/istio/blob/master/pilot/pkg/model/context.go#L480

Also, from my envoy sidecar default config:

```
            "stream_idle_timeout": "0s",
```