### PR TITLE
docs: Use fromHeaders instead of jwtHeaders field in JWTRule example

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -5640,8 +5640,8 @@ spec:
                         type: string
                       type: array
                     forwardOriginalToken:
-                      description: If set to true, the orginal token will be kept
-                        for the ustream request.
+                      description: If set to true, the original token will be kept
+                        for the upstream request.
                       type: boolean
                     fromHeaders:
                       description: List of header locations from which JWT is expected.

--- a/security/v1beta1/jwt.gen.json
+++ b/security/v1beta1/jwt.gen.json
@@ -15,7 +15,7 @@
             "type": "string"
           },
           "prefix": {
-            "description": "The prefix that should be stripped before decoding the token. For example, for \"Authorization: Bearer \u003ctoken\u003e\", prefix=\"Bearer \" with a space at the end. If the header doesn't have this exact prefix, it is considerred invalid.",
+            "description": "The prefix that should be stripped before decoding the token. For example, for \"Authorization: Bearer \u003ctoken\u003e\", prefix=\"Bearer \" with a space at the end. If the header doesn't have this exact prefix, it is considered invalid.",
             "type": "string"
           }
         }
@@ -44,14 +44,14 @@
             "type": "string"
           },
           "fromHeaders": {
-            "description": "List of header locations from which JWT is expected. For example, below is the location spec if JWT is expected to be found in `x-jwt-assertion` header, and have \"Bearer \" prefix: ``` fromHeaders: - name: x-jwt-assertion prefix: \"Bearer \" ```",
+            "description": "List of header locations from which JWT is expected. For example, below is the location spec if JWT is expected to be found in `x-jwt-assertion` header, and have \"Bearer \" prefix: ```yaml fromHeaders: - name: x-jwt-assertion prefix: \"Bearer \" ```",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/istio.security.v1beta1.JWTHeader"
             }
           },
           "fromParams": {
-            "description": "List of query parameters from which JWT is expected. For example, if JWT is provided via query parameter `my_token` (e.g /path?my_token=\u003cJWT\u003e), the config is: ``` fromParams: - \"my_token\" ```",
+            "description": "List of query parameters from which JWT is expected. For example, if JWT is provided via query parameter `my_token` (e.g /path?my_token=\u003cJWT\u003e), the config is: ```yaml fromParams: - \"my_token\" ```",
             "type": "array",
             "items": {
               "type": "string"
@@ -62,7 +62,7 @@
             "type": "string"
           },
           "forwardOriginalToken": {
-            "description": "If set to true, the orginal token will be kept for the ustream request. Default is false.",
+            "description": "If set to true, the original token will be kept for the upstream request. Default is false.",
             "type": "boolean"
           }
         }

--- a/security/v1beta1/jwt.pb.go
+++ b/security/v1beta1/jwt.pb.go
@@ -32,8 +32,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //
 // Spec for a JWT that is issued by `https://example.com`, with the audience claims must be either
 // `bookstore_android.apps.example.com` or `bookstore_web.apps.example.com`.
-// The token should be presented at the `Authorization` header (default). The Json web key set (JWKS)
-// will be discovered followwing OpenID Connect protocol.
+// The token should be presented at the `Authorization` header (default). The JSON Web Key Set (JWKS)
+// will be discovered following OpenID Connect protocol.
 //
 // ```yaml
 // issuer: https://example.com
@@ -42,13 +42,13 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //   bookstore_web.apps.example.com
 // ```
 //
-// This example specifies token in non-default location (`x-goog-iap-jwt-assertion` header). It also
+// This example specifies a token in a non-default location (`x-goog-iap-jwt-assertion` header). It also
 // defines the URI to fetch JWKS explicitly.
 //
 // ```yaml
 // issuer: https://example.com
 // jwksUri: https://example.com/.secret/jwks.json
