### PR TITLE
Document annotations used for injection

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -126,6 +126,20 @@ var (
 		},
 	}
 
+	InjectTemplates = Instance {
+		Name:          "inject.istio.io/templates",
+		Description:   "The name of the inject template(s) to use, as a comma "+
+                        "separate list. See "+
+                        "https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#custom-templates-experimental "+
+                        "for more information.",
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Pod,
+		},
+	}
+
 	OperatorInstallChartOwner = Instance {
 		Name:          "install.operator.istio.io/chart-owner",
 		Description:   "Represents the name of the chart used to create this "+
@@ -218,6 +232,18 @@ var (
                         "https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig.",
 		FeatureStatus: Beta,
 		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Pod,
+		},
+	}
+
+	ProxyOverrides = Instance {
+		Name:          "proxy.istio.io/overrides",
+		Description:   "Used internally to indicate user-specified overrides in "+
+                        "the proxy container of the pod during injection.",
+		FeatureStatus: Alpha,
+		Hidden:        true,
 		Deprecated:    false,
 		Resources: []ResourceTypes{
 			Pod,
@@ -636,6 +662,7 @@ func AllResourceAnnotations() []*Instance {
 		&AlphaIdentity,
 		&AlphaKubernetesServiceAccounts,
 		&GalleyAnalyzeSuppress,
+		&InjectTemplates,
 		&OperatorInstallChartOwner,
 		&OperatorInstallOwnerGeneration,
 		&OperatorInstallVersion,
@@ -644,6 +671,7 @@ func AllResourceAnnotations() []*Instance {
 		&NetworkingExportTo,
 		&PrometheusMergeMetrics,
 		&ProxyConfig,
+		&ProxyOverrides,
 		&SidecarStatusReadinessApplicationPorts,
 		&SidecarStatusReadinessFailureThreshold,
 		&SidecarStatusReadinessInitialDelaySeconds,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -43,6 +43,19 @@ Istio supports to control its behavior.
 				
 					<tr>
 				
+					<td><code>inject.istio.io/templates</code></td>
+				
+					<td>Alpha</td>
+				
+					<td>[Pod]</td>
+					<td>The name of the inject template(s) to use, as a comma separate list. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#custom-templates-experimental for more information.</td>
+				</tr>
+			
+		
+			
+				
+					<tr>
+				
 					<td><code>install.operator.istio.io/chart-owner</code></td>
 				
 					<td>Alpha</td>
@@ -130,6 +143,8 @@ Istio supports to control its behavior.
 					<td>[Pod]</td>
 					<td>Overrides for the proxy configuration for this specific proxy. Available options can be found at https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig.</td>
 				</tr>
+			
+		
 			
 		
 			

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -408,3 +408,20 @@ annotations:
     hidden: true
     resources:
       - AuthorizationPolicy
+
+  - name: proxy.istio.io/overrides
+    featureStatus: Alpha
+    description: Used internally to indicate user-specified overrides in the proxy container of the pod during injection.
+    deprecated: false
+    hidden: true
+    resources:
+      - Pod
+
+  - name: inject.istio.io/templates
+    featureStatus: Alpha
+    description: The name of the inject template(s) to use, as a comma separate list. See
+      https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#custom-templates-experimental for more information.
+    deprecated: false
+    hidden: false
+    resources:
+      - Pod


### PR DESCRIPTION
These are not new annotations, but backfilling ones used in injection
that were not previously in the API repo.