### PR TITLE
Add support for Pod IP listener

### DIFF
--- a/networking/v1alpha3/sidecar.gen.json
+++ b/networking/v1alpha3/sidecar.gen.json
@@ -93,7 +93,7 @@
             "format": "string"
           },
           "defaultEndpoint": {
-            "description": "The loopback IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Format should be `127.0.0.1:PORT` or `unix:///path/to/socket`",
+            "description": "The IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `0.0.0.0:PORT` (which will forward to the instance IP), or `unix:///path/to/socket`",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -595,11 +595,12 @@ type IstioIngressListener struct {
 	// The captureMode option dictates how traffic to the listener is
 	// expected to be captured (or not).
 	CaptureMode CaptureMode `protobuf:"varint,3,opt,name=capture_mode,json=captureMode,proto3,enum=istio.networking.v1alpha3.CaptureMode" json:"capture_mode,omitempty"`
-	// The loopback IP endpoint or Unix domain socket to which
+	// The IP endpoint or Unix domain socket to which
 	// traffic should be forwarded to. This configuration can be used to
 	// redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port`
 	// or Unix domain socket where the application workload instance is listening for
-	// connections. Format should be `127.0.0.1:PORT` or `unix:///path/to/socket`
+	// connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `0.0.0.0:PORT`
+	// (which will forward to the instance IP), or `unix:///path/to/socket`
 	DefaultEndpoint      string   `protobuf:"bytes,4,opt,name=default_endpoint,json=defaultEndpoint,proto3" json:"default_endpoint,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -534,11 +534,12 @@ No
 <td><code>defaultEndpoint</code></td>
 <td><code>string</code></td>
 <td>
-<p>The loopback IP endpoint or Unix domain socket to which
+<p>The IP endpoint or Unix domain socket to which
 traffic should be forwarded to. This configuration can be used to
 redirect traffic arriving at the bind <code>IP:Port</code> on the sidecar to a <code>localhost:port</code>
 or Unix domain socket where the application workload instance is listening for
-connections. Format should be <code>127.0.0.1:PORT</code> or <code>unix:///path/to/socket</code></p>
+connections. Arbitrary IPs are not supported. Format should be one of <code>127.0.0.1:PORT</code>, <code>0.0.0.0:PORT</code>
+(which will forward to the instance IP), or <code>unix:///path/to/socket</code></p>
 
 </td>
 <td>

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -479,11 +479,12 @@ message IstioIngressListener {
   // expected to be captured (or not).
   CaptureMode capture_mode = 3;
 
-  // The loopback IP endpoint or Unix domain socket to which
+  // The IP endpoint or Unix domain socket to which
   // traffic should be forwarded to. This configuration can be used to
   // redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port`
   // or Unix domain socket where the application workload instance is listening for
-  // connections. Format should be `127.0.0.1:PORT` or `unix:///path/to/socket`
+  // connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `0.0.0.0:PORT`
+  // (which will forward to the instance IP), or `unix:///path/to/socket`
   string default_endpoint = 4 [(google.api.field_behavior) = REQUIRED];
 
   reserved "localhost_client_tls";

--- a/networking/v1beta1/sidecar.gen.json
+++ b/networking/v1beta1/sidecar.gen.json
@@ -93,7 +93,7 @@
             "format": "string"
           },
           "defaultEndpoint": {
-            "description": "The loopback IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Format should be `127.0.0.1:PORT` or `unix:///path/to/socket`",
+            "description": "The IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `0.0.0.0:PORT` (which will forward to the instance IP), or `unix:///path/to/socket`",
             "type": "string",
             "format": "string"
           },

--- a/networking/v1beta1/sidecar.pb.go
+++ b/networking/v1beta1/sidecar.pb.go
@@ -594,11 +594,12 @@ type IstioIngressListener struct {
 	// The captureMode option dictates how traffic to the listener is
 	// expected to be captured (or not).
 	CaptureMode CaptureMode `protobuf:"varint,3,opt,name=capture_mode,json=captureMode,proto3,enum=istio.networking.v1beta1.CaptureMode" json:"capture_mode,omitempty"`
-	// The loopback IP endpoint or Unix domain socket to which
+	// The IP endpoint or Unix domain socket to which
 	// traffic should be forwarded to. This configuration can be used to
 	// redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port`
 	// or Unix domain socket where the application workload instance is listening for
-	// connections. Format should be `127.0.0.1:PORT` or `unix:///path/to/socket`
+	// connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `0.0.0.0:PORT`
+	// (which will forward to the instance IP), or `unix:///path/to/socket`
 	DefaultEndpoint      string   `protobuf:"bytes,4,opt,name=default_endpoint,json=defaultEndpoint,proto3" json:"default_endpoint,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/networking/v1beta1/sidecar.proto
+++ b/networking/v1beta1/sidecar.proto
@@ -478,11 +478,12 @@ message IstioIngressListener {
   // expected to be captured (or not).
   CaptureMode capture_mode = 3;
 
-  // The loopback IP endpoint or Unix domain socket to which
+  // The IP endpoint or Unix domain socket to which
   // traffic should be forwarded to. This configuration can be used to
   // redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port`
   // or Unix domain socket where the application workload instance is listening for
-  // connections. Format should be `127.0.0.1:PORT` or `unix:///path/to/socket`
+  // connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `0.0.0.0:PORT`
+  // (which will forward to the instance IP), or `unix:///path/to/socket`
   string default_endpoint = 4 [(google.api.field_behavior) = REQUIRED];
 
   reserved "localhost_client_tls";


### PR DESCRIPTION
Implementation PR: https://github.com/istio/istio/pull/28178

This adds an additional allowed value to the sidecar API to facilitate
applications listening on their Pod IP. For example, to run zookeeper,
a user would configure a sidecar:

```yaml
apiVersion: networking.istio.io/v1beta1
kind: Sidecar
metadata:
  name: zk
spec:
  ingress:
  - port:
      number: 3888
      protocol: TCP
      name: election
    defaultEndpoint: 0.0.0.0:3888
  egress:
  - hosts:
    - "*/*"
```