### PR TITLE
Change dr MaxConnection data type from int32 to uint32

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -211,7 +211,7 @@ spec:
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
                                     to a destination host.
-                                  format: int32
+                                  format: int64
                                   type: integer
                                 tcpKeepalive:
                                   description: If set then set SO_KEEPALIVE on the
@@ -456,7 +456,7 @@ spec:
                                       maxConnections:
                                         description: Maximum number of HTTP1 /TCP
                                           connections to a destination host.
-                                        format: int32
+                                        format: int64
                                         type: integer
                                       tcpKeepalive:
                                         description: If set then set SO_KEEPALIVE
@@ -775,7 +775,7 @@ spec:
                           maxConnections:
                             description: Maximum number of HTTP1 /TCP connections
                               to a destination host.
-                            format: int32
+                            format: int64
                             type: integer
                           tcpKeepalive:
                             description: If set then set SO_KEEPALIVE on the socket
@@ -1014,7 +1014,7 @@ spec:
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
                                     to a destination host.
-                                  format: int32
+                                  format: int64
                                   type: integer
                                 tcpKeepalive:
                                   description: If set then set SO_KEEPALIVE on the
@@ -1378,7 +1378,7 @@ spec:
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
                                     to a destination host.
-                                  format: int32
+                                  format: int64
                                   type: integer
                                 tcpKeepalive:
                                   description: If set then set SO_KEEPALIVE on the
@@ -1623,7 +1623,7 @@ spec:
                                       maxConnections:
                                         description: Maximum number of HTTP1 /TCP
                                           connections to a destination host.
-                                        format: int32
+                                        format: int64
                                         type: integer
                                       tcpKeepalive:
                                         description: If set then set SO_KEEPALIVE
@@ -1942,7 +1942,7 @@ spec:
                           maxConnections:
                             description: Maximum number of HTTP1 /TCP connections
                               to a destination host.
-                            format: int32
+                            format: int64
                             type: integer
                           tcpKeepalive:
                             description: If set then set SO_KEEPALIVE on the socket
@@ -2181,7 +2181,7 @@ spec:
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
                                     to a destination host.
-                                  format: int32
+                                  format: int64
                                   type: integer
                                 tcpKeepalive:
                                   description: If set then set SO_KEEPALIVE on the

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -211,7 +211,7 @@ spec:
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
                                     to a destination host.
-                                  format: int64
+                                  format: uint32
                                   type: integer
                                 tcpKeepalive:
                                   description: If set then set SO_KEEPALIVE on the
@@ -456,7 +456,7 @@ spec:
                                       maxConnections:
                                         description: Maximum number of HTTP1 /TCP
                                           connections to a destination host.
-                                        format: int64
+                                        format: uint32
                                         type: integer
                                       tcpKeepalive:
                                         description: If set then set SO_KEEPALIVE
@@ -775,7 +775,7 @@ spec:
                           maxConnections:
                             description: Maximum number of HTTP1 /TCP connections
                               to a destination host.
-                            format: int64
+                            format: uint32
                             type: integer
                           tcpKeepalive:
                             description: If set then set SO_KEEPALIVE on the socket
@@ -1014,7 +1014,7 @@ spec:
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
                                     to a destination host.
-                                  format: int64
+                                  format: uint32
                                   type: integer
                                 tcpKeepalive:
                                   description: If set then set SO_KEEPALIVE on the
@@ -1378,7 +1378,7 @@ spec:
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
                                     to a destination host.
-                                  format: int64
+                                  format: uint32
                                   type: integer
                                 tcpKeepalive:
                                   description: If set then set SO_KEEPALIVE on the
@@ -1623,7 +1623,7 @@ spec:
                                       maxConnections:
                                         description: Maximum number of HTTP1 /TCP
                                           connections to a destination host.
-                                        format: int64
+                                        format: uint32
                                         type: integer
                                       tcpKeepalive:
                                         description: If set then set SO_KEEPALIVE
@@ -1942,7 +1942,7 @@ spec:
                           maxConnections:
                             description: Maximum number of HTTP1 /TCP connections
                               to a destination host.
-                            format: int64
+                            format: uint32
                             type: integer
                           tcpKeepalive:
                             description: If set then set SO_KEEPALIVE on the socket
