### PR TITLE
typo in virtual-service docs

### DIFF
--- a/networking/v1alpha3/virtual_service.gen.json
+++ b/networking/v1alpha3/virtual_service.gen.json
@@ -433,7 +433,7 @@
         }
       },
       "istio.networking.v1alpha3.Headers": {
-        "description": "Message headers can be manipulated when Envoy forwards requests to, or responses from, a destination service. Header manipulation rules can be specified for a specific route destination or for all destinations. The following VirtualService adds a `test` header with the value `true` to requests that are routed to any `reviews` service destination. It also romoves the `foo` response header, but only from responses coming from the `v1` subset (version) of the `reviews` service.",
+        "description": "Message headers can be manipulated when Envoy forwards requests to, or responses from, a destination service. Header manipulation rules can be specified for a specific route destination or for all destinations. The following VirtualService adds a `test` header with the value `true` to requests that are routed to any `reviews` service destination. It also removes the `foo` response header, but only from responses coming from the `v1` subset (version) of the `reviews` service.",
         "type": "object",
         "properties": {
           "response": {

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -1009,7 +1009,7 @@ func (m *Delegate) GetNamespace() string {
 // be specified for a specific route destination or for all destinations.
 // The following VirtualService adds a `test` header with the value `true`
 // to requests that are routed to any `reviews` service destination.
-// It also romoves the `foo` response header, but only from responses
+// It also removes the `foo` response header, but only from responses
 // coming from the `v1` subset (version) of the `reviews` service.
 //
 // {{<tabset category-name="example">}}

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -931,7 +931,7 @@ or responses from, a destination service. Header manipulation rules can
 be specified for a specific route destination or for all destinations.
 The following VirtualService adds a <code>test</code> header with the value <code>true</code>
 to requests that are routed to any <code>reviews</code> service destination.
-It also romoves the <code>foo</code> response header, but only from responses
+It also removes the <code>foo</code> response header, but only from responses
 coming from the <code>v1</code> subset (version) of the <code>reviews</code> service.</p>
 
 <p>{{<tabset category-name="example">}}

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -722,7 +722,7 @@ message Delegate {
 // be specified for a specific route destination or for all destinations.
 // The following VirtualService adds a `test` header with the value `true`
 // to requests that are routed to any `reviews` service destination.
-// It also romoves the `foo` response header, but only from responses
+// It also removes the `foo` response header, but only from responses
 // coming from the `v1` subset (version) of the `reviews` service.
 //
 // {{<tabset category-name="example">}}

--- a/networking/v1beta1/virtual_service.gen.json
+++ b/networking/v1beta1/virtual_service.gen.json
@@ -433,7 +433,7 @@
         }
       },
       "istio.networking.v1beta1.Headers": {
-        "description": "Message headers can be manipulated when Envoy forwards requests to, or responses from, a destination service. Header manipulation rules can be specified for a specific route destination or for all destinations. The following VirtualService adds a `test` header with the value `true` to requests that are routed to any `reviews` service destination. It also romoves the `foo` response header, but only from responses coming from the `v1` subset (version) of the `reviews` service.",
+        "description": "Message headers can be manipulated when Envoy forwards requests to, or responses from, a destination service. Header manipulation rules can be specified for a specific route destination or for all destinations. The following VirtualService adds a `test` header with the value `true` to requests that are routed to any `reviews` service destination. It also removes the `foo` response header, but only from responses coming from the `v1` subset (version) of the `reviews` service.",
         "type": "object",
         "properties": {
           "response": {

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -1005,7 +1005,7 @@ func (m *Delegate) GetNamespace() string {
 // be specified for a specific route destination or for all destinations.
 // The following VirtualService adds a `test` header with the value `true`
 // to requests that are routed to any `reviews` service destination.
-// It also romoves the `foo` response header, but only from responses
+// It also removes the `foo` response header, but only from responses
 // coming from the `v1` subset (version) of the `reviews` service.
 //
 // {{<tabset category-name="example">}}

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -716,7 +716,7 @@ message Delegate {
 // be specified for a specific route destination or for all destinations.
 // The following VirtualService adds a `test` header with the value `true`
 // to requests that are routed to any `reviews` service destination.
-// It also romoves the `foo` response header, but only from responses
+// It also removes the `foo` response header, but only from responses
 // coming from the `v1` subset (version) of the `reviews` service.
 //
 // {{<tabset category-name="example">}}


### PR DESCRIPTION
It also romoves the foo response header -> It also removes the foo response header