### PR TITLE
Use buf for protobuf linting

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -24,7 +24,6 @@ repo_dir := .
 
 protolock = protolock
 protolock_release = /bin/bash scripts/check-release-locks.sh
-prototool = prototool
 annotations_prep = annotations_prep
 htmlproofer = htmlproofer
 cue = cue-gen -paths=common-protos

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,4 +1,14 @@
 version: v1beta1
 build:
   roots:
-  - .
+    - .
+  excludes:
+    # Note: buf does not allow multi roots that are within each other; as a result, the common-protos folders are
+    # symlinked into the top level directory.
+    - common-protos
+lint:
+  use:
+    - BASIC
+  except:
+    - FIELD_LOWER_SNAKE_CASE
+    - PACKAGE_DIRECTORY_MATCH

--- a/common/Makefile.common.mk
+++ b/common/Makefile.common.mk
@@ -61,7 +61,7 @@ lint-typescript:
 	@${FINDFILES} -name '*.ts' -print0 | ${XARGS} tslint -c common/config/tslint.json
 
 lint-protos:
-	@if test -d common-protos; then $(FINDFILES) -name '*.proto' -print0 | $(XARGS) -L 1 prototool lint --protoc-bin-path=/usr/bin/protoc --protoc-wkt-path=common-protos; fi
+	@buf lint
 
 lint-licenses:
 	@if test -d licenses; then license-lint --config common/config/license-lint.yml; fi

--- a/prototool.yaml
+++ b/prototool.yaml
@@ -3,32 +3,3 @@ protoc:
   # --protoc-bin-path=/usr/bin/protoc to use the protoc from our
   # container
   version: 3.6.1
-
-lint:
-  # Linter files to ignore.
-  ignores:
-    - id: MESSAGE_NAMES_CAMEL_CASE
-      files:
-        - operator/v1alpha1/operator.proto
-    - id: MESSAGE_FIELD_NAMES_LOWER_SNAKE_CASE
-      files:
-        - operator/v1alpha1/operator.proto
-    - id: ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
-      files:
-        - networking/v1alpha3/gateway.proto
-        - policy/v1beta1/http_response.proto
-    - id: REQUEST_RESPONSE_TYPES_UNIQUE
-      files:
-        - mcp/v1alpha1/mcp.proto
-
-  # Linter rules.
-  rules:
-    # The specific linters to remove.
-    remove:
-      - FILE_OPTIONS_REQUIRE_JAVA_MULTIPLE_FILES
-      - FILE_OPTIONS_REQUIRE_JAVA_OUTER_CLASSNAME
-      - FILE_OPTIONS_REQUIRE_JAVA_PACKAGE
-      - FILE_OPTIONS_EQUAL_GO_PACKAGE_PB_SUFFIX
-      - ENUM_FIELD_PREFIXES
-      - ENUM_ZERO_VALUES_INVALID
-      - COMMENTS_NO_C_STYLE


### PR DESCRIPTION
Following up on #1833, this uses `buf` for linting instead of `prototool`.

A couple changes are made:

- `prototool` lint configuration is deleted, as it is not used anymore, and lint configuration remaining in `prototool.yaml` could lead to confusion as to where the SOT is for Protobuf lint configuration. It looked like the ignores were out of date as well.
- `common-protos` is added to `excludes` in `buf.yaml`. This is more a bug fix - since `common-protos` is symlinked into the base of the repository, we want `buf` to ignore `common-protos` altogether for `buf` to work out of the box. This makes `buf` file discovery ignore `common-protos`, and all `buf` commands work now assuming the symlinks are set up (which `make` does). As a fun example:

```
$ buf build --exclude-imports --exclude-source-info -o -#format=json | jq '.file[] | .package' | sort | uniq
"istio.analysis.v1alpha1"
"istio.authentication.v1alpha1"
"istio.envoy.config.filter.http.alpn.v2alpha1"
"istio.envoy.config.filter.http.authn.v2alpha1"
"istio.envoy.config.filter.http.jwt_auth.v2alpha1"
"istio.envoy.config.filter.network.tcp_cluster_rewrite.v2alpha1"
"istio.mcp.v1alpha1"
"istio.mesh.v1alpha1"
"istio.meta.v1alpha1"
"istio.networking.v1alpha3"
"istio.networking.v1beta1"
"istio.operator.v1alpha1"
"istio.security.v1beta1"
"istio.type.v1beta1"
"istio.v1.auth"
```

