### PR TITLE
Move more examples to `credentialName`

### DIFF
--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -645,8 +645,7 @@ func (m *Gateway) GetSelector() map[string]string {
 //     - "*"
 //     tls:
 //       mode: SIMPLE
-//       serverCertificate: /etc/certs/server.pem
-//       privateKey: /etc/certs/privatekey.pem
+//       credentialName: tls-cert
 // ```
 // {{</tab>}}
 //
@@ -668,8 +667,7 @@ func (m *Gateway) GetSelector() map[string]string {
 //     - "*"
 //     tls:
 //       mode: SIMPLE
-//       serverCertificate: /etc/certs/server.pem
-//       privateKey: /etc/certs/privatekey.pem
+//       credentialName: tls-cert
 // ```
 // {{</tab>}}
 // {{</tabset>}}

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -504,8 +504,7 @@ spec:
     - &quot;*&quot;
     tls:
       mode: SIMPLE
-      serverCertificate: /etc/certs/server.pem
-      privateKey: /etc/certs/privatekey.pem
+      credentialName: tls-cert
 </code></pre>
 
 <p>{{</tab>}}</p>
@@ -528,8 +527,7 @@ spec:
     - &quot;*&quot;
     tls:
       mode: SIMPLE
-      serverCertificate: /etc/certs/server.pem
-      privateKey: /etc/certs/privatekey.pem
+      credentialName: tls-cert
 </code></pre>
 
 <p>{{</tab>}}

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -500,8 +500,7 @@ message Gateway {
 //     - "*"
 //     tls:
 //       mode: SIMPLE
-//       serverCertificate: /etc/certs/server.pem
-//       privateKey: /etc/certs/privatekey.pem
+//       credentialName: tls-cert
 // ```
 // {{</tab>}}
 //
@@ -523,8 +522,7 @@ message Gateway {
 //     - "*"
 //     tls:
 //       mode: SIMPLE
-//       serverCertificate: /etc/certs/server.pem
-//       privateKey: /etc/certs/privatekey.pem
+//       credentialName: tls-cert
 // ```
 // {{</tab>}}
 // {{</tabset>}}

--- a/networking/v1beta1/gateway.pb.go
+++ b/networking/v1beta1/gateway.pb.go
@@ -644,8 +644,7 @@ func (m *Gateway) GetSelector() map[string]string {
 //     - "*"
 //     tls:
 //       mode: SIMPLE
-//       serverCertificate: /etc/certs/server.pem
-//       privateKey: /etc/certs/privatekey.pem
+//       credentialName: tls-cert
 // ```
 // {{</tab>}}
 //
@@ -667,8 +666,7 @@ func (m *Gateway) GetSelector() map[string]string {
 //     - "*"
 //     tls:
 //       mode: SIMPLE
-//       serverCertificate: /etc/certs/server.pem
-//       privateKey: /etc/certs/privatekey.pem
+//       credentialName: tls-cert
 // ```
 // {{</tab>}}
 // {{</tabset>}}

--- a/networking/v1beta1/gateway.proto
+++ b/networking/v1beta1/gateway.proto
@@ -500,8 +500,7 @@ message Gateway {
 //     - "*"
 //     tls:
 //       mode: SIMPLE
-//       serverCertificate: /etc/certs/server.pem
-//       privateKey: /etc/certs/privatekey.pem
+//       credentialName: tls-cert
 // ```
 // {{</tab>}}
 //
@@ -523,8 +522,7 @@ message Gateway {
 //     - "*"
 //     tls:
 //       mode: SIMPLE
-//       serverCertificate: /etc/certs/server.pem
-//       privateKey: /etc/certs/privatekey.pem
+//       credentialName: tls-cert
 // ```
 // {{</tab>}}
 // {{</tabset>}}


### PR DESCRIPTION
This is the recommended method for 6 releases now. There is still one
reference to the file mount option.