### PR TITLE
Add info about `portLevelMtls` requirement of workload selector with PeerAuthentication

### DIFF
--- a/security/v1beta1/peer_authentication.gen.json
+++ b/security/v1beta1/peer_authentication.gen.json
@@ -17,7 +17,7 @@
             "$ref": "#/components/schemas/istio.security.v1beta1.PeerAuthentication.MutualTLS"
           },
           "portLevelMtls": {
-            "description": "Port specific mutual TLS settings. This only works when workload selector is specified.",
+            "description": "Port specific mutual TLS settings. These only apply when a workload selector is specified.",
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/istio.security.v1beta1.PeerAuthentication.MutualTLS"

--- a/security/v1beta1/peer_authentication.gen.json
+++ b/security/v1beta1/peer_authentication.gen.json
@@ -17,7 +17,7 @@
             "$ref": "#/components/schemas/istio.security.v1beta1.PeerAuthentication.MutualTLS"
           },
           "portLevelMtls": {
-            "description": "Port specific mutual TLS settings.",
+            "description": "Port specific mutual TLS settings. This only works when workload selector is specified.",
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/istio.security.v1beta1.PeerAuthentication.MutualTLS"

--- a/security/v1beta1/peer_authentication.pb.go
+++ b/security/v1beta1/peer_authentication.pb.go
@@ -165,7 +165,7 @@ type PeerAuthentication struct {
 	Selector *v1beta1.WorkloadSelector `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
 	// Mutual TLS settings for workload. If not defined, inherit from parent.
 	Mtls *PeerAuthentication_MutualTLS `protobuf:"bytes,2,opt,name=mtls,proto3" json:"mtls,omitempty"`
-	// Port specific mutual TLS settings. This only works when workload selector
+	// Port specific mutual TLS settings. These only apply when a workload selector
 	// is specified.
 	PortLevelMtls        map[uint32]*PeerAuthentication_MutualTLS `protobuf:"bytes,3,rep,name=port_level_mtls,json=portLevelMtls,proto3" json:"port_level_mtls,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}                                 `json:"-"`

--- a/security/v1beta1/peer_authentication.pb.go
+++ b/security/v1beta1/peer_authentication.pb.go
@@ -165,7 +165,8 @@ type PeerAuthentication struct {
 	Selector *v1beta1.WorkloadSelector `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
 	// Mutual TLS settings for workload. If not defined, inherit from parent.
 	Mtls *PeerAuthentication_MutualTLS `protobuf:"bytes,2,opt,name=mtls,proto3" json:"mtls,omitempty"`
-	// Port specific mutual TLS settings.
+	// Port specific mutual TLS settings. This only works when workload selector
+	// is specified.
 	PortLevelMtls        map[uint32]*PeerAuthentication_MutualTLS `protobuf:"bytes,3,rep,name=port_level_mtls,json=portLevelMtls,proto3" json:"port_level_mtls,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}                                 `json:"-"`
 	XXX_unrecognized     []byte                                   `json:"-"`

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -128,7 +128,8 @@ No
 <td><code>portLevelMtls</code></td>
 <td><code>map&lt;uint32,&nbsp;<a href="#PeerAuthentication-MutualTLS">MutualTLS</a>&gt;</code></td>
 <td>
-<p>Port specific mutual TLS settings.</p>
+<p>Port specific mutual TLS settings. This only works when workload selector
+is specified.</p>
 
 </td>
 <td>

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -128,7 +128,7 @@ No
 <td><code>portLevelMtls</code></td>
 <td><code>map&lt;uint32,&nbsp;<a href="#PeerAuthentication-MutualTLS">MutualTLS</a>&gt;</code></td>
 <td>
-<p>Port specific mutual TLS settings. This only works when workload selector
+<p>Port specific mutual TLS settings. These only apply when a workload selector
 is specified.</p>
 
 </td>

--- a/security/v1beta1/peer_authentication.proto
+++ b/security/v1beta1/peer_authentication.proto
@@ -154,6 +154,7 @@ message PeerAuthentication {
   // Mutual TLS settings for workload. If not defined, inherit from parent.
   MutualTLS mtls = 2;
 
-  // Port specific mutual TLS settings.
+  // Port specific mutual TLS settings. This only works when workload selector
+  // is specified.
   map<uint32, MutualTLS> port_level_mtls = 3;
 }

--- a/security/v1beta1/peer_authentication.proto
+++ b/security/v1beta1/peer_authentication.proto
@@ -154,7 +154,7 @@ message PeerAuthentication {
   // Mutual TLS settings for workload. If not defined, inherit from parent.
   MutualTLS mtls = 2;
 
-  // Port specific mutual TLS settings. This only works when workload selector
+  // Port specific mutual TLS settings. These only apply when a workload selector
   // is specified.
   map<uint32, MutualTLS> port_level_mtls = 3;
 }


### PR DESCRIPTION
Adding validation would be better, but in either case, the documentation should make that requirement clear.

Ref:
https://istio.slack.com/archives/C37A4KAAD/p1615592450286300