### PR TITLE
Fix telemetry API docs on inheritance

### DIFF
--- a/telemetry/v1alpha1/telemetry.pb.go
+++ b/telemetry/v1alpha1/telemetry.pb.go
@@ -35,16 +35,19 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // For resources with a workload selector, it is only valid to have one resource selecting
 // any given workload.
 //
-// Telemetry configuration will be evaluated in order, from most specific matches per telemetry
-// type (tracing, access logging, and metrics) to least specific matches. The first
-// matching configuration for the telemetry type will be applied. The order of evaluation will be:
+// Telemetry configuration will use a "shallow merge" semantic for configuration override
+// for each telemetry type (Tracing, Metrics, AccessLogging). For example, Tracing configuration
+// will support overrides of the fields `providers`, `random_sampling_percentage`, `disable_span_reporting`,
+// and `custom_tags` at each level in the configuration hierarchy, with absent values filled in
+// from parent resources. However, when specified, fields like `custom_tags` will
+// fully replace any values provided by parent configuration.
 //
+// The hierarchy of Telemetry configuration is as follows:
 // 1. Workload-specific configuration
 // 1. Namespace-specific configuration
 // 1. Root namespace configuration
 //
-// Telemetry configuration does not inherit. Rather, matched configurations must fully-specify
-// the desired behavior. Workload-specific configuration fully replaces any configuration
+// NOTE: Any specified "top-level" field within a Telemetry type fully replaces any configuration
 // defined at the local and root namespace levels.
 //
 // WARNING: Support for Telemetry policies is under active development and is *not*

--- a/telemetry/v1alpha1/telemetry.pb.html
+++ b/telemetry/v1alpha1/telemetry.pb.html
@@ -17,18 +17,19 @@ to have a single workload selector-less Telemetry resource.</p>
 <p>For resources with a workload selector, it is only valid to have one resource selecting
 any given workload.</p>
 
-<p>Telemetry configuration will be evaluated in order, from most specific matches per telemetry
-type (tracing, access logging, and metrics) to least specific matches. The first
-matching configuration for the telemetry type will be applied. The order of evaluation will be:</p>
+<p>Telemetry configuration will use a &ldquo;shallow merge&rdquo; semantic for configuration override
+for each telemetry type (Tracing, Metrics, AccessLogging). For example, Tracing configuration
+will support overrides of the fields <code>providers</code>, <code>random_sampling_percentage</code>, <code>disable_span_reporting</code>,
+and <code>custom_tags</code> at each level in the configuration hierarchy, with absent values filled in
+from parent resources. However, when specified, fields like <code>custom_tags</code> will
+fully replace any values provided by parent configuration.</p>
 
-<ol>
-<li>Workload-specific configuration</li>
-<li>Namespace-specific configuration</li>
-<li>Root namespace configuration</li>
-</ol>
+<p>The hierarchy of Telemetry configuration is as follows:
+1. Workload-specific configuration
+1. Namespace-specific configuration
+1. Root namespace configuration</p>
 
-<p>Telemetry configuration does not inherit. Rather, matched configurations must fully-specify
-the desired behavior. Workload-specific configuration fully replaces any configuration
+<p>NOTE: Any specified &ldquo;top-level&rdquo; field within a Telemetry type fully replaces any configuration
 defined at the local and root namespace levels.</p>
 
 <p>WARNING: Support for Telemetry policies is under active development and is <em>not</em>

--- a/telemetry/v1alpha1/telemetry.proto
+++ b/telemetry/v1alpha1/telemetry.proto
@@ -37,16 +37,19 @@ package istio.telemetry.v1alpha1;
 // For resources with a workload selector, it is only valid to have one resource selecting
 // any given workload.
 //
-// Telemetry configuration will be evaluated in order, from most specific matches per telemetry
-// type (tracing, access logging, and metrics) to least specific matches. The first
-// matching configuration for the telemetry type will be applied. The order of evaluation will be:
+// Telemetry configuration will use a "shallow merge" semantic for configuration override
+// for each telemetry type (Tracing, Metrics, AccessLogging). For example, Tracing configuration
+// will support overrides of the fields `providers`, `random_sampling_percentage`, `disable_span_reporting`,
+// and `custom_tags` at each level in the configuration hierarchy, with absent values filled in
+// from parent resources. However, when specified, fields like `custom_tags` will
+// fully replace any values provided by parent configuration.
 //
+// The hierarchy of Telemetry configuration is as follows:
 // 1. Workload-specific configuration
 // 1. Namespace-specific configuration
 // 1. Root namespace configuration
 //
-// Telemetry configuration does not inherit. Rather, matched configurations must fully-specify
-// the desired behavior. Workload-specific configuration fully replaces any configuration
+// NOTE: Any specified "top-level" field within a Telemetry type fully replaces any configuration
 // defined at the local and root namespace levels.
 //
 // WARNING: Support for Telemetry policies is under active development and is *not* 


### PR DESCRIPTION
The docs on the new Telemetry API do not reflect the agreed inheritance semantic described in [Telemetry API Inheritance](https://docs.google.com/document/d/1o3rH_C9sWM9Y2xAFfkvlHXEnF6vBR3OfkklHkwjwTAc/edit?hl=en&resourcekey=0-4e-YSD_7fwtCqQuNnhiNEQ#).

This PR attempts to provide clearer guidance, based on design discussions.