### PR TITLE
update jwt based routing

### DIFF
--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -153,19 +153,16 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //         paths: ["/healthz"]
 // ```
 //
-// - [Experimental] When applied on a Gateway, a special attribute `@request.auth.claims` will be available for using
-// in the header field of the virtual service for JWT claim based routing. The prefix `@` indicates that it is
-// matching with special attributes derived from validated JWT and not with normal HTTP headers.
+// [Experimental] Routing based on internally derived [metadata](https://istio.io/latest/docs/reference/config/security/conditions/)
+// is now supported. A prefix '@' is used to denote a match against internal metadata instead of the headers in the request.
+// Currently this feature is only supported for the following metadata:
 //
-// Currently JWT claims of type string, list of string and nested claims are supported. The claim name itself must
-// not include the `.` character for now.
-// Examples: `@request.auth.claims.admin` refers to the claim "admin" and `@request.auth.claims.group.id` refers to the nested claims "group" and "id".
+// - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
+// currently does not support the `.` character. Examples: `request.auth.claims.name` and `request.auth.claims.group.id`.
 //
-// **Note:** The JWT claim routing and the special attribute is an experimental feature and only supported on Gateways. The
-// request authentication must first be applied on gateways to validate the JWT to make the JWT claims available for routing.
-//
-// The following example creates the request authentication and authorization policy for JWT validation on ingress
-// gateway and virtual service for routing based on the "version" JWT claim.
+// You could use the `request.auth.claims` attribute for JWT claim based routing on gateways. The following example creates
+// the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
+// routing based on the "version" JWT claim.
 //
 // ```yaml
 // apiVersion: security.istio.io/v1beta1

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -205,7 +205,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //   - name: "v2-route"
 //     match:
 //     - headers:
-//         @request.auth.claims.version:
+//         "@request.auth.claims.version":
 //           exact: "v2"
 //     route:
 //     - destination:

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -153,14 +153,13 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //         paths: ["/healthz"]
 // ```
 //
-// - [Experimental] When applied on a Gateway, a special attribute `@request.auth.claims[...]` will be available to be
-// used in the header field in the virtual service route matching. This can be used for routing based on JWT claims.
-// The special prefix `@` indicates that it is matching with attributes derived from validated JWT and not with normal
-// HTTP headers.
+// - [Experimental] When applied on a Gateway, a special attribute `@request.auth.claims` will be available for using
+// in the header field of the virtual service for JWT claim based routing. The prefix `@` indicates that it is
+// matching with special attributes derived from validated JWT and not with normal HTTP headers.
 //
-// JWT claims of type string or list of string are supported and nested claims are also supported.
-// Examples: `@request.auth.claims[admin]` refers to the claim "admin" and
-// `@request.auth.claims[group][id]` refers to the nested claims "group" and "id".
+// Currently JWT claims of type string, list of string and nested claims are supported. The claim name itself must
+// not include the `.` character for now.
+// Examples: `@request.auth.claims.admin` refers to the claim "admin" and `@request.auth.claims.group.id` refers to the nested claims "group" and "id".
 //
 // **Note:** The JWT claim routing and the special attribute is an experimental feature and only supported on Gateways. The
 // request authentication must first be applied on gateways to validate the JWT to make the JWT claims available for routing.
@@ -209,7 +208,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //   - name: "v2-route"
 //     match:
 //     - headers:
-//         @request.auth.claims[version]:
+//         @request.auth.claims.version:
 //           exact: "v2"
 //     route:
 //     - destination:

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -160,7 +160,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
 // currently does not support the `.` character. Examples: `request.auth.claims.name` and `request.auth.claims.group.id`.
 //
-// You could use the `request.auth.claims` attribute for JWT claim based routing on gateways. The following example creates
+// The use of matches against JWT claim metadata is only supported in Gateways. The following example creates
 // the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
 // routing based on the "version" JWT claim.
 //

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -153,13 +153,18 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //         paths: ["/healthz"]
 // ```
 //
-// - When applied on a Gateway, you can also use the special header name `x-jwt-claim` for matching JWT claims in
-// the VirtualService. Claims of type string or list of string are supported and nested claims are also supported using
-// `.` as a separator for claim names. Examples: `x-jwt-claim.admin` matches the claim "admin" and `x-jwt-claim.group.id`
-// matches the nested claims "group" and "id".
+// - [Experimental] When applied on a Gateway, a special variable `{request.auth.claims[...]}` will be available for use in
+// the header matching field in the virtual service. This can be used for routing based on JWT claims. The special variable
+// is enclosed by a `{}` pair indicating that it is matching with attributes derived from validated JWT instead of normal HTTP headers.
 //
