### PR TITLE
add dry-run annotation

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -28,6 +28,7 @@ type ResourceTypes int
 const (
 	Unknown ResourceTypes = iota
     Any
+    AuthorizationPolicy
     Ingress
     Pod
     Service
@@ -38,10 +39,12 @@ func (r ResourceTypes) String() string {
 	case 1:
 		return "Any"
 	case 2:
-		return "Ingress"
+		return "AuthorizationPolicy"
 	case 3:
-		return "Pod"
+		return "Ingress"
 	case 4:
+		return "Pod"
+	case 5:
 		return "Service"
 	}
 	return "Unknown"
@@ -155,6 +158,18 @@ var (
 		Deprecated:    false,
 		Resources: []ResourceTypes{
 			Any,
+		},
+	}
+
+	IoIstioDryRun = Instance {
+		Name:          "istio.io/dry-run",
+		Description:   "Specifies whether or not the given resource is in dry-run "+
+                        "mode.",
+		FeatureStatus: Alpha,
+		Hidden:        true,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			AuthorizationPolicy,
 		},
 	}
 
@@ -613,6 +628,7 @@ func AllResourceAnnotations() []*Instance {
 		&OperatorInstallChartOwner,
 		&OperatorInstallOwnerGeneration,
 		&OperatorInstallVersion,
+		&IoIstioDryRun,
 		&IoKubernetesIngressClass,
 		&NetworkingExportTo,
 		&PrometheusMergeMetrics,
@@ -655,6 +671,7 @@ func AllResourceAnnotations() []*Instance {
 func AllResourceTypes() []string {
 	return []string {
 		"Any",
+		"AuthorizationPolicy",
 		"Ingress",
 		"Pod",
 		"Service",

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -79,6 +79,8 @@ Istio supports to control its behavior.
 			
 		
 			
+		
+			
 				
 					<tr>
 				

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -392,3 +392,11 @@ annotations:
     hidden: false
     resources:
       - Pod
+
+  - name: istio.io/dry-run
+    featureStatus: Alpha
+    description: Specifies whether or not the given resource is in dry-run mode.
+    deprecated: false
+    hidden: true
+    resources:
+      - AuthorizationPolicy


### PR DESCRIPTION
Allows customers to dry-run an authorization policy to test the effect using real traffic without enforcing the policy, reducing the risk of creating or changing the authorization policy. 

Only supports AuthorizationPolicy for now, the admission controller will reject other resources with the dry-run annotation.

Design doc: https://docs.google.com/document/d/1xQdZsEgJ3Ld2qebfT3EJkg2COTtCR1TqBVojmnvI78g (approved by Security WG)