### PR TITLE
link to the correct workload selector used in security API

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -140,7 +140,7 @@ type_v1beta1_path := type/v1beta1
 type_v1beta1_protos := $(wildcard $(type_v1beta1_path)/*.proto)
 type_v1beta1_pb_gos := $(type_v1beta1_protos:.proto=.pb.go)
 type_v1beta1_pb_pythons := $(patsubst $(type_v1beta1_path)/%.proto,$(python_output_path)/$(type_v1beta1_path)/%_pb2.py,$(type_v1beta1_protos))
-type_v1beta1_pb_doc := $(type_v1beta1_path)/istio.type.v1beta1.pb.html
+type_v1beta1_pb_doc := $(type_v1beta1_path:.proto=.pb.html)
 type_v1beta1_openapi := $(type_v1beta1_protos:.proto=.gen.json)
 type_v1beta1_k8s_gos := \
 	$(patsubst $(type_v1beta1_path)/%.proto,$(type_v1beta1_path)/%_json.gen.go,$(shell grep -l "^ *oneof " $(type_v1beta1_protos))) \
@@ -148,7 +148,7 @@ type_v1beta1_k8s_gos := \
 
 $(type_v1beta1_pb_gos) $(type_v1beta1_pb_doc) $(type_v1beta1_pb_pythons) $(type_v1beta1_k8s_gos): $(type_v1beta1_protos)
 	@$(protolock) status
-	@$(protoc) $(gogofast_plugin) $(protoc_gen_k8s_support_plugins) $(protoc_gen_docs_plugin)$(type_v1beta1_path) $(protoc_gen_python_plugin) $^
+	@$(protoc) $(gogofast_plugin) $(protoc_gen_k8s_support_plugins) $(protoc_gen_docs_plugin_per_file)$(type_v1beta1_path) $(protoc_gen_python_plugin) $^
 	@cp -r /tmp/istio.io/api/type/* type
 
 generate-type: $(type_v1beta1_pb_gos) $(type_v1beta1_pb_doc) $(type_v1beta1_pb_pythons) $(type_v1beta1_k8s_gos)

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -211,7 +211,7 @@ spec:
 <tbody>
 <tr id="AuthorizationPolicy-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>Optional. Workload selector decides where to apply the authorization policy.
 If not set, the authorization policy will be applied to all workloads in the

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -103,7 +103,7 @@ spec:
 <tbody>
 <tr id="PeerAuthentication-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>The selector determines the workloads to apply the ChannelAuthentication on.
 If not set, the policy will be applied to all workloads in the same namespace as the policy.</p>

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -126,7 +126,7 @@ spec:
 <tbody>
 <tr id="RequestAuthentication-selector">
 <td><code>selector</code></td>
-<td><code><a href="https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>The selector determines the workloads to apply the RequestAuthentication on.
 If not set, the policy will be applied to all workloads in the same namespace as the policy.</p>

--- a/type/v1beta1/selector.pb.html
+++ b/type/v1beta1/selector.pb.html
@@ -1,8 +1,9 @@
 ---
-title: istio.type.v1beta1
+title: Workload Selector
+description: Definition of a workload selector.
+location: https://istio.io/docs/reference/config/type/workload-selector.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
-aliases: [https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html]
 number_of_entries: 1
 ---
 <h2 id="WorkloadSelector">WorkloadSelector</h2>

--- a/type/v1beta1/selector.proto
+++ b/type/v1beta1/selector.proto
@@ -17,8 +17,7 @@ import "google/api/field_behavior.proto";
 
 // $title: Workload Selector
 // $description: Definition of a workload selector.
-// $location: https://istio.io/latest/docs/reference/config/networking/sidecar/
-// $aliases: [https://istio.io/docs/reference/config/type/v1beta1/workload-selector.html]
+// $location: https://istio.io/docs/reference/config/type/workload-selector.html
 
 package istio.type.v1beta1;
 


### PR DESCRIPTION
For https://github.com/istio/api/issues/1700, tested locally it now links to the correct workload selector (not the one used in sidecar) for security API. 
(Will send another PR in istio.io to show the `Common type` in the sidebar)

![image](https://user-images.githubusercontent.com/2189160/96678258-3a232980-1326-11eb-9c00-83a5b571afac.png)