-// The following example creates the request authentication and authorization policies for JWT validation on ingress
-// gateway and routes requests based on the "version" claim in the validated JWT.
+// Claims of type string or list of string are supported and nested claims are also supported. Examples:
+// `{request.auth.claims[admin]}` refers to the claim "admin" and `{request.auth.claims[group][id]}` refers to the nested claims "group" and "id".
+//
+// **Note:** This routing is an experimental feature and only supported on Gateways. The request authentication must
+// first be applied on gateways to validate the JWT to make the JWT claims available for routing.
+//
+// The following example creates the request authentication and authorization policy for JWT validation on ingress
+// gateway and virtual service for routing based on the "version" JWT claim.
 //
 // ```yaml
 // apiVersion: security.istio.io/v1beta1
@@ -202,7 +207,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //   - name: "v2-route"
 //     match:
 //     - headers:
-//         x-jwt-claim.version:
+//         {request.auth.claims[version]}:
 //           exact: "v2"
 //     route:
 //     - destination:
@@ -214,8 +219,6 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //         host: foo.prod.svc.cluster.local
 //         subset: v1
 // ```
-//
-// **Note:** This routing is only supported on Gateways and proper request authentication must first be applied to validate the JWT.
 //
 // <!-- crd generation tags
 // +cue-gen:RequestAuthentication:groupName:security.istio.io

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -153,16 +153,16 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //         paths: ["/healthz"]
 // ```
 //
-// [Experimental] Routing based on internally derived [metadata](https://istio.io/latest/docs/reference/config/security/conditions/)
+// [Experimental] Routing based on derived [metadata](https://istio.io/latest/docs/reference/config/security/conditions/)
 // is now supported. A prefix '@' is used to denote a match against internal metadata instead of the headers in the request.
 // Currently this feature is only supported for the following metadata:
 //
 // - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
-// currently does not support the `.` character. Examples: `request.auth.claims.name` and `request.auth.claims.group.id`.
+// currently does not support the `.` character. Examples: `request.auth.claims.sub` and `request.auth.claims.name.givenName`.
 //
 // The use of matches against JWT claim metadata is only supported in Gateways. The following example creates
 // the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
-// routing based on the "version" JWT claim.
+// routing based on the "sub" JWT claim.
 //
 // ```yaml
 // apiVersion: security.istio.io/v1beta1
@@ -205,8 +205,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //   - name: "v2-route"
 //     match:
 //     - headers:
-//         "@request.auth.claims.version":
-//           exact: "v2"
+//         "@request.auth.claims.sub":
+//           exact: "dev"
 //     route:
 //     - destination:
 //         host: foo.prod.svc.cluster.local

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -160,9 +160,11 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
 // currently does not support the `.` character. Examples: `request.auth.claims.sub` and `request.auth.claims.name.givenName`.
 //
-// The use of matches against JWT claim metadata is only supported in Gateways. The following example creates
-// the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
-// routing based on the "sub" JWT claim.
+// The use of matches against JWT claim metadata is only supported in Gateways. The following example shows:
+//
+// - RequestAuthentication to decode and validate a JWT. This also makes the `@request.auth.claims` available for use in the VirtualService.
+// - AuthorizationPolicy to check for valid principals in the request. This makes the JWT required for the request.
+// - VirtualService to route the request based on the "sub" claim.
 //
 // ```yaml
 // apiVersion: security.istio.io/v1beta1
@@ -175,7 +177,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //    matchLabels:
 //      app: istio-ingressgateway
 //   jwtRules:
-//   - issuer: "issuer-foo"
+//   - issuer: "example.com"
 //     jwksUri: https://example.com/.well-known/jwks.json
 // ---
 // apiVersion: security.istio.io/v1beta1
@@ -202,7 +204,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //   gateways:
 //   - istio-ingressgateway
 //   http:
-//   - name: "v2-route"
+//   - name: "v2"
 //     match:
 //     - headers:
 //         "@request.auth.claims.sub":
@@ -211,7 +213,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //     - destination:
 //         host: foo.prod.svc.cluster.local
 //         subset: v2
-//   - name: "default-route"
+//   - name: "default"
 //     route:
 //     - destination:
 //         host: foo.prod.svc.cluster.local

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -153,15 +153,17 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //         paths: ["/healthz"]
 // ```
 //
