### PR TITLE
Fix broken links for locations

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -5423,7 +5423,7 @@ spec:
         properties:
           spec:
             description: 'Configuration for access control on workloads. See more
-              details at: https://istio.io/latest/docs/reference/config/security/authorization-policy.html'
+              details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
             oneOf:
             - not:
                 anyOf:

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -1,7 +1,7 @@
 ---
 title: Authorization Policy
 description: Configuration for access control on workloads.
-location: https://istio.io/latest/docs/reference/config/security/authorization-policy.html
+location: https://istio.io/docs/reference/config/security/authorization-policy.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
 schema: istio.security.v1beta1.AuthorizationPolicy

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -19,7 +19,7 @@ import "type/v1beta1/selector.proto";
 // $schema: istio.security.v1beta1.AuthorizationPolicy
 // $title: Authorization Policy
 // $description: Configuration for access control on workloads.
-// $location: https://istio.io/latest/docs/reference/config/security/authorization-policy.html
+// $location: https://istio.io/docs/reference/config/security/authorization-policy.html
 // $weight: 20
 // $aliases: [/docs/reference/config/authorization/authorization-policy]
 


### PR DESCRIPTION
Similar to https://github.com/istio/api/pull/1907

Other `kubectl explain kind` are also have a broken links.

```
$ k explain Gateway.spec
KIND:     Gateway
VERSION:  networking.istio.io/v1beta1

RESOURCE: spec <Object>

DESCRIPTION:
     Configuration affecting edge load balancer. See more details at:
     https://istio.io/docs/reference/config/networking/gateway.html
```

```
$ k explain WorkloadGroup.spec
KIND:     WorkloadGroup
VERSION:  networking.istio.io/v1alpha3

RESOURCE: spec <Object>

DESCRIPTION:
     Describes a collection of workload instances. See more details at:
     https://istio.io/docs/reference/config/networking/workload-group.html
```
