### PR TITLE
add disable_clear_route_cache to the internal authn filter config

### DIFF
--- a/envoy/config/filter/http/authn/v2alpha1/config.proto
+++ b/envoy/config/filter/http/authn/v2alpha1/config.proto
@@ -50,4 +50,9 @@ message FilterConfig {
   // When this field is set, the skip_validate_trust_domain field is ignored.
   // This field has no effect for plaintext traffic.
   repeated string allowed_trust_domains = 4;
+
+  // If true, the authn filter will clear the route cache so that the validated
+  // JWT token claims can be used in routing.
+  // This should be set to true for routing based on JWT claims.
+  bool clear_route_cache = 5;
 }

--- a/envoy/config/filter/http/authn/v2alpha1/config.proto
+++ b/envoy/config/filter/http/authn/v2alpha1/config.proto
@@ -51,8 +51,10 @@ message FilterConfig {
   // This field has no effect for plaintext traffic.
   repeated string allowed_trust_domains = 4;
 
-  // If true, the authn filter will clear the route cache so that the validated
+  // By default the authn filter will clear the route cache so that the validated
   // JWT token claims can be used in routing.
-  // This should be set to true for routing based on JWT claims.
-  bool clear_route_cache = 5;
+  // Advanced users can set this to true to disable the behavior if they do not
+  // want the authn filter to clear the route cache for any reasons.
+  // Warning: setting this to true will break the JWT claim based routing.
+  bool disable_clear_route_cache = 5;
 }


### PR DESCRIPTION
Note: This only changes the internal authn filter to allow opt-out of the JWT claim based routing feature (see https://github.com/istio/proxy/pull/3477).

This is NOT end-user facing API and does not change the Istio CRDs at all.

@kyessenov @bianpengyuan @mandarjog @lambdai 