-// - [Experimental] When applied on a Gateway, a special variable `{request.auth.claims[...]}` will be available for use in
-// the header matching field in the virtual service. This can be used for routing based on JWT claims. The special variable
-// is enclosed by a `{}` pair indicating that it is matching with attributes derived from validated JWT instead of normal HTTP headers.
+// - [Experimental] When applied on a Gateway, a special attribute `@request.auth.claims[...]` will be available to be
+// used in the header field in the virtual service route matching. This can be used for routing based on JWT claims.
+// The special prefix `@` indicates that it is matching with attributes derived from validated JWT and not with normal
+// HTTP headers.
 //
-// Claims of type string or list of string are supported and nested claims are also supported. Examples:
-// `{request.auth.claims[admin]}` refers to the claim "admin" and `{request.auth.claims[group][id]}` refers to the nested claims "group" and "id".
+// JWT claims of type string or list of string are supported and nested claims are also supported.
+// Examples: `@request.auth.claims[admin]` refers to the claim "admin" and
+// `@request.auth.claims[group][id]` refers to the nested claims "group" and "id".
 //
-// **Note:** This routing is an experimental feature and only supported on Gateways. The request authentication must
-// first be applied on gateways to validate the JWT to make the JWT claims available for routing.
+// **Note:** The JWT claim routing and the special attribute is an experimental feature and only supported on Gateways. The
+// request authentication must first be applied on gateways to validate the JWT to make the JWT claims available for routing.
 //
 // The following example creates the request authentication and authorization policy for JWT validation on ingress
 // gateway and virtual service for routing based on the "version" JWT claim.
@@ -207,7 +209,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //   - name: "v2-route"
 //     match:
 //     - headers:
-//         {request.auth.claims[version]}:
+//         @request.auth.claims[version]:
 //           exact: "v2"
 //     route:
 //     - destination:

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -197,7 +197,7 @@ spec:
   - name: &quot;v2-route&quot;
     match:
     - headers:
-        @request.auth.claims.version:
+        &quot;@request.auth.claims.version&quot;:
           exact: &quot;v2&quot;
     route:
     - destination:

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -145,15 +145,14 @@ spec:
 </code></pre>
 
 <ul>
-<li>[Experimental] When applied on a Gateway, a special attribute <code>@request.auth.claims[...]</code> will be available to be
-used in the header field in the virtual service route matching. This can be used for routing based on JWT claims.
-The special prefix <code>@</code> indicates that it is matching with attributes derived from validated JWT and not with normal
-HTTP headers.</li>
+<li>[Experimental] When applied on a Gateway, a special attribute <code>@request.auth.claims</code> will be available for using
+in the header field of the virtual service for JWT claim based routing. The prefix <code>@</code> indicates that it is
+matching with special attributes derived from validated JWT and not with normal HTTP headers.</li>
 </ul>
 
-<p>JWT claims of type string or list of string are supported and nested claims are also supported.
-Examples: <code>@request.auth.claims[admin]</code> refers to the claim &ldquo;admin&rdquo; and
-<code>@request.auth.claims*group*</code> refers to the nested claims &ldquo;group&rdquo; and &ldquo;id&rdquo;.</p>
+<p>Currently JWT claims of type string, list of string and nested claims are supported. The claim name itself must
+not include the <code>.</code> character for now.
+Examples: <code>@request.auth.claims.admin</code> refers to the claim &ldquo;admin&rdquo; and <code>@request.auth.claims.group.id</code> refers to the nested claims &ldquo;group&rdquo; and &ldquo;id&rdquo;.</p>
 
 <p><strong>Note:</strong> The JWT claim routing and the special attribute is an experimental feature and only supported on Gateways. The
 request authentication must first be applied on gateways to validate the JWT to make the JWT claims available for routing.</p>
@@ -201,7 +200,7 @@ spec:
   - name: &quot;v2-route&quot;
     match:
     - headers:
-        @request.auth.claims[version]:
+        @request.auth.claims.version:
           exact: &quot;v2&quot;
     route:
     - destination:

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -144,21 +144,18 @@ spec:
         paths: [&quot;/healthz&quot;]
 </code></pre>
 
+<p>[Experimental] Routing based on internally derived <a href="https://istio.io/latest/docs/reference/config/security/conditions/">metadata</a>
+is now supported. A prefix &lsquo;@&rsquo; is used to denote a match against internal metadata instead of the headers in the request.
+Currently this feature is only supported for the following metadata:</p>
+
 <ul>
-<li>[Experimental] When applied on a Gateway, a special attribute <code>@request.auth.claims</code> will be available for using
-in the header field of the virtual service for JWT claim based routing. The prefix <code>@</code> indicates that it is
-matching with special attributes derived from validated JWT and not with normal HTTP headers.</li>
+<li><code>request.auth.claims.{claim-name}[.{sub-claim}]*</code> which are extracted from validated JWT tokens. The claim name
+currently does not support the <code>.</code> character. Examples: <code>request.auth.claims.name</code> and <code>request.auth.claims.group.id</code>.</li>
 </ul>
 
