### PR TITLE
update sampling doc

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -819,7 +819,7 @@
             "type": "integer"
           },
           "sampling": {
-            "description": "The percentage of requests (0.0 - 100.0) that will be randomly selected for trace generation, if not requested by the client or not forced. Default is 100. $hide_from_docs",
+            "description": "The percentage of requests (0.0 - 100.0) that will be randomly selected for trace generation, if not requested by the client or not forced. Default is 1.0.",
             "type": "number",
             "format": "double"
           }

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -937,6 +937,18 @@ No
 No
 </td>
 </tr>
+<tr id="Tracing-sampling">
+<td><code>sampling</code></td>
+<td><code>double</code></td>
+<td>
+<p>The percentage of requests (0.0 - 100.0) that will be randomly selected for trace generation,
+if not requested by the client or not forced. Default is 1.0.</p>
+
+</td>
+<td>
+No
+</td>
+</tr>
 <tr id="Tracing-tls_settings">
 <td><code>tlsSettings</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/networking/destination-rule.html#ClientTLSSettings">ClientTLSSettings</a></code></td>

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -225,8 +225,7 @@ type Tracing struct {
 	// $hide_from_docs
 	MaxPathTagLength uint32 `protobuf:"varint,6,opt,name=max_path_tag_length,json=maxPathTagLength,proto3" json:"maxPathTagLength,omitempty"`
 	// The percentage of requests (0.0 - 100.0) that will be randomly selected for trace generation,
-	// if not requested by the client or not forced. Default is 100.
-	// $hide_from_docs
+	// if not requested by the client or not forced. Default is 1.0.
 	Sampling float64 `protobuf:"fixed64,7,opt,name=sampling,proto3" json:"sampling,omitempty"`
 	// Use the tls_settings to specify the tls mode to use. If the remote tracing service
 	// uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -209,10 +209,8 @@ message Tracing {
   uint32 max_path_tag_length = 6;
 
   // The percentage of requests (0.0 - 100.0) that will be randomly selected for trace generation,
-  // if not requested by the client or not forced. Default is 100.
-  // $hide_from_docs
+  // if not requested by the client or not forced. Default is 1.0.
   double sampling = 7;
-
 
   // Use the tls_settings to specify the tls mode to use. If the remote tracing service
   // uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS


### PR DESCRIPTION
Since it is already in our user [doc](https://istio.io/latest/docs/tasks/observability/distributed-tracing/configurability/#customizing-trace-sampling), it makes sense to have this reflected in our generated API doc. 

Also, the default was wrong.