### PR TITLE
Make termination drain duration default to 30s

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -1406,7 +1406,7 @@
             "$ref": "#/components/schemas/istio.mesh.v1alpha1.Topology"
           },
           "terminationDrainDuration": {
-            "description": "The amount of time allowed for connections to complete on proxy shutdown. On receiving `SIGTERM` or `SIGINT`, `istio-agent` tells the active Envoy to start draining, preventing any new connections and allowing existing connections to complete. It then sleeps for the `termination_drain_duration` and then kills any remaining active Envoy processes. If not set, a default of `5s` will be applied.",
+            "description": "The amount of time allowed for connections to complete on proxy shutdown. On receiving `SIGTERM` or `SIGINT`, `istio-agent` tells the active Envoy to start draining, preventing any new connections and allowing existing connections to complete. It then sleeps for the `termination_drain_duration` and then kills any remaining active Envoy processes. If not set, a default of `30s` will be applied.",
             "type": "string"
           },
           "meshId": {

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -2739,7 +2739,7 @@ No
 On receiving <code>SIGTERM</code> or <code>SIGINT</code>, <code>istio-agent</code> tells the active Envoy to start draining,
 preventing any new connections and allowing existing connections to complete. It then
 sleeps for the <code>termination_drain_duration</code> and then kills any remaining active Envoy processes.
-If not set, a default of <code>5s</code> will be applied.</p>
+If not set, a default of <code>30s</code> will be applied.</p>
 
 </td>
 <td>

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -1232,7 +1232,7 @@ type ProxyConfig struct {
 	// On receiving `SIGTERM` or `SIGINT`, `istio-agent` tells the active Envoy to start draining,
 	// preventing any new connections and allowing existing connections to complete. It then
 	// sleeps for the `termination_drain_duration` and then kills any remaining active Envoy processes.
-	// If not set, a default of `5s` will be applied.
+	// If not set, a default of `30s` will be applied.
 	TerminationDrainDuration *types.Duration `protobuf:"bytes,29,opt,name=termination_drain_duration,json=terminationDrainDuration,proto3" json:"terminationDrainDuration,omitempty"`
 	// The unique identifier for the [service mesh](https://istio.io/docs/reference/glossary/#service-mesh)
 	// All control planes running in the same service mesh should specify the same mesh ID.

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -457,10 +457,10 @@ message ProxyConfig {
   Topology gateway_topology = 28;
 
   // The amount of time allowed for connections to complete on proxy shutdown.
-	// On receiving `SIGTERM` or `SIGINT`, `istio-agent` tells the active Envoy to start draining,
-	// preventing any new connections and allowing existing connections to complete. It then
+  // On receiving `SIGTERM` or `SIGINT`, `istio-agent` tells the active Envoy to start draining,
+  // preventing any new connections and allowing existing connections to complete. It then
   // sleeps for the `termination_drain_duration` and then kills any remaining active Envoy processes.
-  // If not set, a default of `5s` will be applied.
+  // If not set, a default of `30s` will be applied.
   google.protobuf.Duration  termination_drain_duration = 29;
 
   // The unique identifier for the [service mesh](https://istio.io/docs/reference/glossary/#service-mesh)


### PR DESCRIPTION
The current default value is quite  different from k8s pod default value. (5s vs 30s) So when pod is terminated, envoy will be killed after 5s, but application container can be still there, maybe requiring communication with the outside.  It was  not a graceful way before.