### PR TITLE
Invalid default value for int32 in documentation

### DIFF
--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1498,7 +1498,7 @@ Yes
 <td><code>maxConnections</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of HTTP1 /TCP connections to a destination host. Default 2^31-1.</p>
+<p>Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.</p>
 
 </td>
 <td>
@@ -1549,7 +1549,7 @@ No
 <td><code>http1MaxPendingRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of pending HTTP requests to a destination. Default 2^31-1.</p>
+<p>Maximum number of pending HTTP requests to a destination. Default 2^32-1.</p>
 
 </td>
 <td>
@@ -1560,7 +1560,7 @@ No
 <td><code>http2MaxRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of requests to a backend. Default 2^31-1.</p>
+<p>Maximum number of requests to a backend. Default 2^32-1.</p>
 
 </td>
 <td>
@@ -1585,7 +1585,7 @@ No
 <td><code>int32</code></td>
 <td>
 <p>Maximum number of retries that can be outstanding to all hosts in a
-cluster at a given time. Defaults to 2^31-1.</p>
+cluster at a given time. Defaults to 2^32-1.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1498,7 +1498,7 @@ Yes
 <td><code>maxConnections</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.</p>
+<p>Maximum number of HTTP1 /TCP connections to a destination host. Default 2^31-1.</p>
 
 </td>
 <td>
@@ -1549,7 +1549,7 @@ No
 <td><code>http1MaxPendingRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of pending HTTP requests to a destination. Default 2^32-1.</p>
+<p>Maximum number of pending HTTP requests to a destination. Default 2^31-1.</p>
 
 </td>
 <td>
@@ -1560,7 +1560,7 @@ No
 <td><code>http2MaxRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of requests to a backend. Default 2^32-1.</p>
+<p>Maximum number of requests to a backend. Default 2^31-1.</p>
 
 </td>
 <td>
@@ -1585,7 +1585,7 @@ No
 <td><code>int32</code></td>
 <td>
 <p>Maximum number of retries that can be outstanding to all hosts in a
-cluster at a given time. Defaults to 2^32-1.</p>
+cluster at a given time. Defaults to 2^31-1.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -590,7 +590,7 @@ message ConnectionPoolSettings {
       google.protobuf.Duration interval = 3;
     };
 
-    // Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.
+    // Maximum number of HTTP1 /TCP connections to a destination host. Default 2^31-1.
     int32 max_connections = 1;
 
     // TCP connection timeout. format:
@@ -603,10 +603,10 @@ message ConnectionPoolSettings {
 
   // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
   message HTTPSettings {
-    // Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+    // Maximum number of pending HTTP requests to a destination. Default 2^31-1.
     int32 http1_max_pending_requests = 1;
 
-    // Maximum number of requests to a backend. Default 2^32-1.
+    // Maximum number of requests to a backend. Default 2^31-1.
     int32 http2_max_requests = 2;
 
     // Maximum number of requests per connection to a backend. Setting this
@@ -615,7 +615,7 @@ message ConnectionPoolSettings {
     int32 max_requests_per_connection = 3;
 
     // Maximum number of retries that can be outstanding to all hosts in a
-    // cluster at a given time. Defaults to 2^32-1.
+    // cluster at a given time. Defaults to 2^31-1.
     int32 max_retries = 4;
 
     // The idle timeout for upstream connection pool connections. The idle timeout

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -590,7 +590,7 @@ message ConnectionPoolSettings {
       google.protobuf.Duration interval = 3;
     };
 
-    // Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.
+    // Maximum number of HTTP1 /TCP connections to a destination host. Default 2^31-1.
     int32 max_connections = 1;
 
     // TCP connection timeout. format:
@@ -603,10 +603,10 @@ message ConnectionPoolSettings {
 
   // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
   message HTTPSettings {
-    // Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+    // Maximum number of pending HTTP requests to a destination. Default 2^31-1.
     int32 http1_max_pending_requests = 1;
 
-    // Maximum number of requests to a backend. Default 2^32-1.
+    // Maximum number of requests to a backend. Default 2^31-1.
     int32 http2_max_requests = 2;
 
     // Maximum number of requests per connection to a backend. Setting this
@@ -615,7 +615,7 @@ message ConnectionPoolSettings {
     int32 max_requests_per_connection = 3;
 
     // Maximum number of retries that can be outstanding to all hosts in a
-    // cluster at a given time. Defaults to 2^32-1.
+    // cluster at a given time. Defaults to 2^31-1.
     int32 max_retries = 4;
 
     // The idle timeout for upstream connection pool connections. The idle timeout


### PR DESCRIPTION
The Go int32 max value is 2^31-1 not 2^32-1. 
Putting 2^32-1 in the destination rule configuration leads to an error:
````
DestinationRule: admission webhook "validation.istio.io" denied the request: error decoding configuration: json: cannot unmarshal number 4294967295 into Go value of type int32 
````

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [X] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure