### PR TITLE
Run go1.17.1 mod tidy -go=1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module istio.io/api
 
-go 1.12
+go 1.17
 
 require (
 	github.com/gogo/protobuf v1.3.2
@@ -8,4 +8,22 @@ require (
 	istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
+)
+
+require (
+	github.com/go-logr/logr v0.2.0 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd // indirect
+	golang.org/x/text v0.3.4 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
+	k8s.io/klog/v2 v2.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.0.2 // indirect
 )


### PR DESCRIPTION
See https://tip.golang.org/doc/go1.17#go-command

Updating go.mod to 1.17 requires transitive dependencies to use be specified.

They give us the command `go mod tidy -go=1.17` to have this be generated automatically for you to migrate.