-// jwtHeaders:
+// fromHeaders:
 // - "x-goog-iap-jwt-assertion"
 // ```
 type JWTRule struct {
@@ -94,7 +94,8 @@ type JWTRule struct {
 	Jwks string `protobuf:"bytes,10,opt,name=jwks,proto3" json:"jwks,omitempty"`
 	// List of header locations from which JWT is expected. For example, below is the location spec
 	// if JWT is expected to be found in `x-jwt-assertion` header, and have "Bearer " prefix:
-	// ```
+	//
+	// ```yaml
 	//   fromHeaders:
 	//   - name: x-jwt-assertion
 	//     prefix: "Bearer "
@@ -102,7 +103,8 @@ type JWTRule struct {
 	FromHeaders []*JWTHeader `protobuf:"bytes,6,rep,name=from_headers,json=fromHeaders,proto3" json:"from_headers,omitempty"`
 	// List of query parameters from which JWT is expected. For example, if JWT is provided via query
 	// parameter `my_token` (e.g /path?my_token=<JWT>), the config is:
-	// ```
+	//
+	// ```yaml
 	//   fromParams:
 	//   - "my_token"
 	// ```
@@ -111,7 +113,7 @@ type JWTRule struct {
 	// backend. The forwarded data is `base64_encoded(jwt_payload_in_JSON)`. If it is not specified,
 	// the payload will not be emitted.
 	OutputPayloadToHeader string `protobuf:"bytes,8,opt,name=output_payload_to_header,json=outputPayloadToHeader,proto3" json:"output_payload_to_header,omitempty"`
-	// If set to true, the orginal token will be kept for the ustream request. Default is false.
+	// If set to true, the original token will be kept for the upstream request. Default is false.
 	ForwardOriginalToken bool     `protobuf:"varint,9,opt,name=forward_original_token,json=forwardOriginalToken,proto3" json:"forward_original_token,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -213,7 +215,7 @@ type JWTHeader struct {
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// The prefix that should be stripped before decoding the token.
 	// For example, for "Authorization: Bearer <token>", prefix="Bearer " with a space at the end.
-	// If the header doesn't have this exact prefix, it is considerred invalid.
+	// If the header doesn't have this exact prefix, it is considered invalid.
 	Prefix               string   `protobuf:"bytes,2,opt,name=prefix,proto3" json:"prefix,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/security/v1beta1/jwt.pb.html
+++ b/security/v1beta1/jwt.pb.html
@@ -19,8 +19,8 @@ authentication flow.</p>
 
 <p>Spec for a JWT that is issued by <code>https://example.com</code>, with the audience claims must be either
 <code>bookstore_android.apps.example.com</code> or <code>bookstore_web.apps.example.com</code>.
-The token should be presented at the <code>Authorization</code> header (default). The Json web key set (JWKS)
-will be discovered followwing OpenID Connect protocol.</p>
+The token should be presented at the <code>Authorization</code> header (default). The JSON Web Key Set (JWKS)
+will be discovered following OpenID Connect protocol.</p>
 
 <pre><code class="language-yaml">issuer: https://example.com
 audiences:
@@ -28,12 +28,12 @@ audiences:
   bookstore_web.apps.example.com
 </code></pre>
 
-<p>This example specifies token in non-default location (<code>x-goog-iap-jwt-assertion</code> header). It also
+<p>This example specifies a token in a non-default location (<code>x-goog-iap-jwt-assertion</code> header). It also
 defines the URI to fetch JWKS explicitly.</p>
 
 <pre><code class="language-yaml">issuer: https://example.com
 jwksUri: https://example.com/.secret/jwks.json
-jwtHeaders:
+fromHeaders:
 - &quot;x-goog-iap-jwt-assertion&quot;
 </code></pre>
 
@@ -129,7 +129,7 @@ No
 <p>List of header locations from which JWT is expected. For example, below is the location spec
 if JWT is expected to be found in <code>x-jwt-assertion</code> header, and have &ldquo;Bearer &rdquo; prefix:</p>
 
-<pre><code>  fromHeaders:
+<pre><code class="language-yaml">  fromHeaders:
   - name: x-jwt-assertion
     prefix: &quot;Bearer &quot;
 </code></pre>
@@ -146,7 +146,7 @@ No
 <p>List of query parameters from which JWT is expected. For example, if JWT is provided via query
 parameter <code>my_token</code> (e.g /path?my_token=<JWT>), the config is:</p>
 
-<pre><code>  fromParams:
+<pre><code class="language-yaml">  fromParams:
   - &quot;my_token&quot;
 </code></pre>
 
@@ -172,7 +172,7 @@ No
 <td><code>forwardOriginalToken</code></td>
 <td><code>bool</code></td>
 <td>
-<p>If set to true, the orginal token will be kept for the ustream request. Default is false.</p>
+<p>If set to true, the original token will be kept for the upstream request. Default is false.</p>
 
 </td>
 <td>
@@ -213,7 +213,7 @@ Yes
 <td>
 <p>The prefix that should be stripped before decoding the token.
 For example, for &ldquo;Authorization: Bearer <token>&rdquo;, prefix=&ldquo;Bearer &rdquo; with a space at the end.
-If the header doesn&rsquo;t have this exact prefix, it is considerred invalid.</p>
+If the header doesn&rsquo;t have this exact prefix, it is considered invalid.</p>
 
 </td>
 <td>

--- a/security/v1beta1/jwt.proto
+++ b/security/v1beta1/jwt.proto
@@ -34,8 +34,8 @@ option go_package="istio.io/api/security/v1beta1";
 //
 // Spec for a JWT that is issued by `https://example.com`, with the audience claims must be either
 // `bookstore_android.apps.example.com` or `bookstore_web.apps.example.com`.
-// The token should be presented at the `Authorization` header (default). The Json web key set (JWKS)
-// will be discovered followwing OpenID Connect protocol.
+// The token should be presented at the `Authorization` header (default). The JSON Web Key Set (JWKS)
+// will be discovered following OpenID Connect protocol.
 //
 // ```yaml
 // issuer: https://example.com
@@ -44,13 +44,13 @@ option go_package="istio.io/api/security/v1beta1";
 //   bookstore_web.apps.example.com
 // ```
 //
-// This example specifies token in non-default location (`x-goog-iap-jwt-assertion` header). It also
+// This example specifies a token in a non-default location (`x-goog-iap-jwt-assertion` header). It also
 // defines the URI to fetch JWKS explicitly.
 //
 // ```yaml
 // issuer: https://example.com
 // jwksUri: https://example.com/.secret/jwks.json
-// jwtHeaders:
+// fromHeaders:
 // - "x-goog-iap-jwt-assertion"
 // ```
 message JWTRule {
@@ -113,7 +113,8 @@ message JWTRule {
 
   // List of header locations from which JWT is expected. For example, below is the location spec
   // if JWT is expected to be found in `x-jwt-assertion` header, and have "Bearer " prefix:
-  // ```
+  //
+  // ```yaml
   //   fromHeaders:
   //   - name: x-jwt-assertion
   //     prefix: "Bearer "
@@ -122,7 +123,8 @@ message JWTRule {
 
   // List of query parameters from which JWT is expected. For example, if JWT is provided via query
   // parameter `my_token` (e.g /path?my_token=<JWT>), the config is:
-  // ```
+  //
+  // ```yaml
   //   fromParams:
   //   - "my_token"
   // ```
@@ -133,7 +135,7 @@ message JWTRule {
   // the payload will not be emitted.
   string output_payload_to_header = 8;
 
-  // If set to true, the orginal token will be kept for the ustream request. Default is false.
+  // If set to true, the original token will be kept for the upstream request. Default is false.
   bool forward_original_token = 9;
 }
 
@@ -144,6 +146,6 @@ message JWTHeader {
 
   // The prefix that should be stripped before decoding the token.
   // For example, for "Authorization: Bearer <token>", prefix="Bearer " with a space at the end.
-  // If the header doesn't have this exact prefix, it is considerred invalid.
+  // If the header doesn't have this exact prefix, it is considered invalid.
   string prefix = 2;
 }

--- a/security/v1beta1/request_authentication.gen.json
+++ b/security/v1beta1/request_authentication.gen.json
@@ -15,7 +15,7 @@
             "type": "string"
           },
           "prefix": {
-            "description": "The prefix that should be stripped before decoding the token. For example, for \"Authorization: Bearer \u003ctoken\u003e\", prefix=\"Bearer \" with a space at the end. If the header doesn't have this exact prefix, it is considerred invalid.",
+            "description": "The prefix that should be stripped before decoding the token. For example, for \"Authorization: Bearer \u003ctoken\u003e\", prefix=\"Bearer \" with a space at the end. If the header doesn't have this exact prefix, it is considered invalid.",
             "type": "string"
           }
         }
@@ -44,14 +44,14 @@
             "type": "string"
           },
           "fromHeaders": {
-            "description": "List of header locations from which JWT is expected. For example, below is the location spec if JWT is expected to be found in `x-jwt-assertion` header, and have \"Bearer \" prefix: ``` fromHeaders: - name: x-jwt-assertion prefix: \"Bearer \" ```",
+            "description": "List of header locations from which JWT is expected. For example, below is the location spec if JWT is expected to be found in `x-jwt-assertion` header, and have \"Bearer \" prefix: ```yaml fromHeaders: - name: x-jwt-assertion prefix: \"Bearer \" ```",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/istio.security.v1beta1.JWTHeader"
             }
           },
           "fromParams": {
-            "description": "List of query parameters from which JWT is expected. For example, if JWT is provided via query parameter `my_token` (e.g /path?my_token=\u003cJWT\u003e), the config is: ``` fromParams: - \"my_token\" ```",
+            "description": "List of query parameters from which JWT is expected. For example, if JWT is provided via query parameter `my_token` (e.g /path?my_token=\u003cJWT\u003e), the config is: ```yaml fromParams: - \"my_token\" ```",
             "type": "array",
             "items": {
               "type": "string"
@@ -62,7 +62,7 @@
             "type": "string"
           },
           "forwardOriginalToken": {
-            "description": "If set to true, the orginal token will be kept for the ustream request. Default is false.",
+            "description": "If set to true, the original token will be kept for the upstream request. Default is false.",
             "type": "boolean"
           }
         }


### PR DESCRIPTION
This patch fixes the use of jwtHeaders as a field in the example (there is no `jwtHeaders` field). This is tipped by an issue comment here: https://github.com/envoyproxy/envoy/issues/11672#issuecomment-653404950. This also fixes some of the typos.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>