### PR TITLE
Align ProxyConfig merge semantics with other Istio resources

### DIFF
--- a/networking/v1beta1/proxy_config.proto
+++ b/networking/v1beta1/proxy_config.proto
@@ -30,6 +30,12 @@ import "type/v1beta1/selector.proto";
 //
 // **NOTE**: fields in ProxyConfig are not dynamically configured - changes will require restart of workloads to take effect.
 //
+// For any namespace, including the root configuration namespace, it is only valid
+// to have a single workload selector-less `ProxyConfig` resource.
+//
+// For resources with a workload selector, it is only valid to have one resource selecting
+// any given workload.
+//
 // For mesh level configuration, put the resource in the root configuration namespace for
 // your Istio installation *without* a workload selector:
 //
@@ -55,9 +61,6 @@ import "type/v1beta1/selector.proto";
 //   concurrency: 0
 // ```
 //
-// If multiple `ProxyConfig` CRs without a `selector` field exist in the same namespace the CRs will be merged together
-// with no guaranteed field precedence.
-//
 // For workload level configuration, set the `selector` field on the `ProxyConfig` resource:
 //
 // ```yaml
@@ -72,9 +75,6 @@ import "type/v1beta1/selector.proto";
 //       app: ratings
 //   concurrency: 0
 // ```
-//
-// If multiple workload level `ProxyConfig` CRs select the same workload the resources will be merged together
-// with no guaranteed field precedence.
 //
 // If a `ProxyConfig` CR is defined that matches a workload it will merge with its `proxy.istio.io/config` annotation if present,
 // with the CR taking precedence over the annotation for overlapping fields. Similarly, if a mesh wide `ProxyConfig` CR is defined and


### PR DESCRIPTION
Previously, the defined merge semantics with multiple PC CRs in the same namespace or matching the same workload was to merge with no guaranteed precedence. This does not align with other Istio CRs: usually, we document that it's only valid to have 1 workload / namespace and then take the oldest.