-<p>Currently JWT claims of type string, list of string and nested claims are supported. The claim name itself must
-not include the <code>.</code> character for now.
-Examples: <code>@request.auth.claims.admin</code> refers to the claim &ldquo;admin&rdquo; and <code>@request.auth.claims.group.id</code> refers to the nested claims &ldquo;group&rdquo; and &ldquo;id&rdquo;.</p>
-
-<p><strong>Note:</strong> The JWT claim routing and the special attribute is an experimental feature and only supported on Gateways. The
-request authentication must first be applied on gateways to validate the JWT to make the JWT claims available for routing.</p>
-
-<p>The following example creates the request authentication and authorization policy for JWT validation on ingress
-gateway and virtual service for routing based on the &ldquo;version&rdquo; JWT claim.</p>
+<p>You could use the <code>request.auth.claims</code> attribute for JWT claim based routing on gateways. The following example creates
+the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
+routing based on the &ldquo;version&rdquo; JWT claim.</p>
 
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -153,9 +153,13 @@ Currently this feature is only supported for the following metadata:</p>
 currently does not support the <code>.</code> character. Examples: <code>request.auth.claims.sub</code> and <code>request.auth.claims.name.givenName</code>.</li>
 </ul>
 
-<p>The use of matches against JWT claim metadata is only supported in Gateways. The following example creates
-the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
-routing based on the &ldquo;sub&rdquo; JWT claim.</p>
+<p>The use of matches against JWT claim metadata is only supported in Gateways. The following example shows:</p>
+
+<ul>
+<li>RequestAuthentication to decode and validate a JWT. This also makes the <code>@request.auth.claims</code> available for use in the VirtualService.</li>
+<li>AuthorizationPolicy to check for valid principals in the request. This makes the JWT required for the request.</li>
+<li>VirtualService to route the request based on the &ldquo;sub&rdquo; claim.</li>
+</ul>
 
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
@@ -167,7 +171,7 @@ spec:
    matchLabels:
      app: istio-ingressgateway
   jwtRules:
-  - issuer: &quot;issuer-foo&quot;
+  - issuer: &quot;example.com&quot;
     jwksUri: https://example.com/.well-known/jwks.json
 ---
 apiVersion: security.istio.io/v1beta1
@@ -194,7 +198,7 @@ spec:
   gateways:
   - istio-ingressgateway
   http:
-  - name: &quot;v2-route&quot;
+  - name: &quot;v2&quot;
     match:
     - headers:
         &quot;@request.auth.claims.sub&quot;:
@@ -203,7 +207,7 @@ spec:
     - destination:
         host: foo.prod.svc.cluster.local
         subset: v2
-  - name: &quot;default-route&quot;
+  - name: &quot;default&quot;
     route:
     - destination:
         host: foo.prod.svc.cluster.local

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -145,14 +145,19 @@ spec:
 </code></pre>
 
 <ul>
-<li>When applied on a Gateway, you can also use the special header name <code>x-jwt-claim</code> for matching JWT claims in
-the VirtualService. Claims of type string or list of string are supported and nested claims are also supported using
-<code>.</code> as a separator for claim names. Examples: <code>x-jwt-claim.admin</code> matches the claim &ldquo;admin&rdquo; and <code>x-jwt-claim.group.id</code>
-matches the nested claims &ldquo;group&rdquo; and &ldquo;id&rdquo;.</li>
+<li>[Experimental] When applied on a Gateway, a special variable <code>{request.auth.claims[...]}</code> will be available for use in
+the header matching field in the virtual service. This can be used for routing based on JWT claims. The special variable
+is enclosed by a <code>{}</code> pair indicating that it is matching with attributes derived from validated JWT instead of normal HTTP headers.</li>
 </ul>
 
-<p>The following example creates the request authentication and authorization policies for JWT validation on ingress
-gateway and routes requests based on the &ldquo;version&rdquo; claim in the validated JWT.</p>
+<p>Claims of type string or list of string are supported and nested claims are also supported. Examples:
+<code>{request.auth.claims[admin]}</code> refers to the claim &ldquo;admin&rdquo; and <code>{request.auth.claims*group*}</code> refers to the nested claims &ldquo;group&rdquo; and &ldquo;id&rdquo;.</p>
+
+<p><strong>Note:</strong> This routing is an experimental feature and only supported on Gateways. The request authentication must
+first be applied on gateways to validate the JWT to make the JWT claims available for routing.</p>
+
+<p>The following example creates the request authentication and authorization policy for JWT validation on ingress
+gateway and virtual service for routing based on the &ldquo;version&rdquo; JWT claim.</p>
 
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
@@ -194,7 +199,7 @@ spec:
   - name: &quot;v2-route&quot;
     match:
     - headers:
