### PR TITLE
Fix MeshNetworks example documentation

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -1715,7 +1715,7 @@ inside a mesh and how to route to endpoints in each network. For example</p>
 
 <pre><code class="language-yaml">networks:
   network1:
-  - endpoints:
+    endpoints:
     - fromRegistry: registry1 #must match kubeconfig name in Kubernetes secret
     - fromCidr: 192.168.100.0/22 #a VM network for example
     gateways:

--- a/mesh/v1alpha1/network.pb.go
+++ b/mesh/v1alpha1/network.pb.go
@@ -312,7 +312,7 @@ func (*Network_IstioNetworkGateway) XXX_OneofWrappers() []interface{} {
 // ```yaml
 // networks:
 //   network1:
-//   - endpoints:
+//     endpoints:
 //     - fromRegistry: registry1 #must match kubeconfig name in Kubernetes secret
 //     - fromCidr: 192.168.100.0/22 #a VM network for example
 //     gateways:

--- a/mesh/v1alpha1/network.proto
+++ b/mesh/v1alpha1/network.proto
@@ -102,7 +102,7 @@ message Network {
 // ```yaml
 // networks:
 //   network1:
-//   - endpoints:
+//     endpoints:
 //     - fromRegistry: registry1 #must match kubeconfig name in Kubernetes secret
 //     - fromCidr: 192.168.100.0/22 #a VM network for example
 //     gateways:


### PR DESCRIPTION
The example for MeshNetworks in the [documentation page](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshNetworks) doesn't seem to be correct. The generated pb.go file looks like this:

https://github.com/istio/api/blob/11df83b4d252c9eee246fc26aaa5d4fc2e0acd78/mesh/v1alpha1/network.pb.go#L327-L331
