### PR TITLE
Update to use local-lint-protos

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -105,7 +105,11 @@ release-lock-status:
 # Misc
 #####################
 
-lint: lint-all
+# lint-protos is different for istio/api. List all other lint-all targets and add local-lint-protos
+local-lint-protos:
+	@buf lint
+
+lint: lint-dockerfiles lint-scripts lint-yaml lint-helm lint-copyright-banner lint-go lint-python lint-markdown lint-sass lint-typescript lint-licenses local-lint-protos
  	@$(htmlproofer) . --url-swap "istio.io:preliminary.istio.io" --assume-extension --check-html --check-external-hash --check-opengraph --timeframe 2d --storage-dir $(repo_dir)/.htmlproofer --url-ignore "/localhost/"
 
 fmt: format-python


### PR DESCRIPTION
#1863 updated the `lint-protos` take in the common directory. Of course a common-files change will overwrite the change in that PR and that cause a lint failure. See #1872.

This PR makes the lint-protos change local to istio/api so a later common-files update regressing the file here will have no effect.