-        x-jwt-claim.version:
+        {request.auth.claims[version]}:
           exact: &quot;v2&quot;
     route:
     - destination:
@@ -206,8 +211,6 @@ spec:
         host: foo.prod.svc.cluster.local
         subset: v1
 </code></pre>
-
-<p><strong>Note:</strong> This routing is only supported on Gateways and proper request authentication must first be applied to validate the JWT.</p>
 
 <table class="message-fields">
 <thead>

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -144,18 +144,18 @@ spec:
         paths: [&quot;/healthz&quot;]
 </code></pre>
 
-<p>[Experimental] Routing based on internally derived <a href="https://istio.io/latest/docs/reference/config/security/conditions/">metadata</a>
+<p>[Experimental] Routing based on derived <a href="https://istio.io/latest/docs/reference/config/security/conditions/">metadata</a>
 is now supported. A prefix &lsquo;@&rsquo; is used to denote a match against internal metadata instead of the headers in the request.
 Currently this feature is only supported for the following metadata:</p>
 
 <ul>
 <li><code>request.auth.claims.{claim-name}[.{sub-claim}]*</code> which are extracted from validated JWT tokens. The claim name
-currently does not support the <code>.</code> character. Examples: <code>request.auth.claims.name</code> and <code>request.auth.claims.group.id</code>.</li>
+currently does not support the <code>.</code> character. Examples: <code>request.auth.claims.sub</code> and <code>request.auth.claims.name.givenName</code>.</li>
 </ul>
 
 <p>The use of matches against JWT claim metadata is only supported in Gateways. The following example creates
 the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
-routing based on the &ldquo;version&rdquo; JWT claim.</p>
+routing based on the &ldquo;sub&rdquo; JWT claim.</p>
 
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
@@ -197,8 +197,8 @@ spec:
   - name: &quot;v2-route&quot;
     match:
     - headers:
-        &quot;@request.auth.claims.version&quot;:
-          exact: &quot;v2&quot;
+        &quot;@request.auth.claims.sub&quot;:
+          exact: &quot;dev&quot;
     route:
     - destination:
         host: foo.prod.svc.cluster.local

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -153,7 +153,7 @@ Currently this feature is only supported for the following metadata:</p>
 currently does not support the <code>.</code> character. Examples: <code>request.auth.claims.name</code> and <code>request.auth.claims.group.id</code>.</li>
 </ul>
 
-<p>You could use the <code>request.auth.claims</code> attribute for JWT claim based routing on gateways. The following example creates
+<p>The use of matches against JWT claim metadata is only supported in Gateways. The following example creates
 the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
 routing based on the &ldquo;version&rdquo; JWT claim.</p>
 

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -145,16 +145,18 @@ spec:
 </code></pre>
 
 <ul>
-<li>[Experimental] When applied on a Gateway, a special variable <code>{request.auth.claims[...]}</code> will be available for use in
-the header matching field in the virtual service. This can be used for routing based on JWT claims. The special variable
-is enclosed by a <code>{}</code> pair indicating that it is matching with attributes derived from validated JWT instead of normal HTTP headers.</li>
+<li>[Experimental] When applied on a Gateway, a special attribute <code>@request.auth.claims[...]</code> will be available to be
+used in the header field in the virtual service route matching. This can be used for routing based on JWT claims.
+The special prefix <code>@</code> indicates that it is matching with attributes derived from validated JWT and not with normal
+HTTP headers.</li>
 </ul>
 
-<p>Claims of type string or list of string are supported and nested claims are also supported. Examples:
-<code>{request.auth.claims[admin]}</code> refers to the claim &ldquo;admin&rdquo; and <code>{request.auth.claims*group*}</code> refers to the nested claims &ldquo;group&rdquo; and &ldquo;id&rdquo;.</p>
+<p>JWT claims of type string or list of string are supported and nested claims are also supported.
+Examples: <code>@request.auth.claims[admin]</code> refers to the claim &ldquo;admin&rdquo; and
+<code>@request.auth.claims*group*</code> refers to the nested claims &ldquo;group&rdquo; and &ldquo;id&rdquo;.</p>
 