@@ -2181,7 +2181,7 @@ spec:
                                 maxConnections:
                                   description: Maximum number of HTTP1 /TCP connections
                                     to a destination host.
-                                  format: int64
+                                  format: uint32
                                   type: integer
                                 tcpKeepalive:
                                   description: If set then set SO_KEEPALIVE on the

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -122,7 +122,7 @@
           "maxConnections": {
             "description": "Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.",
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           },
           "connectTimeout": {
             "description": "TCP connection timeout. format: 1h/1m/1s/1ms. MUST BE \u003e=1ms. Default is 10s.",

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -122,7 +122,7 @@
           "maxConnections": {
             "description": "Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.",
             "type": "integer",
-            "format": "int64"
+            "format": "uint32"
           },
           "connectTimeout": {
             "description": "TCP connection timeout. format: 1h/1m/1s/1ms. MUST BE \u003e=1ms. Default is 10s.",

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1225,7 +1225,7 @@ func (m *ConnectionPoolSettings) GetHttp() *ConnectionPoolSettings_HTTPSettings 
 // Settings common to both HTTP and TCP upstream connections.
 type ConnectionPoolSettings_TCPSettings struct {
 	// Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.
-	MaxConnections int32 `protobuf:"varint,1,opt,name=max_connections,json=maxConnections,proto3" json:"max_connections,omitempty"`
+	MaxConnections int64 `protobuf:"varint,1,opt,name=max_connections,json=maxConnections,proto3" json:"max_connections,omitempty"`
 	// TCP connection timeout. format:
 	// 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.
 	ConnectTimeout *types.Duration `protobuf:"bytes,2,opt,name=connect_timeout,json=connectTimeout,proto3" json:"connect_timeout,omitempty"`
@@ -1269,7 +1269,7 @@ func (m *ConnectionPoolSettings_TCPSettings) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ConnectionPoolSettings_TCPSettings proto.InternalMessageInfo
 
-func (m *ConnectionPoolSettings_TCPSettings) GetMaxConnections() int32 {
+func (m *ConnectionPoolSettings_TCPSettings) GetMaxConnections() int64{
 	if m != nil {
 		return m.MaxConnections
 	}
@@ -5654,7 +5654,7 @@ func (m *ConnectionPoolSettings_TCPSettings) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MaxConnections |= int32(b&0x7F) << shift
+				m.MaxConnections |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1225,7 +1225,7 @@ func (m *ConnectionPoolSettings) GetHttp() *ConnectionPoolSettings_HTTPSettings 
 // Settings common to both HTTP and TCP upstream connections.
 type ConnectionPoolSettings_TCPSettings struct {
 	// Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.
-	MaxConnections int64 `protobuf:"varint,1,opt,name=max_connections,json=maxConnections,proto3" json:"max_connections,omitempty"`
+	MaxConnections uint32 `protobuf:"varint,1,opt,name=max_connections,json=maxConnections,proto3" json:"max_connections,omitempty"`
 	// TCP connection timeout. format:
 	// 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.
 	ConnectTimeout *types.Duration `protobuf:"bytes,2,opt,name=connect_timeout,json=connectTimeout,proto3" json:"connect_timeout,omitempty"`
@@ -1269,7 +1269,7 @@ func (m *ConnectionPoolSettings_TCPSettings) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ConnectionPoolSettings_TCPSettings proto.InternalMessageInfo
 
-func (m *ConnectionPoolSettings_TCPSettings) GetMaxConnections() int64{
+func (m *ConnectionPoolSettings_TCPSettings) GetMaxConnections() uint32{
 	if m != nil {
 		return m.MaxConnections
 	}
@@ -5654,7 +5654,7 @@ func (m *ConnectionPoolSettings_TCPSettings) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MaxConnections |= int64(b&0x7F) << shift
+				m.MaxConnections |= uint32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1496,7 +1496,7 @@ Yes
 <tbody>
 <tr id="ConnectionPoolSettings-TCPSettings-max_connections">
 <td><code>maxConnections</code></td>
-<td><code>int32</code></td>
+<td><code>int64</code></td>
 <td>
 <p>Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.</p>
 

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1496,7 +1496,7 @@ Yes
 <tbody>
 <tr id="ConnectionPoolSettings-TCPSettings-max_connections">
 <td><code>maxConnections</code></td>
-<td><code>int64</code></td>
+<td><code>uint32</code></td>
 <td>
 <p>Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.</p>
 

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -122,7 +122,7 @@
           "maxConnections": {
             "description": "Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.",
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           },
           "connectTimeout": {
             "description": "TCP connection timeout. format: 1h/1m/1s/1ms. MUST BE \u003e=1ms. Default is 10s.",

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -122,7 +122,7 @@
           "maxConnections": {
             "description": "Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.",
             "type": "integer",
-            "format": "int64"
+            "format": "uint32"
           },
           "connectTimeout": {
             "description": "TCP connection timeout. format: 1h/1m/1s/1ms. MUST BE \u003e=1ms. Default is 10s.",

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1224,7 +1224,7 @@ func (m *ConnectionPoolSettings) GetHttp() *ConnectionPoolSettings_HTTPSettings 
 // Settings common to both HTTP and TCP upstream connections.
 type ConnectionPoolSettings_TCPSettings struct {
 	// Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.
-	MaxConnections int32 `protobuf:"varint,1,opt,name=max_connections,json=maxConnections,proto3" json:"max_connections,omitempty"`
+	MaxConnections int64 `protobuf:"varint,1,opt,name=max_connections,json=maxConnections,proto3" json:"max_connections,omitempty"`
 	// TCP connection timeout. format:
 	// 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.
 	ConnectTimeout *types.Duration `protobuf:"bytes,2,opt,name=connect_timeout,json=connectTimeout,proto3" json:"connect_timeout,omitempty"`
@@ -1268,7 +1268,7 @@ func (m *ConnectionPoolSettings_TCPSettings) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ConnectionPoolSettings_TCPSettings proto.InternalMessageInfo
 
-func (m *ConnectionPoolSettings_TCPSettings) GetMaxConnections() int32 {
+func (m *ConnectionPoolSettings_TCPSettings) GetMaxConnections() int64 {
 	if m != nil {
 		return m.MaxConnections
 	}
@@ -5653,7 +5653,7 @@ func (m *ConnectionPoolSettings_TCPSettings) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MaxConnections |= int32(b&0x7F) << shift
+				m.MaxConnections |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1224,7 +1224,7 @@ func (m *ConnectionPoolSettings) GetHttp() *ConnectionPoolSettings_HTTPSettings 
 // Settings common to both HTTP and TCP upstream connections.
 type ConnectionPoolSettings_TCPSettings struct {
 	// Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.
-	MaxConnections int64 `protobuf:"varint,1,opt,name=max_connections,json=maxConnections,proto3" json:"max_connections,omitempty"`
+	MaxConnections uint32 `protobuf:"varint,1,opt,name=max_connections,json=maxConnections,proto3" json:"max_connections,omitempty"`
 	// TCP connection timeout. format:
 	// 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.
 	ConnectTimeout *types.Duration `protobuf:"bytes,2,opt,name=connect_timeout,json=connectTimeout,proto3" json:"connect_timeout,omitempty"`
@@ -1268,7 +1268,7 @@ func (m *ConnectionPoolSettings_TCPSettings) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ConnectionPoolSettings_TCPSettings proto.InternalMessageInfo
 
-func (m *ConnectionPoolSettings_TCPSettings) GetMaxConnections() int64 {
+func (m *ConnectionPoolSettings_TCPSettings) GetMaxConnections() uint32 {
 	if m != nil {
 		return m.MaxConnections
 	}
@@ -5653,7 +5653,7 @@ func (m *ConnectionPoolSettings_TCPSettings) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MaxConnections |= int64(b&0x7F) << shift
+				m.MaxConnections |= uint32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}


### PR DESCRIPTION
- [x] Change dr tcpSetting's MaxConnection int type from int32 to uint32
  
  Refer to: https://istio.io/v1.5/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-TCPSettings
![image](https://user-images.githubusercontent.com/11749867/142347158-69e5edb6-ae9a-4416-b119-6a5e7ae1e15b.png)

  When configure a value to above red part value: `4294967295`, the value can't be parsed due to int32 can't meet it, so need to use `int64` to meet it.