### PR TITLE
Deprecate injection annotation

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -447,7 +447,7 @@ var (
                         "automatically injected into the workload.",
 		FeatureStatus: Beta,
 		Hidden:        false,
-		Deprecated:    false,
+		Deprecated:    true,
 		Resources: []ResourceTypes{
 			Pod,
 		},

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -298,7 +298,7 @@ Istio supports to control its behavior.
 		
 			
 				
-					<tr>
+					<tr class="deprecated">
 				
 					<td><code>sidecar.istio.io/extraStatTags</code></td>
 				
@@ -315,7 +315,7 @@ Istio supports to control its behavior.
 				
 					<td><code>sidecar.istio.io/inject</code></td>
 				
-					<td>Beta</td>
+					<td>Deprecated</td>
 				
 					<td>[Pod]</td>
 					<td>Specifies whether or not an Envoy sidecar should be automatically injected into the workload.</td>

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -298,7 +298,7 @@ Istio supports to control its behavior.
 		
 			
 				
-					<tr class="deprecated">
+					<tr>
 				
 					<td><code>sidecar.istio.io/extraStatTags</code></td>
 				
@@ -311,7 +311,7 @@ Istio supports to control its behavior.
 		
 			
 				
-					<tr>
+					<tr class="deprecated">
 				
 					<td><code>sidecar.istio.io/inject</code></td>
 				

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -65,7 +65,7 @@ annotations:
     featureStatus: Beta
     description: Specifies whether or not an Envoy sidecar should be automatically
       injected into the workload.
-    deprecated: false
+    deprecated: true
     hidden: false
     resources:
       - Pod


### PR DESCRIPTION
This has been replaced with a label of the same name. The label is
strictly more powerful since selection is done in Kubernetes, rather
than in Istio.

See https://preliminary.istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy for documentation on the new label.

This change simply makes `istioctl analyze` report an info warning. https://github.com/istio/istio/pull/32959 is added to enhance the message to make it more clear. 

This does not change the runtime behavior, nor imply the annotation will be removed at any time.