-<p><strong>Note:</strong> This routing is an experimental feature and only supported on Gateways. The request authentication must
-first be applied on gateways to validate the JWT to make the JWT claims available for routing.</p>
+<p><strong>Note:</strong> The JWT claim routing and the special attribute is an experimental feature and only supported on Gateways. The
+request authentication must first be applied on gateways to validate the JWT to make the JWT claims available for routing.</p>
 
 <p>The following example creates the request authentication and authorization policy for JWT validation on ingress
 gateway and virtual service for routing based on the &ldquo;version&rdquo; JWT claim.</p>
@@ -199,7 +201,7 @@ spec:
   - name: &quot;v2-route&quot;
     match:
     - headers:
-        {request.auth.claims[version]}:
+        @request.auth.claims[version]:
           exact: &quot;v2&quot;
     route:
     - destination:

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -208,7 +208,7 @@ option go_package="istio.io/api/security/v1beta1";
 //   - name: "v2-route"
 //     match:
 //     - headers:
-//         @request.auth.claims.version:
+//         "@request.auth.claims.version":
 //           exact: "v2"
 //     route:
 //     - destination:

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -156,19 +156,16 @@ option go_package="istio.io/api/security/v1beta1";
 //         paths: ["/healthz"]
 // ```
 //
-// - [Experimental] When applied on a Gateway, a special attribute `@request.auth.claims` will be available for using
-// in the header field of the virtual service for JWT claim based routing. The prefix `@` indicates that it is
-// matching with special attributes derived from validated JWT and not with normal HTTP headers.
+// [Experimental] Routing based on internally derived [metadata](https://istio.io/latest/docs/reference/config/security/conditions/)
+// is now supported. A prefix '@' is used to denote a match against internal metadata instead of the headers in the request.
+// Currently this feature is only supported for the following metadata:
 //
-// Currently JWT claims of type string, list of string and nested claims are supported. The claim name itself must
-// not include the `.` character for now.
-// Examples: `@request.auth.claims.admin` refers to the claim "admin" and `@request.auth.claims.group.id` refers to the nested claims "group" and "id".
+// - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
+// currently does not support the `.` character. Examples: `request.auth.claims.name` and `request.auth.claims.group.id`.
 //
-// **Note:** The JWT claim routing and the special attribute is an experimental feature and only supported on Gateways. The
-// request authentication must first be applied on gateways to validate the JWT to make the JWT claims available for routing.
-//
-// The following example creates the request authentication and authorization policy for JWT validation on ingress
-// gateway and virtual service for routing based on the "version" JWT claim.
+// You could use the `request.auth.claims` attribute for JWT claim based routing on gateways. The following example creates
+// the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
+// routing based on the "version" JWT claim.
 //
 // ```yaml
 // apiVersion: security.istio.io/v1beta1

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -156,14 +156,13 @@ option go_package="istio.io/api/security/v1beta1";
 //         paths: ["/healthz"]
 // ```
 //
-// - [Experimental] When applied on a Gateway, a special attribute `@request.auth.claims[...]` will be available to be
-// used in the header field in the virtual service route matching. This can be used for routing based on JWT claims.
-// The special prefix `@` indicates that it is matching with attributes derived from validated JWT and not with normal
-// HTTP headers.
+// - [Experimental] When applied on a Gateway, a special attribute `@request.auth.claims` will be available for using
+// in the header field of the virtual service for JWT claim based routing. The prefix `@` indicates that it is
+// matching with special attributes derived from validated JWT and not with normal HTTP headers.
 //
-// JWT claims of type string or list of string are supported and nested claims are also supported.
-// Examples: `@request.auth.claims[admin]` refers to the claim "admin" and
-// `@request.auth.claims[group][id]` refers to the nested claims "group" and "id".
+// Currently JWT claims of type string, list of string and nested claims are supported. The claim name itself must
+// not include the `.` character for now.
+// Examples: `@request.auth.claims.admin` refers to the claim "admin" and `@request.auth.claims.group.id` refers to the nested claims "group" and "id".
 //
 // **Note:** The JWT claim routing and the special attribute is an experimental feature and only supported on Gateways. The
 // request authentication must first be applied on gateways to validate the JWT to make the JWT claims available for routing.
@@ -212,7 +211,7 @@ option go_package="istio.io/api/security/v1beta1";
 //   - name: "v2-route"
 //     match:
 //     - headers:
-//         @request.auth.claims[version]:
+//         @request.auth.claims.version:
 //           exact: "v2"
 //     route:
 //     - destination:

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -156,15 +156,17 @@ option go_package="istio.io/api/security/v1beta1";
 //         paths: ["/healthz"]
 // ```
 //
