### PR TITLE
gofumpt operator/v1alpha1/deepcopy.go

### DIFF
--- a/operator/v1alpha1/deepcopy.go
+++ b/operator/v1alpha1/deepcopy.go
@@ -24,9 +24,11 @@ import (
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // DeepCopyInto supports using IstioOperatorSpec within kubernetes types, where deepcopy-gen is used.
 func (in *IstioOperatorSpec) DeepCopyInto(out *IstioOperatorSpec) {


### PR DESCRIPTION
gofumpt was added to provide extra Golang file formatting.

In the istio/api repo we do minimal checking as most files are generated. However, one un-generated file needs to be updated.