### PR TITLE
update envoyfilter EXTENSION_CONFIG demo

### DIFF
--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -331,16 +331,20 @@
 //   # The second patch instructs to apply the above Wasm filter to the listener/http connection manager.
 //   - applyTo: HTTP_FILTER
 //     match:
-//       context: SIDECAR_INBOUND
+//       listener:
+//         filterChain:
+//           filter:
+//             name: envoy.filters.network.http_connection_manager
+//             subFilter:
+//               name: envoy.filters.http.router
 //     patch:
-//       operation: ADD
-//       filterClass: AUTHZ # This filter will run *after* the Istio authz filter.
+//       operation: INSERT_BEFORE
 //       value:
 //         name: my-wasm-extension # This must match the name above
 //         config_discovery:
 //           config_source:
 //             ads: {}
-//           type_urls: ["envoy.extensions.filters.http.wasm.v3.Wasm"]
+//           type_urls: ["type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm"]
 // ```
 //
 // The following example adds a Wasm service extension for all proxies using a locally available Wasm file.

--- a/networking/v1alpha3/envoy_filter.pb.html
+++ b/networking/v1alpha3/envoy_filter.pb.html
@@ -330,16 +330,20 @@ spec:
   # The second patch instructs to apply the above Wasm filter to the listener/http connection manager.
   - applyTo: HTTP_FILTER
     match:
-      context: SIDECAR_INBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.filters.network.http_connection_manager
+            subFilter:
+              name: envoy.filters.http.router
     patch:
-      operation: ADD
-      filterClass: AUTHZ # This filter will run *after* the Istio authz filter.
+      operation: INSERT_BEFORE
       value:
         name: my-wasm-extension # This must match the name above
         config_discovery:
           config_source:
             ads: {}
-          type_urls: [&quot;envoy.extensions.filters.http.wasm.v3.Wasm&quot;]
+          type_urls: [&quot;type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm&quot;]
 </code></pre>
 
 <p>The following example adds a Wasm service extension for all proxies using a locally available Wasm file.

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -354,16 +354,20 @@ import "networking/v1alpha3/sidecar.proto";
 //   # The second patch instructs to apply the above Wasm filter to the listener/http connection manager.
 //   - applyTo: HTTP_FILTER
 //     match:
-//       context: SIDECAR_INBOUND
+//       listener:
+//         filterChain:
+//           filter:
+//             name: envoy.filters.network.http_connection_manager
+//             subFilter:
+//               name: envoy.filters.http.router
 //     patch:
-//       operation: ADD
-//       filterClass: AUTHZ # This filter will run *after* the Istio authz filter.
+//       operation: INSERT_BEFORE
 //       value:
 //         name: my-wasm-extension # This must match the name above
 //         config_discovery:
 //           config_source:
 //             ads: {}
-//           type_urls: ["envoy.extensions.filters.http.wasm.v3.Wasm"]
+//           type_urls: ["type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm"]
 // ```
 //
 // The following example adds a Wasm service extension for all proxies using a locally available Wasm file.

--- a/networking/v1alpha3/envoy_filter_deepcopy.gen.go
+++ b/networking/v1alpha3/envoy_filter_deepcopy.gen.go
@@ -331,16 +331,20 @@
 //   # The second patch instructs to apply the above Wasm filter to the listener/http connection manager.
 //   - applyTo: HTTP_FILTER
 //     match:
-//       context: SIDECAR_INBOUND
+//       listener:
+//         filterChain:
+//           filter:
+//             name: envoy.filters.network.http_connection_manager
+//             subFilter:
+//               name: envoy.filters.http.router
 //     patch:
-//       operation: ADD
-//       filterClass: AUTHZ # This filter will run *after* the Istio authz filter.
+//       operation: INSERT_BEFORE
 //       value:
 //         name: my-wasm-extension # This must match the name above
 //         config_discovery:
 //           config_source:
 //             ads: {}
-//           type_urls: ["envoy.extensions.filters.http.wasm.v3.Wasm"]
+//           type_urls: ["type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm"]
 // ```
 //
 // The following example adds a Wasm service extension for all proxies using a locally available Wasm file.

--- a/networking/v1alpha3/envoy_filter_json.gen.go
+++ b/networking/v1alpha3/envoy_filter_json.gen.go
@@ -331,16 +331,20 @@
 //   # The second patch instructs to apply the above Wasm filter to the listener/http connection manager.
 //   - applyTo: HTTP_FILTER
 //     match:
-//       context: SIDECAR_INBOUND
+//       listener:
+//         filterChain:
+//           filter:
+//             name: envoy.filters.network.http_connection_manager
+//             subFilter:
+//               name: envoy.filters.http.router
 //     patch:
-//       operation: ADD
-//       filterClass: AUTHZ # This filter will run *after* the Istio authz filter.
+//       operation: INSERT_BEFORE
 //       value:
 //         name: my-wasm-extension # This must match the name above
 //         config_discovery:
 //           config_source:
 //             ads: {}
-//           type_urls: ["envoy.extensions.filters.http.wasm.v3.Wasm"]
+//           type_urls: ["type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm"]
 // ```
 //
 // The following example adds a Wasm service extension for all proxies using a locally available Wasm file.


### PR DESCRIPTION
the original demo will be rejected:
```console
ACK ERROR httpbin-74fb669cc6-tpjfh.default-4 Internal:Error adding/updating listener(s) virtualInbound: Error: terminal filter named envoy.filters.http.router of type envoy.filters.http.router must be the last filter in a http filter chain.
```