-// - [Experimental] When applied on a Gateway, a special variable `{request.auth.claims[...]}` will be available for use in
-// the header matching field in the virtual service. This can be used for routing based on JWT claims. The special variable
-// is enclosed by a `{}` pair indicating that it is matching with attributes derived from validated JWT instead of normal HTTP headers.
+// - [Experimental] When applied on a Gateway, a special attribute `@request.auth.claims[...]` will be available to be
+// used in the header field in the virtual service route matching. This can be used for routing based on JWT claims.
+// The special prefix `@` indicates that it is matching with attributes derived from validated JWT and not with normal
+// HTTP headers.
 //
-// Claims of type string or list of string are supported and nested claims are also supported. Examples:
-// `{request.auth.claims[admin]}` refers to the claim "admin" and `{request.auth.claims[group][id]}` refers to the nested claims "group" and "id".
+// JWT claims of type string or list of string are supported and nested claims are also supported.
+// Examples: `@request.auth.claims[admin]` refers to the claim "admin" and
+// `@request.auth.claims[group][id]` refers to the nested claims "group" and "id".
 //
-// **Note:** This routing is an experimental feature and only supported on Gateways. The request authentication must
-// first be applied on gateways to validate the JWT to make the JWT claims available for routing.
+// **Note:** The JWT claim routing and the special attribute is an experimental feature and only supported on Gateways. The
+// request authentication must first be applied on gateways to validate the JWT to make the JWT claims available for routing.
 //
 // The following example creates the request authentication and authorization policy for JWT validation on ingress
 // gateway and virtual service for routing based on the "version" JWT claim.
@@ -210,7 +212,7 @@ option go_package="istio.io/api/security/v1beta1";
 //   - name: "v2-route"
 //     match:
 //     - headers:
-//         {request.auth.claims[version]}:
+//         @request.auth.claims[version]:
 //           exact: "v2"
 //     route:
 //     - destination:

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -163,7 +163,7 @@ option go_package="istio.io/api/security/v1beta1";
 // - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
 // currently does not support the `.` character. Examples: `request.auth.claims.name` and `request.auth.claims.group.id`.
 //
-// You could use the `request.auth.claims` attribute for JWT claim based routing on gateways. The following example creates
+// The use of matches against JWT claim metadata is only supported in Gateways. The following example creates
 // the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
 // routing based on the "version" JWT claim.
 //

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -163,9 +163,11 @@ option go_package="istio.io/api/security/v1beta1";
 // - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
 // currently does not support the `.` character. Examples: `request.auth.claims.sub` and `request.auth.claims.name.givenName`.
 //
-// The use of matches against JWT claim metadata is only supported in Gateways. The following example creates
-// the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
-// routing based on the "sub" JWT claim.
+// The use of matches against JWT claim metadata is only supported in Gateways. The following example shows:
+//
+// - RequestAuthentication to decode and validate a JWT. This also makes the `@request.auth.claims` available for use in the VirtualService.
+// - AuthorizationPolicy to check for valid principals in the request. This makes the JWT required for the request.
+// - VirtualService to route the request based on the "sub" claim.
 //
 // ```yaml
 // apiVersion: security.istio.io/v1beta1
@@ -178,7 +180,7 @@ option go_package="istio.io/api/security/v1beta1";
 //    matchLabels:
 //      app: istio-ingressgateway
 //   jwtRules:
-//   - issuer: "issuer-foo"
+//   - issuer: "example.com"
 //     jwksUri: https://example.com/.well-known/jwks.json
 // ---
 // apiVersion: security.istio.io/v1beta1
@@ -205,7 +207,7 @@ option go_package="istio.io/api/security/v1beta1";
 //   gateways:
 //   - istio-ingressgateway
 //   http:
-//   - name: "v2-route"
+//   - name: "v2"
 //     match:
 //     - headers:
 //         "@request.auth.claims.sub":
@@ -214,7 +216,7 @@ option go_package="istio.io/api/security/v1beta1";
 //     - destination:
 //         host: foo.prod.svc.cluster.local
 //         subset: v2
-//   - name: "default-route"
+//   - name: "default"
 //     route:
 //     - destination:
 //         host: foo.prod.svc.cluster.local

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -156,13 +156,18 @@ option go_package="istio.io/api/security/v1beta1";
 //         paths: ["/healthz"]
 // ```
 //
