### PR TITLE
lint updates needed for common-files updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module istio.io/api
 
-go 1.12
+go 1.17
 
 require (
 	github.com/gogo/protobuf v1.3.2
@@ -10,4 +10,23 @@ require (
 	istio.io/gogo-genproto v0.0.0-20211208193508-5ab4acc9eb1e
 	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0
+)
+
+require (
+	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
+	golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/klog/v2 v2.30.0 // indirect
+	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect
+	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )

--- a/operator/fixup_structs/main.go
+++ b/operator/fixup_structs/main.go
@@ -197,7 +197,7 @@ func main() {
 
 	fmt.Printf("Writing to output file %s\n", filePath)
 
-	if err := ioutil.WriteFile(filePath, []byte(strings.Join(out, "\n")), 0644); err != nil {
+	if err := ioutil.WriteFile(filePath, []byte(strings.Join(out, "\n")), 0o644); err != nil {
 		fmt.Println(err)
 		os.Exit(1) //nolint: gomnd
 	}


### PR DESCRIPTION
Had to update go version:
```
operator/fixup_structs/main.go:200:72: 0o/0O-style octal literals requires go1.13 or later (-lang was set to go1.12; check go.mod)
```