### PR TITLE
Workaround golang bug causing make gen to fail

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -47,8 +47,8 @@ gen: \
 	gen-proto \
 	generate-annotations \
 	generate-labels \
-	tidy-go \
-	mirror-licenses
+	mirror-licenses \
+	tidy-go
 
 gen-check: gen check-clean-repo
 


### PR DESCRIPTION
Workaround https://github.com/golang/go/issues/43994

Run tidy after download