### PR TITLE
add support for zone/subzone level failover settings

### DIFF
--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -276,7 +276,7 @@
             }
           },
           "failover": {
-            "description": "Optional: only failover or distribute can be set. Explicitly specify the region traffic will land on when endpoints in local region becomes unhealthy. Should be used together with OutlierDetection to detect unhealthy endpoints. Note: if no OutlierDetection specified, this will not take effect.",
+            "description": "Optional: only failover or distribute can be set. Explicitly specify the locality traffic will land on when endpoints in local locality becomes unhealthy. Should be used together with OutlierDetection to detect unhealthy endpoints. Note: if no OutlierDetection specified, this will not take effect.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/istio.networking.v1beta1.LocalityLoadBalancerSetting.Failover"
@@ -538,16 +538,16 @@
         }
       },
       "istio.networking.v1beta1.LocalityLoadBalancerSetting.Failover": {
-        "description": "Specify the traffic failover policy across regions. Since zone and sub-zone failover is supported by default this only needs to be specified for regions when the operator needs to constrain traffic failover so that the default behavior of failing over to any endpoint globally does not apply. This is useful when failing over traffic across regions would not improve service health or may need to be restricted for other reasons like regulatory controls.",
+        "description": "Specify the traffic failover policy. Examples: `us-west` or `us-west/*` - all zones and sub-zones within the us-west region",
         "type": "object",
         "properties": {
           "from": {
-            "description": "Originating region.",
+            "description": "Originating locality.",
             "type": "string",
             "format": "string"
           },
           "to": {
-            "description": "Destination region the traffic will fail over to when endpoints in the 'from' region becomes unhealthy.",
+            "description": "Destination locality the traffic will fail over to when endpoints in the 'from' locality becomes unhealthy.",
             "type": "string",
             "format": "string"
           }

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1951,18 +1951,18 @@ func (m *ClientTLSSettings) GetSni() string {
 // operational requirements an operator can set a 'failover' policy instead of
 // a 'distribute' policy.
 //
-// The following example sets up a locality failover policy for regions.
-// Assume a service resides in zones within us-east, us-west & eu-west
-// this example specifies that when endpoints within us-east become unhealthy
-// traffic should failover to endpoints in any zone or sub-zone within eu-west
-// and similarly us-west should failover to us-east.
+// The following example sets up a locality failover policy.
+// Assume a service resides in "us-east/zone1/subzone1" and "eu-west/zone2/subzone2",
+// this example specifies that when endpoints within "us-east/zone1/subzone1" become unhealthy
+// traffic should failover to endpoints in "eu-west/zone2/subzone2"
+// and similarly "eu-west/zone2/subzone2" should failover to "us-east/zone1/subzone1".
 //
 // ```yaml
 //  failover:
-//    - from: us-east
-//      to: eu-west
-//    - from: us-west
-//      to: us-east
+//    - from: us-east/zone1/subzone1
+//      to: eu-west/zone2/subzone2
+//    - from: us-west/zone2/subzone2
+//      to: us-east/zone1/subzone1
 // ```
 // Locality load balancing settings.
 type LocalityLoadBalancerSetting struct {
@@ -1972,7 +1972,7 @@ type LocalityLoadBalancerSetting struct {
 	// If empty, the locality weight is set according to the endpoints number within it.
 	Distribute []*LocalityLoadBalancerSetting_Distribute `protobuf:"bytes,1,rep,name=distribute,proto3" json:"distribute,omitempty"`
 	// Optional: only failover or distribute can be set.
-	// Explicitly specify the region traffic will land on when endpoints in local region becomes unhealthy.
+	// Explicitly specify the locality traffic will land on when endpoints in local locality becomes unhealthy.
 	// Should be used together with OutlierDetection to detect unhealthy endpoints.
 	// Note: if no OutlierDetection specified, this will not take effect.
 	Failover []*LocalityLoadBalancerSetting_Failover `protobuf:"bytes,2,rep,name=failover,proto3" json:"failover,omitempty"`

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -984,18 +984,18 @@ message ClientTLSSettings {
 // operational requirements an operator can set a 'failover' policy instead of
 // a 'distribute' policy.
 //
-// The following example sets up a locality failover policy for regions.
-// Assume a service resides in zones within us-east, us-west & eu-west
-// this example specifies that when endpoints within us-east become unhealthy
-// traffic should failover to endpoints in any zone or sub-zone within eu-west
-// and similarly us-west should failover to us-east.
+// The following example sets up a locality failover policy.
+// Assume a service resides in "us-east/zone1/subzone1" and "eu-west/zone2/subzone2",
+// this example specifies that when endpoints within "us-east/zone1/subzone1" become unhealthy
+// traffic should failover to endpoints in "eu-west/zone2/subzone2"
+// and similarly "eu-west/zone2/subzone2" should failover to "us-east/zone1/subzone1".
 //
 // ```yaml
 //  failover:
-//    - from: us-east
-//      to: eu-west
-//    - from: us-west
-//      to: us-east
+//    - from: us-east/zone1/subzone1
+//      to: eu-west/zone2/subzone2
+//    - from: us-west/zone2/subzone2
+//      to: us-east/zone1/subzone1
 // ```
 // Locality load balancing settings.
 message LocalityLoadBalancerSetting{
@@ -1019,19 +1019,19 @@ message LocalityLoadBalancerSetting{
         map<string, uint32> to = 2;
     };
 
-    // Specify the traffic failover policy across regions. Since zone and sub-zone
-    // failover is supported by default this only needs to be specified for
-    // regions when the operator needs to constrain traffic failover so that
-    // the default behavior of failing over to any endpoint globally does not
-    // apply. This is useful when failing over traffic across regions would not
-    // improve service health or may need to be restricted for other reasons
-    // like regulatory controls.
+    // Specify the traffic failover policy. Examples:
+    //
+    // `us-west` or `us-west/*` - all zones and sub-zones within the us-west region
+    //
+    // `us-west/zone-1/*` - all sub-zones within us-west/zone-1
+    //
+    // `us-west/zone-1/subzone-1` - subzone-1 within us-west/zone-1
     message Failover{
-        // Originating region.
+        // Originating locality.
         string from = 1;
 
-        // Destination region the traffic will fail over to when endpoints in
-        // the 'from' region becomes unhealthy.
+        // Destination locality the traffic will fail over to when endpoints in
+        // the 'from' locality becomes unhealthy.
         string to = 2;
     };
 
@@ -1042,7 +1042,7 @@ message LocalityLoadBalancerSetting{
     repeated Distribute distribute = 1;
 
     // Optional: only failover or distribute can be set.
-    // Explicitly specify the region traffic will land on when endpoints in local region becomes unhealthy.
+    // Explicitly specify the locality traffic will land on when endpoints in local locality becomes unhealthy.
     // Should be used together with OutlierDetection to detect unhealthy endpoints.
     // Note: if no OutlierDetection specified, this will not take effect.
     repeated Failover failover = 2;


### PR DESCRIPTION
Current failover settings only support failover from one region to another region, but sometimes we prefer to failover from one zone to another zone, even from one subzone to another subzone.

This pull request adds support for zone/subzone failover settings. For example, failover settings can set as
`
{ 
  From: "region1/zone1/subzone1", 
  To: "region2/zone2/subzone2" 
}
`

For pepole who only concerns about region-level failover, they can still use failover setting as follow, which compatible with before.
`
{ 
  From: "region1", 
  To: "region2" 
}
`

**This pull request just modify failover releated comments, no proto struct changes.**


Related implementation changes resides in this pull request: https://github.com/istio/istio/pull/30781
