### PR TITLE
use default Telemetry accessLogging provider "envoy" instead of "envo…

### DIFF
--- a/telemetry/v1alpha1/telemetry.pb.go
+++ b/telemetry/v1alpha1/telemetry.pb.go
@@ -172,7 +172,7 @@
 //   # no selector specified, applies to all workloads
 //   accessLogging:
 //   - providers:
-//     - name: envoyFileAccessLogger
+//     - name: envoy
 //     # By default, this turns on access logging (no need to set `disabled: false`).
 //     # Unspecified `disabled` will be treated as `disabled: false`, except in
 //     # cases where a parent configuration has marked as `disabled: true`. In

--- a/telemetry/v1alpha1/telemetry.pb.html
+++ b/telemetry/v1alpha1/telemetry.pb.html
@@ -181,7 +181,7 @@ spec:
   # no selector specified, applies to all workloads
   accessLogging:
   - providers:
-    - name: envoyFileAccessLogger
+    - name: envoy
     # By default, this turns on access logging (no need to set `disabled: false`).
     # Unspecified `disabled` will be treated as `disabled: false`, except in
     # cases where a parent configuration has marked as `disabled: true`. In

--- a/telemetry/v1alpha1/telemetry.proto
+++ b/telemetry/v1alpha1/telemetry.proto
@@ -195,7 +195,7 @@ import "google/protobuf/wrappers.proto";
 //   # no selector specified, applies to all workloads
 //   accessLogging:
 //   - providers:
-//     - name: envoyFileAccessLogger
+//     - name: envoy
 //     # By default, this turns on access logging (no need to set `disabled: false`).
 //     # Unspecified `disabled` will be treated as `disabled: false`, except in
 //     # cases where a parent configuration has marked as `disabled: true`. In

--- a/telemetry/v1alpha1/telemetry_deepcopy.gen.go
+++ b/telemetry/v1alpha1/telemetry_deepcopy.gen.go
@@ -172,7 +172,7 @@
 //   # no selector specified, applies to all workloads
 //   accessLogging:
 //   - providers:
-//     - name: envoyFileAccessLogger
+//     - name: envoy
 //     # By default, this turns on access logging (no need to set `disabled: false`).
 //     # Unspecified `disabled` will be treated as `disabled: false`, except in
 //     # cases where a parent configuration has marked as `disabled: true`. In

--- a/telemetry/v1alpha1/telemetry_json.gen.go
+++ b/telemetry/v1alpha1/telemetry_json.gen.go
@@ -172,7 +172,7 @@
 //   # no selector specified, applies to all workloads
 //   accessLogging:
 //   - providers:
-//     - name: envoyFileAccessLogger
+//     - name: envoy
 //     # By default, this turns on access logging (no need to set `disabled: false`).
 //     # Unspecified `disabled` will be treated as `disabled: false`, except in
 //     # cases where a parent configuration has marked as `disabled: true`. In


### PR DESCRIPTION
use default Telemetry accessLogging provider "envoy" instead of "envoyFileAccessLogger"

there is no Telemetry accessLogging provider named "envoyFileAccessLogger", for default Telemetry accessLogging provider, only "envoy" can be used.