### PR TITLE
Typo: entirity for entirety

### DIFF
--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -172,7 +172,7 @@ const (
 	EnvoyFilter_Patch_INVALID EnvoyFilter_Patch_Operation = 0
 	// Merge the provided config with the generated config using
 	// proto merge semantics. If you are specifying config in its
-	// entirity, use `REPLACE` instead.
+	// entirety, use `REPLACE` instead.
 	EnvoyFilter_Patch_MERGE EnvoyFilter_Patch_Operation = 1
 	// Add the provided config to an existing list (of listeners,
 	// clusters, virtual hosts, network filters, or http

--- a/networking/v1alpha3/envoy_filter.pb.html
+++ b/networking/v1alpha3/envoy_filter.pb.html
@@ -836,7 +836,7 @@ configuration.</p>
 <td>
 <p>Merge the provided config with the generated config using
 proto merge semantics. If you are specifying config in its
-entirity, use <code>REPLACE</code> instead.</p>
+entirety, use <code>REPLACE</code> instead.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -657,7 +657,7 @@ message EnvoyFilter {
 
       // Merge the provided config with the generated config using
       // proto merge semantics. If you are specifying config in its
-      // entirity, use `REPLACE` instead.
+      // entirety, use `REPLACE` instead.
       MERGE = 1;
 
       // Add the provided config to an existing list (of listeners,


### PR DESCRIPTION
Spell check.  Shows up in user facing docs at https://istio.io/latest/docs/reference/config/networking/envoy-filter/#EnvoyFilter-Patch-Operation