### PR TITLE
Add dummy release note

### DIFF
--- a/releasenotes/notes/add-release-notes-generation.yaml
+++ b/releasenotes/notes/add-release-notes-generation.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: documentation
+issue:
+- https://github.com/istio/istio/issues/23622
+releaseNotes:
+- |
+  **Added** support for autogenerating release notes based off of a file present in the /releasenotes/notes directory.
+


### PR DESCRIPTION
This adds a dummy release note. This allows us to create the release notes directory in GitHub, which provides the structure and allows the release notes tooling to work (it wants to check the directory, which currently doesn't exist). This should be removed from the initial release notes we actually ship and will be ignored past the first set.