### PR TITLE
clean up mixer reference in sidecar API

### DIFF
--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -720,15 +720,6 @@ type IstioEgressListener struct {
 	// Private configurations (e.g., `exportTo` set to `.`) will
 	// not be available. Refer to the `exportTo` setting in `VirtualService`,
 	// `DestinationRule`, and `ServiceEntry` configurations for details.
-	//
-	// **WARNING:** The list of egress hosts in a `Sidecar` must also include
-	// the Mixer control plane services if they are enabled. Envoy will not
-	// be able to reach them otherwise. For example, add host
-	// `istio-system/istio-telemetry.istio-system.svc.cluster.local` if telemetry
-	// is enabled, `istio-system/istio-policy.istio-system.svc.cluster.local` if
-	// policy is enabled, or add `istio-system/*` to allow all services in the
-	// `istio-system` namespace. This requirement is temporary and will be removed
-	// in a future Istio release.
 	Hosts                []string `protobuf:"bytes,4,rep,name=hosts,proto3" json:"hosts,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -645,15 +645,6 @@ Private configurations (e.g., <code>exportTo</code> set to <code>.</code>) will
 not be available. Refer to the <code>exportTo</code> setting in <code>VirtualService</code>,
 <code>DestinationRule</code>, and <code>ServiceEntry</code> configurations for details.</p>
 
-<p><strong>WARNING:</strong> The list of egress hosts in a <code>Sidecar</code> must also include
-the Mixer control plane services if they are enabled. Envoy will not
-be able to reach them otherwise. For example, add host
-<code>istio-system/istio-telemetry.istio-system.svc.cluster.local</code> if telemetry
-is enabled, <code>istio-system/istio-policy.istio-system.svc.cluster.local</code> if
-policy is enabled, or add <code>istio-system/*</code> to allow all services in the
-<code>istio-system</code> namespace. This requirement is temporary and will be removed
-in a future Istio release.</p>
-
 </td>
 <td>
 Yes

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -545,15 +545,6 @@ message IstioEgressListener {
   // Private configurations (e.g., `exportTo` set to `.`) will
   // not be available. Refer to the `exportTo` setting in `VirtualService`,
   // `DestinationRule`, and `ServiceEntry` configurations for details.
-  //
-  // **WARNING:** The list of egress hosts in a `Sidecar` must also include
-  // the Mixer control plane services if they are enabled. Envoy will not
-  // be able to reach them otherwise. For example, add host
-  // `istio-system/istio-telemetry.istio-system.svc.cluster.local` if telemetry
-  // is enabled, `istio-system/istio-policy.istio-system.svc.cluster.local` if
-  // policy is enabled, or add `istio-system/*` to allow all services in the
-  // `istio-system` namespace. This requirement is temporary and will be removed
-  // in a future Istio release.
   repeated string hosts = 4 [(google.api.field_behavior) = REQUIRED];
 
   reserved "localhost_server_tls";

--- a/networking/v1beta1/sidecar.pb.go
+++ b/networking/v1beta1/sidecar.pb.go
@@ -719,15 +719,6 @@ type IstioEgressListener struct {
 	// Private configurations (e.g., `exportTo` set to `.`) will
 	// not be available. Refer to the `exportTo` setting in `VirtualService`,
 	// `DestinationRule`, and `ServiceEntry` configurations for details.
-	//
-	// **WARNING:** The list of egress hosts in a `Sidecar` must also include
-	// the Mixer control plane services if they are enabled. Envoy will not
-	// be able to reach them otherwise. For example, add host
-	// `istio-system/istio-telemetry.istio-system.svc.cluster.local` if telemetry
-	// is enabled, `istio-system/istio-policy.istio-system.svc.cluster.local` if
-	// policy is enabled, or add `istio-system/*` to allow all services in the
-	// `istio-system` namespace. This requirement is temporary and will be removed
-	// in a future Istio release.
 	Hosts                []string `protobuf:"bytes,4,rep,name=hosts,proto3" json:"hosts,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/networking/v1beta1/sidecar.proto
+++ b/networking/v1beta1/sidecar.proto
@@ -545,15 +545,6 @@ message IstioEgressListener {
   // Private configurations (e.g., `exportTo` set to `.`) will
   // not be available. Refer to the `exportTo` setting in `VirtualService`,
   // `DestinationRule`, and `ServiceEntry` configurations for details.
-  //
-  // **WARNING:** The list of egress hosts in a `Sidecar` must also include
-  // the Mixer control plane services if they are enabled. Envoy will not
-  // be able to reach them otherwise. For example, add host
-  // `istio-system/istio-telemetry.istio-system.svc.cluster.local` if telemetry
-  // is enabled, `istio-system/istio-policy.istio-system.svc.cluster.local` if
-  // policy is enabled, or add `istio-system/*` to allow all services in the
-  // `istio-system` namespace. This requirement is temporary and will be removed
-  // in a future Istio release.
   repeated string hosts = 4 [(google.api.field_behavior) = REQUIRED];
 
   reserved "localhost_server_tls";


### PR DESCRIPTION
Since we no longer allow users to enable mixer in default istio.