-// - When applied on a Gateway, you can also use the special header name `x-jwt-claim` for matching JWT claims in
-// the VirtualService. Claims of type string or list of string are supported and nested claims are also supported using
-// `.` as a separator for claim names. Examples: `x-jwt-claim.admin` matches the claim "admin" and `x-jwt-claim.group.id`
-// matches the nested claims "group" and "id".
+// - [Experimental] When applied on a Gateway, a special variable `{request.auth.claims[...]}` will be available for use in
+// the header matching field in the virtual service. This can be used for routing based on JWT claims. The special variable
+// is enclosed by a `{}` pair indicating that it is matching with attributes derived from validated JWT instead of normal HTTP headers.
 //
-// The following example creates the request authentication and authorization policies for JWT validation on ingress
-// gateway and routes requests based on the "version" claim in the validated JWT.
+// Claims of type string or list of string are supported and nested claims are also supported. Examples:
+// `{request.auth.claims[admin]}` refers to the claim "admin" and `{request.auth.claims[group][id]}` refers to the nested claims "group" and "id".
+//
+// **Note:** This routing is an experimental feature and only supported on Gateways. The request authentication must
+// first be applied on gateways to validate the JWT to make the JWT claims available for routing.
+//
+// The following example creates the request authentication and authorization policy for JWT validation on ingress
+// gateway and virtual service for routing based on the "version" JWT claim.
 //
 // ```yaml
 // apiVersion: security.istio.io/v1beta1
@@ -205,7 +210,7 @@ option go_package="istio.io/api/security/v1beta1";
 //   - name: "v2-route"
 //     match:
 //     - headers:
-//         x-jwt-claim.version:
+//         {request.auth.claims[version]}:
 //           exact: "v2"
 //     route:
 //     - destination:
@@ -217,8 +222,6 @@ option go_package="istio.io/api/security/v1beta1";
 //         host: foo.prod.svc.cluster.local
 //         subset: v1
 // ```
-//
-// **Note:** This routing is only supported on Gateways and proper request authentication must first be applied to validate the JWT.
 //
 // <!-- crd generation tags
 // +cue-gen:RequestAuthentication:groupName:security.istio.io

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -156,16 +156,16 @@ option go_package="istio.io/api/security/v1beta1";
 //         paths: ["/healthz"]
 // ```
 //
-// [Experimental] Routing based on internally derived [metadata](https://istio.io/latest/docs/reference/config/security/conditions/)
+// [Experimental] Routing based on derived [metadata](https://istio.io/latest/docs/reference/config/security/conditions/)
 // is now supported. A prefix '@' is used to denote a match against internal metadata instead of the headers in the request.
 // Currently this feature is only supported for the following metadata:
 //
 // - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
-// currently does not support the `.` character. Examples: `request.auth.claims.name` and `request.auth.claims.group.id`.
+// currently does not support the `.` character. Examples: `request.auth.claims.sub` and `request.auth.claims.name.givenName`.
 //
 // The use of matches against JWT claim metadata is only supported in Gateways. The following example creates
 // the request authentication and authorization policy for JWT validation on ingress gateway and virtual service for
-// routing based on the "version" JWT claim.
+// routing based on the "sub" JWT claim.
 //
 // ```yaml
 // apiVersion: security.istio.io/v1beta1
@@ -208,8 +208,8 @@ option go_package="istio.io/api/security/v1beta1";
 //   - name: "v2-route"
 //     match:
 //     - headers:
-//         "@request.auth.claims.version":
-//           exact: "v2"
+//         "@request.auth.claims.sub":
+//           exact: "dev"
 //     route:
 //     - destination:
 //         host: foo.prod.svc.cluster.local


### PR DESCRIPTION
This PR changes the format of the special header used for JWT claim based routing in virtual service from `x-jwt-claim...` to `@request.auth.claims...`:

1. The use of the `@` makes the header name drastically different from a normal real HTTP header. This change is made to:

    - Prevent possible customer confusion of the special header name with real HTTP headers, and any security and usability issues caused by the confusion.

    - Prevent potential collision with existing values because a customer might already be using the same header in the virtual service.

    The `@` makes it invalid for HTTP header which is intentionally to make sure it is never used by customer before and will never collide with existing HTTP headers. For example, Envoy and google.com will simply reject the header using `@` with `400` code. This also makes sure the user will not confuse it with real HTTP headers.

2. The use of the `request.auth.claims` is to align with the existing attribute (`request.auth.claims`) in the authorization policy for JWT claim matching (https://istio.io/latest/docs/reference/config/security/conditions/#supported-conditions). By reusing the same attribute (under the hood they are actually also sharing the same matching code), this helps to reduce the user learning efforts for understanding and adopting the feature as they might be already familiar with the name. And this makes our API consistent across different places.

@howardjohn @costinm @louiscryan PTAL, thanks.
