### PR TITLE
Add tooling to automatically sync proto versions

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -16,6 +16,9 @@
 
 set -eu
 
+# Sync API versions
+scripts/sync.sh
+
 # Generate all protos
 buf generate \
   --path networking \

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -310,6 +310,9 @@ func (ClientTLSSettings_TLSmode) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 type DestinationRule struct {
 	// The name of a service from the service registry. Service
 	// names are looked up from the platform's service registry (e.g.,

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -194,6 +194,9 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 message DestinationRule {
   // The name of a service from the service registry. Service
   // names are looked up from the platform's service registry (e.g.,
@@ -615,13 +618,13 @@ message ConnectionPoolSettings {
     // cluster at a given time. Defaults to 2^32-1.
     int32 max_retries = 4;
 
-    // The idle timeout for upstream connection pool connections. The idle timeout 
+    // The idle timeout for upstream connection pool connections. The idle timeout
     // is defined as the period in which there are no active requests.
-    // If not set, the default is 1 hour. When the idle timeout is reached, 
-    // the connection will be closed. If the connection is an HTTP/2 
-    // connection a drain sequence will occur prior to closing the connection. 
-    // Note that request based timeouts mean that HTTP/2 PINGs will not 
-    // keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections. 
+    // If not set, the default is 1 hour. When the idle timeout is reached,
+    // the connection will be closed. If the connection is an HTTP/2
+    // connection a drain sequence will occur prior to closing the connection.
+    // Note that request based timeouts mean that HTTP/2 PINGs will not
+    // keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
     google.protobuf.Duration idle_timeout = 5;
 
     // Policy for upgrading http1.1 connections to http2.

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -471,6 +471,9 @@ func (ServerTLSSettings_TLSProtocol) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 type Gateway struct {
 	// A list of server specifications.
 	Servers []*Server `protobuf:"bytes,1,rep,name=servers,proto3" json:"servers,omitempty"`

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -372,6 +372,9 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 message Gateway {
   // A list of server specifications.
   repeated Server servers = 1 [(google.api.field_behavior) = REQUIRED];
@@ -675,8 +678,8 @@ message ServerTLSSettings {
   // holds the TLS certs including the CA certificates. Applicable
   // only on Kubernetes. The secret (of type `generic`) should
   // contain the following keys and values: `key:
-  // <privateKey>` and `cert: <serverCert>`. For mutual TLS, 
-  // `cacert: <CACertificate>` can be provided in the same secret or 
+  // <privateKey>` and `cert: <serverCert>`. For mutual TLS,
+  // `cacert: <CACertificate>` can be provided in the same secret or
   // a separate secret named `<secret>-cacert`.
   // Secret of type tls for server certificates along with
   // ca.crt key for CA certificates is also supported.

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -889,6 +889,9 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 type ServiceEntry struct {
 	// The hosts associated with the ServiceEntry. Could be a DNS
 	// name with wildcard prefix.

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -805,6 +805,9 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 message ServiceEntry {
   // The hosts associated with the ServiceEntry. Could be a DNS
   // name with wildcard prefix.

--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -489,6 +489,9 @@ func (OutboundTrafficPolicy_Mode) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 type Sidecar struct {
 	// Criteria used to select the specific set of pods/VMs on which this
 	// `Sidecar` configuration should be applied. If omitted, the `Sidecar`

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -427,6 +427,9 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 message Sidecar {
   // Criteria used to select the specific set of pods/VMs on which this
   // `Sidecar` configuration should be applied. If omitted, the `Sidecar`
@@ -607,7 +610,7 @@ message OutboundTrafficPolicy {
   // Envoy's dynamic forward proxy can handle only HTTP and TLS
   // connections.
   // $hide_from_docs
-  istio.networking.v1alpha3.Destination egress_proxy = 2;
+  Destination egress_proxy = 2;
 }
 
 

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -200,6 +200,9 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 type VirtualService struct {
 	// The destination hosts to which traffic is being sent. Could
 	// be a DNS name with wildcard prefix or an IP address.  Depending on the
@@ -277,9 +280,6 @@ type VirtualService struct {
 	// The value "." is reserved and defines an export to the same namespace that
 	// the virtual service is declared in. Similarly the value "*" is reserved and
 	// defines an export to all namespaces.
-	//
-	// NOTE: in the current release, the `exportTo` value is restricted to
-	// "." or "*" (i.e., the current namespace or all namespaces).
 	ExportTo             []string `protobuf:"bytes,6,rep,name=export_to,json=exportTo,proto3" json:"export_to,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -586,7 +586,7 @@ func (m *VirtualService) GetExportTo() []string {
 //     protocol: HTTP
 //   resolution: DNS
 // ---
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1beta1
 // kind: VirtualService
 // metadata:
 //   name: my-wiki-rule

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -298,9 +298,6 @@ namespaces by default.</p>
 the virtual service is declared in. Similarly the value &ldquo;*&rdquo; is reserved and
 defines an export to all namespaces.</p>
 
-<p>NOTE: in the current release, the <code>exportTo</code> value is restricted to
-&ldquo;.&rdquo; or &ldquo;*&rdquo; (i.e., the current namespace or all namespaces).</p>
-
 </td>
 <td>
 No
@@ -543,7 +540,7 @@ spec:
     protocol: HTTP
   resolution: DNS
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: my-wiki-rule

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -202,6 +202,9 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 message VirtualService {
   // The destination hosts to which traffic is being sent. Could
   // be a DNS name with wildcard prefix or an IP address.  Depending on the
@@ -284,9 +287,6 @@ message VirtualService {
   // The value "." is reserved and defines an export to the same namespace that
   // the virtual service is declared in. Similarly the value "*" is reserved and
   // defines an export to all namespaces.
-  //
-  // NOTE: in the current release, the `exportTo` value is restricted to
-  // "." or "*" (i.e., the current namespace or all namespaces).
   repeated string export_to = 6;
 }
 
@@ -515,7 +515,7 @@ message VirtualService {
 //     protocol: HTTP
 //   resolution: DNS
 // ---
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1beta1
 // kind: VirtualService
 // metadata:
 //   name: my-wiki-rule

--- a/networking/v1alpha3/workload_entry.pb.go
+++ b/networking/v1alpha3/workload_entry.pb.go
@@ -255,6 +255,9 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 type WorkloadEntry struct {
 	// Address associated with the network endpoint without the
 	// port.  Domain names can be used if and only if the resolution is set

--- a/networking/v1alpha3/workload_entry.proto
+++ b/networking/v1alpha3/workload_entry.proto
@@ -257,6 +257,9 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-start
+// -->
 message WorkloadEntry {
   // Address associated with the network endpoint without the
   // port.  Domain names can be used if and only if the resolution is set

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -309,6 +309,9 @@ func (ClientTLSSettings_TLSmode) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/destination_rule.proto
+// -->
 type DestinationRule struct {
 	// The name of a service from the service registry. Service
 	// names are looked up from the platform's service registry (e.g.,

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -194,6 +194,9 @@ option go_package = "istio.io/api/networking/v1beta1";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/destination_rule.proto
+// -->
 message DestinationRule {
   // The name of a service from the service registry. Service
   // names are looked up from the platform's service registry (e.g.,

--- a/networking/v1beta1/gateway.pb.go
+++ b/networking/v1beta1/gateway.pb.go
@@ -470,6 +470,9 @@ func (ServerTLSSettings_TLSProtocol) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/gateway.proto
+// -->
 type Gateway struct {
 	// A list of server specifications.
 	Servers []*Server `protobuf:"bytes,1,rep,name=servers,proto3" json:"servers,omitempty"`
@@ -691,17 +694,16 @@ type Server struct {
 	// HTTP services, it can also be used for TCP services using TLS with SNI.
 	// A host is specified as a `dnsName` with an optional `namespace/` prefix.
 	// The `dnsName` should be specified using FQDN format, optionally including
-	// a wildcard character in the left-most component (e.g.,
-	// `prod/*.example.com`). Set the `dnsName` to `*` to select all
-	// `VirtualService` hosts from the specified namespace (e.g.,`prod/*`).
+	// a wildcard character in the left-most component (e.g., `prod/*.example.com`).
+	// Set the `dnsName` to `*` to select all `VirtualService` hosts from the
+	// specified namespace (e.g.,`prod/*`).
 	//
 	// The `namespace` can be set to `*` or `.`, representing any or the current
 	// namespace, respectively. For example, `*/foo.example.com` selects the
 	// service from any available namespace while `./foo.example.com` only selects
-	// the service from the namespace of the sidecar. The default, if no
-	// `namespace/` is specified, is `*/`, that is, select services from any
-	// namespace. Any associated `DestinationRule` in the selected namespace will
-	// also be used.
+	// the service from the namespace of the sidecar. The default, if no `namespace/`
+	// is specified, is `*/`, that is, select services from any namespace.
+	// Any associated `DestinationRule` in the selected namespace will also be used.
 	//
 	// A `VirtualService` must be bound to the gateway and must have one or
 	// more hosts that match the hosts specified in a server. The match

--- a/networking/v1beta1/gateway.proto
+++ b/networking/v1beta1/gateway.proto
@@ -372,6 +372,9 @@ option go_package = "istio.io/api/networking/v1beta1";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/gateway.proto
+// -->
 message Gateway {
   // A list of server specifications.
   repeated Server servers = 1 [(google.api.field_behavior) = REQUIRED];
@@ -546,17 +549,16 @@ message Server {
   // HTTP services, it can also be used for TCP services using TLS with SNI.
   // A host is specified as a `dnsName` with an optional `namespace/` prefix.
   // The `dnsName` should be specified using FQDN format, optionally including
-  // a wildcard character in the left-most component (e.g.,
-  // `prod/*.example.com`). Set the `dnsName` to `*` to select all
-  // `VirtualService` hosts from the specified namespace (e.g.,`prod/*`).
+  // a wildcard character in the left-most component (e.g., `prod/*.example.com`).
+  // Set the `dnsName` to `*` to select all `VirtualService` hosts from the
+  // specified namespace (e.g.,`prod/*`).
   //
   // The `namespace` can be set to `*` or `.`, representing any or the current
   // namespace, respectively. For example, `*/foo.example.com` selects the
   // service from any available namespace while `./foo.example.com` only selects
-  // the service from the namespace of the sidecar. The default, if no
-  // `namespace/` is specified, is `*/`, that is, select services from any
-  // namespace. Any associated `DestinationRule` in the selected namespace will
-  // also be used.
+  // the service from the namespace of the sidecar. The default, if no `namespace/`
+  // is specified, is `*/`, that is, select services from any namespace.
+  // Any associated `DestinationRule` in the selected namespace will also be used.
   //
   // A `VirtualService` must be bound to the gateway and must have one or
   // more hosts that match the hosts specified in a server. The match

--- a/networking/v1beta1/service_entry.pb.go
+++ b/networking/v1beta1/service_entry.pb.go
@@ -888,6 +888,9 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/service_entry.proto
+// -->
 type ServiceEntry struct {
 	// The hosts associated with the ServiceEntry. Could be a DNS
 	// name with wildcard prefix.

--- a/networking/v1beta1/service_entry.proto
+++ b/networking/v1beta1/service_entry.proto
@@ -805,6 +805,9 @@ option go_package = "istio.io/api/networking/v1beta1";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/service_entry.proto
+// -->
 message ServiceEntry {
   // The hosts associated with the ServiceEntry. Could be a DNS
   // name with wildcard prefix.

--- a/networking/v1beta1/sidecar.pb.go
+++ b/networking/v1beta1/sidecar.pb.go
@@ -488,6 +488,9 @@ func (OutboundTrafficPolicy_Mode) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/sidecar.proto
+// -->
 type Sidecar struct {
 	// Criteria used to select the specific set of pods/VMs on which this
 	// `Sidecar` configuration should be applied. If omitted, the `Sidecar`

--- a/networking/v1beta1/sidecar.proto
+++ b/networking/v1beta1/sidecar.proto
@@ -427,6 +427,9 @@ option go_package = "istio.io/api/networking/v1beta1";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/sidecar.proto
+// -->
 message Sidecar {
   // Criteria used to select the specific set of pods/VMs on which this
   // `Sidecar` configuration should be applied. If omitted, the `Sidecar`
@@ -607,7 +610,7 @@ message OutboundTrafficPolicy {
   // Envoy's dynamic forward proxy can handle only HTTP and TLS
   // connections.
   // $hide_from_docs
-  istio.networking.v1beta1.Destination egress_proxy = 2;
+  Destination egress_proxy = 2;
 }
 
 

--- a/networking/v1beta1/virtual_service.gen.json
+++ b/networking/v1beta1/virtual_service.gen.json
@@ -278,7 +278,7 @@
             "type": "integer"
           },
           "sourceLabels": {
-            "description": "One or more labels that constrain the applicability of a rule to workloads with the given labels. If the VirtualService has a list of gateways specified in the top-level `gateways` field, it must include the reserved gateway `mesh` for this field to be applicable.",
+            "description": "One or more labels that constrain the applicability of a rule to source (client) workloads with the given labels. If the VirtualService has a list of gateways specified in the top-level `gateways` field, it must include the reserved gateway `mesh` for this field to be applicable.",
             "type": "object",
             "additionalProperties": {
               "type": "string"

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -199,6 +199,9 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/virtual_service.proto
+// -->
 type VirtualService struct {
 	// The destination hosts to which traffic is being sent. Could
 	// be a DNS name with wildcard prefix or an IP address.  Depending on the
@@ -1550,9 +1553,9 @@ type HTTPMatchRequest struct {
 	// only expose a single port or label ports with the protocols they support,
 	// in these cases it is not required to explicitly select the port.
 	Port uint32 `protobuf:"varint,6,opt,name=port,proto3" json:"port,omitempty"`
-	// One or more labels that constrain the applicability of a rule to
-	// workloads with the given labels. If the VirtualService has a list of
-	// gateways specified in the top-level `gateways` field, it must include the reserved gateway
+	// One or more labels that constrain the applicability of a rule to source (client) workloads
+	// with the given labels. If the VirtualService has a list of gateways specified
+	// in the top-level `gateways` field, it must include the reserved gateway
 	// `mesh` for this field to be applicable.
 	SourceLabels map[string]string `protobuf:"bytes,7,rep,name=source_labels,json=sourceLabels,proto3" json:"source_labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Names of gateways where the rule should be applied. Gateway names

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -202,6 +202,9 @@ option go_package = "istio.io/api/networking/v1beta1";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/virtual_service.proto
+// -->
 message VirtualService {
   // The destination hosts to which traffic is being sent. Could
   // be a DNS name with wildcard prefix or an IP address.  Depending on the
@@ -586,7 +589,7 @@ message HTTPRoute {
   // Delegate is used to specify the particular VirtualService which
   // can be used to define delegate HTTPRoute.
   //
-  // It can be set only when `Route` and `Redirect` are empty, and the route 
+  // It can be set only when `Route` and `Redirect` are empty, and the route
   // rules of the delegate VirtualService will be merged with that in the
   // current one.
   //
@@ -647,6 +650,7 @@ message HTTPRoute {
   // $hide_from_docs
   // Next available field number: 21
 }
+
 
 // Describes the delegate VirtualService.
 // The following routing rules forward the traffic to `/productpage` by a delegate VirtualService named `productpage`,
@@ -715,6 +719,7 @@ message Delegate {
   // By default, it is same to the root's.
   string namespace = 2;
 }
+
 
 // Message headers can be manipulated when Envoy forwards requests to,
 // or responses from, a destination service. Header manipulation rules can
@@ -1064,9 +1069,9 @@ message HTTPMatchRequest {
   // in these cases it is not required to explicitly select the port.
   uint32 port = 6;
 
-  // One or more labels that constrain the applicability of a rule to
-  // workloads with the given labels. If the VirtualService has a list of
-  // gateways specified in the top-level `gateways` field, it must include the reserved gateway
+  // One or more labels that constrain the applicability of a rule to source (client) workloads
+  // with the given labels. If the VirtualService has a list of gateways specified
+  // in the top-level `gateways` field, it must include the reserved gateway
   // `mesh` for this field to be applicable.
   map<string, string> source_labels = 7;
 

--- a/networking/v1beta1/workload_entry.pb.go
+++ b/networking/v1beta1/workload_entry.pb.go
@@ -254,6 +254,9 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/workload_entry.proto
+// -->
 type WorkloadEntry struct {
 	// Address associated with the network endpoint without the
 	// port.  Domain names can be used if and only if the resolution is set

--- a/networking/v1beta1/workload_entry.proto
+++ b/networking/v1beta1/workload_entry.proto
@@ -257,6 +257,9 @@ option go_package = "istio.io/api/networking/v1beta1";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
+// <!-- istio code generation tags
+// +istio.io/sync-from:networking/v1alpha3/workload_entry.proto
+// -->
 message WorkloadEntry {
   // Address associated with the network endpoint without the
   // port.  Domain names can be used if and only if the resolution is set
@@ -322,4 +325,3 @@ message WorkloadEntry {
   // ServiceEntry)
   string service_account = 7;
 };
-

--- a/proto.lock
+++ b/proto.lock
@@ -36012,7 +36012,7 @@
               {
                 "id": 2,
                 "name": "egress_proxy",
-                "type": "istio.networking.v1alpha3.Destination"
+                "type": "Destination"
               }
             ]
           }
@@ -38249,7 +38249,7 @@
               {
                 "id": 2,
                 "name": "egress_proxy",
-                "type": "istio.networking.v1beta1.Destination"
+                "type": "Destination"
               }
             ]
           }

--- a/releaselocks/release-1.6/proto.lock.status
+++ b/releaselocks/release-1.6/proto.lock.status
@@ -1155,6 +1155,8 @@ CONFLICT: "ObjectMetricSource" ID: "2" has been removed, but is not reserved [op
 CONFLICT: "ObjectMetricSource" ID: "3" has been removed, but is not reserved [operator/v1alpha1/kubernetes.proto]
 CONFLICT: "ObjectMetricSource" ID: "4" has been removed, but is not reserved [operator/v1alpha1/kubernetes.proto]
 CONFLICT: "ObjectMetricSource" ID: "5" has been removed, but is not reserved [operator/v1alpha1/kubernetes.proto]
+CONFLICT: "OutboundTrafficPolicy" field: "egress_proxy" has a different type: Destination, previously istio.networking.v1alpha3.Destination [networking/v1alpha3/sidecar.proto]
+CONFLICT: "OutboundTrafficPolicy" field: "egress_proxy" has a different type: Destination, previously istio.networking.v1beta1.Destination [networking/v1beta1/sidecar.proto]
 CONFLICT: "PodAffinity" field: "preferredDuringSchedulingIgnoredDuringExecution" has been removed, but is not reserved [operator/v1alpha1/kubernetes.proto]
 CONFLICT: "PodAffinity" field: "requiredDuringSchedulingIgnoredDuringExecution" has been removed, but is not reserved [operator/v1alpha1/kubernetes.proto]
 CONFLICT: "PodAffinity" ID: "1" has been removed, but is not reserved [operator/v1alpha1/kubernetes.proto]

--- a/scripts/check-release-locks.md
+++ b/scripts/check-release-locks.md
@@ -8,18 +8,7 @@ previous releases.
 1. First ensure the changes you are making are not breaking backwards
    compatibility with any of these releases.
 
-1. Edit `scripts/check-release-locks.sh` and comment out the line `rm status`.
-
-1. Run `make release-lock-status`.
-
-1. Copy the file `status` over the file
-    `releaselocks/release-<ver>/proto.lock.status`, corresponding to
-   the release version.
-
-1. `scripts/check-release-locks.sh` can be reverted.
-
-1. Include `releaselocks/release-<ver>/proto.lock.status` in your PR
-   and justification for the change.
+1. Run `REFRESH=true scripts/check-release-locks.sh`.
 
 Lock files should not be updated. These should be the `proto.lock`
 result of running `protolock init` in HEAD of the corresponding

--- a/scripts/check-release-locks.sh
+++ b/scripts/check-release-locks.sh
@@ -16,6 +16,7 @@
 
 set -eu
 
+LC_ALL=c
 locks=$(find ./releaselocks -type d -name 'release-*' | sort)
 fail=none
 REFRESH="${REFRESH:-false}"

--- a/scripts/check-release-locks.sh
+++ b/scripts/check-release-locks.sh
@@ -18,12 +18,22 @@ set -eu
 
 locks=$(find ./releaselocks -type d -name 'release-*' | sort)
 fail=none
+REFRESH="${REFRESH:-false}"
 
 for lock in $locks; do
     echo "Testing $lock"
     # shellcheck disable=SC2094
     protolock status --lockdir="${lock}" | sort -fd > status && :
     diff status "${lock}"/proto.lock.status > diff.out || fail=$lock
+    if [[ "${REFRESH}" == "true" ]]; then
+      if [[ $fail != "none" ]]; then
+        echo "Overwriting changes: $fail"
+        cat diff.out
+      fi
+      rm diff.out
+      mv status "${lock}"/proto.lock.status
+      continue
+    fi
     rm status
     if [[ $fail != "none" ]]; then
         echo "Error $fail"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eEou pipefail
+
+# sync.sh keeps pairs of files in sync. Specifically, this is used for multi version protobuf.
+# These files have a unique (comment) header per version, but should have identical proto definitions.
+# To pair two files, The +istio.io/sync-{from,start} tags can be added.
+# For example: In v1beta1/service_entry.proto, we can add `+istio.io/sync-from:networking/v1alpha3/service_entry.proto`.
+# Next, we add `+istio.io/sync-start` to the `v1alpha3/service_entry.proto` file
+
+FROM_TAG="+istio.io/sync-from"
+START_TAG="+istio.io/sync-start"
+
+BIG_NUMBER=100000 # If our files are longer than this we have bigger issues..
+
+find . -name '*.proto'  -not -path "./common-protos/*" -print0 | while read -r -d $'\0' file; do
+  res="$(grep "${FROM_TAG}" "${file}" || true)"
+  if [[ "${res}" != "" ]]; then # We need to sync this file
+    replacement="$(echo "${res}" | cut -d: -f2)"
+    echo "Syncing ${file} from ${replacement}"
+    # First we retain the top section of the file, everything before FROM_TAG
+    header="$(grep "${FROM_TAG}" "${file}" -B "${BIG_NUMBER}")"
+    # Then we copy the bottom section of the replacement file, everything after START_TAG
+    body="$(grep "${START_TAG}" "${replacement}" -A "${BIG_NUMBER}")"
+    # And merge them into a single file
+    echo "${header}" > "${file}"
+    # We skip the first line of the replacement to avoid copying the start tag
+    echo "${body}" | tail -n +2 >> "${file}"
+  fi
+done


### PR DESCRIPTION
This adds a small script to sync v1alpha3 -> v1beta1, to ensure they are
in sync. This defines 2 custom tags which are included in the proto
comments to indicate where to sync from/to.

The resulting generated config is unchanged other than to include the
new tag (which has no impact, it is a comment) and a few trivial
documentation differences between the versions.