### PR TITLE
fix storageversion for workload group

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -5521,7 +5521,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 

--- a/networking/v1beta1/workload_group.pb.go
+++ b/networking/v1beta1/workload_group.pb.go
@@ -83,7 +83,6 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // <!-- crd generation tags
 // +cue-gen:WorkloadGroup:groupName:networking.istio.io
 // +cue-gen:WorkloadGroup:version:v1beta1
-// +cue-gen:WorkloadGroup:storageVersion
 // +cue-gen:WorkloadGroup:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadGroup:subresource:status
 // +cue-gen:WorkloadGroup:scope:Namespaced

--- a/networking/v1beta1/workload_group.proto
+++ b/networking/v1beta1/workload_group.proto
@@ -86,7 +86,6 @@ option go_package = "istio.io/api/networking/v1beta1";
 // <!-- crd generation tags
 // +cue-gen:WorkloadGroup:groupName:networking.istio.io
 // +cue-gen:WorkloadGroup:version:v1beta1
-// +cue-gen:WorkloadGroup:storageVersion
 // +cue-gen:WorkloadGroup:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadGroup:subresource:status
 // +cue-gen:WorkloadGroup:scope:Namespaced

--- a/releasenotes/notes/workloadgroup-v1beta1.yaml
+++ b/releasenotes/notes/workloadgroup-v1beta1.yaml
@@ -6,4 +6,4 @@ issue:
 
 releaseNotes:
   - |
-    **Prommoted** WorkloadGroup to v1beta1.
+    **Promoted** WorkloadGroup to v1beta1.


### PR DESCRIPTION
Looks like v1beta1 workload entry drops storageVersion... this should fix automator failures. 

https://github.com/istio/istio/pull/36754