- Lint configuration is added to `buf.yaml` that seems to align with what is wanted in this repository. See https://docs.buf.build/lint-configuration for configuration options, and https://docs.buf.build/lint-rules for available rules. With this configuration, the configured rules are:

```
$ buf config ls-lint-rules
ID                                CATEGORIES                                  PURPOSE
DIRECTORY_SAME_PACKAGE            MINIMAL, BASIC, DEFAULT, FILE_LAYOUT        Checks that all files in a given directory are in the same package.
PACKAGE_SAME_DIRECTORY            MINIMAL, BASIC, DEFAULT, FILE_LAYOUT        Checks that all files with a given package are in the same directory.
PACKAGE_SAME_CSHARP_NAMESPACE     MINIMAL, BASIC, DEFAULT, PACKAGE_AFFINITY   Checks that all files with a given package have the same value for the csharp_namespace option.
PACKAGE_SAME_GO_PACKAGE           MINIMAL, BASIC, DEFAULT, PACKAGE_AFFINITY   Checks that all files with a given package have the same value for the go_package option.
PACKAGE_SAME_JAVA_MULTIPLE_FILES  MINIMAL, BASIC, DEFAULT, PACKAGE_AFFINITY   Checks that all files with a given package have the same value for the java_multiple_files option.
PACKAGE_SAME_JAVA_PACKAGE         MINIMAL, BASIC, DEFAULT, PACKAGE_AFFINITY   Checks that all files with a given package have the same value for the java_package option.
PACKAGE_SAME_PHP_NAMESPACE        MINIMAL, BASIC, DEFAULT, PACKAGE_AFFINITY   Checks that all files with a given package have the same value for the php_namespace option.
PACKAGE_SAME_RUBY_PACKAGE         MINIMAL, BASIC, DEFAULT, PACKAGE_AFFINITY   Checks that all files with a given package have the same value for the ruby_package option.
PACKAGE_SAME_SWIFT_PREFIX         MINIMAL, BASIC, DEFAULT, PACKAGE_AFFINITY   Checks that all files with a given package have the same value for the swift_prefix option.
ENUM_NO_ALLOW_ALIAS               MINIMAL, BASIC, DEFAULT, SENSIBLE           Checks that enums do not have the allow_alias option set.
FIELD_NO_DESCRIPTOR               MINIMAL, BASIC, DEFAULT, SENSIBLE           Checks that field names are not name capitalization of "descriptor" with any number of prefix or suffix underscores.
IMPORT_NO_PUBLIC                  MINIMAL, BASIC, DEFAULT, SENSIBLE           Checks that imports are not public.
IMPORT_NO_WEAK                    MINIMAL, BASIC, DEFAULT, SENSIBLE           Checks that imports are not weak.
PACKAGE_DEFINED                   MINIMAL, BASIC, DEFAULT, SENSIBLE           Checks that all files have a package defined.
ENUM_PASCAL_CASE                  BASIC, DEFAULT, STYLE_BASIC, STYLE_DEFAULT  Checks that enums are PascalCase.
ENUM_VALUE_UPPER_SNAKE_CASE       BASIC, DEFAULT, STYLE_BASIC, STYLE_DEFAULT  Checks that enum values are UPPER_SNAKE_CASE.
MESSAGE_PASCAL_CASE               BASIC, DEFAULT, STYLE_BASIC, STYLE_DEFAULT  Checks that messages are PascalCase.
ONEOF_LOWER_SNAKE_CASE            BASIC, DEFAULT, STYLE_BASIC, STYLE_DEFAULT  Checks that oneof names are lower_snake_case.
PACKAGE_LOWER_SNAKE_CASE          BASIC, DEFAULT, STYLE_BASIC, STYLE_DEFAULT  Checks that packages are lower_snake.case.
RPC_PASCAL_CASE                   BASIC, DEFAULT, STYLE_BASIC, STYLE_DEFAULT  Checks that RPCs are PascalCase.
SERVICE_PASCAL_CASE               BASIC, DEFAULT, STYLE_BASIC, STYLE_DEFAULT  Checks that services are PascalCase.
```

Future tasks:

- Migrate from `prototool format` to `buf format` and delete `prototool` entirely once `buf format` is released https://github.com/bufbuild/buf/issues/253
- Migrate from `prototool check break` to `buf breaking`. I've actually done this locally, and it works just fine, but `scripts/check-release-locks.sh` will take some work. See https://docs.buf.build/migration-protolock for the pros/cons of `protolock` vs `buf`, and the migration.
