### PR TITLE
WIP: add auto-sni and auto-san fields in ClientTLSSettings

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -691,6 +691,10 @@ spec:
                                 description: TLS related settings for connections
                                   to the upstream service.
                                 properties:
+                                  autoSan:
+                                    type: boolean
+                                  autoSni:
+                                    type: boolean
                                   caCertificates:
                                     type: string
                                   clientCertificate:
@@ -726,6 +730,10 @@ spec:
                           description: TLS related settings for connections to the
                             upstream service.
                           properties:
+                            autoSan:
+                              type: boolean
+                            autoSni:
+                              type: boolean
                             caCertificates:
                               type: string
                             clientCertificate:
@@ -1256,6 +1264,10 @@ spec:
                           description: TLS related settings for connections to the
                             upstream service.
                           properties:
+                            autoSan:
+                              type: boolean
+                            autoSni:
+                              type: boolean
                             caCertificates:
                               type: string
                             clientCertificate:
@@ -1291,6 +1303,10 @@ spec:
                     description: TLS related settings for connections to the upstream
                       service.
                     properties:
+                      autoSan:
+                        type: boolean
+                      autoSni:
+                        type: boolean
                       caCertificates:
                         type: string
                       clientCertificate:
@@ -1886,6 +1902,10 @@ spec:
                                 description: TLS related settings for connections
                                   to the upstream service.
                                 properties:
+                                  autoSan:
+                                    type: boolean
+                                  autoSni:
+                                    type: boolean
                                   caCertificates:
                                     type: string
                                   clientCertificate:
@@ -1921,6 +1941,10 @@ spec:
                           description: TLS related settings for connections to the
                             upstream service.
                           properties:
+                            autoSan:
+                              type: boolean
+                            autoSni:
+                              type: boolean
                             caCertificates:
                               type: string
                             clientCertificate:
@@ -2451,6 +2475,10 @@ spec:
                           description: TLS related settings for connections to the
                             upstream service.
                           properties:
+                            autoSan:
+                              type: boolean
+                            autoSni:
+                              type: boolean
                             caCertificates:
                               type: string
                             clientCertificate:
@@ -2486,6 +2514,10 @@ spec:
                     description: TLS related settings for connections to the upstream
                       service.
                     properties:
+                      autoSan:
+                        type: boolean
+                      autoSni:
+                        type: boolean
                       caCertificates:
                         type: string
                       clientCertificate:

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -2089,6 +2089,13 @@
             "description": "InsecureSkipVerify specifies whether the proxy should skip verifying the CA signature and SAN for the server certificate corresponding to the host. This flag should only be set if global CA signature verifcation is enabled, `VerifyCertAtClient` environmental variable is set to `true`, but no verification is desired for a specific host. If enabled with or without `VerifyCertAtClient` enabled, verification of the CA signature and SAN will be skipped.",
             "type": "boolean",
             "nullable": true
+          },
+          "autoSni": {
+            "description": "auto_sni and auto_san could automatically set the outbound SNI based on host/authority **NOTE:** auto_sni and auto_san fields are only applicable for HTTPs traffic when auto_sni field set as true, it will override the sni set above. Additional context: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-upstreamhttpprotocoloptions-auto-sni https://github.com/istio/istio/issues/27847",
+            "type": "boolean"
+          },
+          "autoSan": {
+            "type": "boolean"
           }
         }
       },

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -44,6 +44,13 @@
             "description": "InsecureSkipVerify specifies whether the proxy should skip verifying the CA signature and SAN for the server certificate corresponding to the host. This flag should only be set if global CA signature verifcation is enabled, `VerifyCertAtClient` environmental variable is set to `true`, but no verification is desired for a specific host. If enabled with or without `VerifyCertAtClient` enabled, verification of the CA signature and SAN will be skipped.",
             "type": "boolean",
             "nullable": true
+          },
+          "autoSni": {
+            "description": "auto_sni and auto_san could automatically set the outbound SNI based on host/authority **NOTE:** auto_sni and auto_san fields are only applicable for HTTPs traffic when auto_sni field set as true, it will override the sni set above. Additional context: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-upstreamhttpprotocoloptions-auto-sni https://github.com/istio/istio/issues/27847",
+            "type": "boolean"
+          },
+          "autoSan": {
+            "type": "boolean"
           }
         }
       },

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1966,10 +1966,19 @@ type ClientTLSSettings struct {
 	// `VerifyCertAtClient` is `false` by default in Istio version 1.9 but will
 	// be `true` by default in a later version where, going forward, it will be
 	// enabled by default.
-	InsecureSkipVerify   *types.BoolValue `protobuf:"bytes,8,opt,name=insecure_skip_verify,json=insecureSkipVerify,proto3" json:"insecure_skip_verify,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
-	XXX_unrecognized     []byte           `json:"-"`
-	XXX_sizecache        int32            `json:"-"`
+	InsecureSkipVerify *types.BoolValue `protobuf:"bytes,8,opt,name=insecure_skip_verify,json=insecureSkipVerify,proto3" json:"insecure_skip_verify,omitempty"`
+	// auto_sni and auto_san could automatically set the outbound SNI
+	// based on host/authority
+	// **NOTE:** auto_sni and auto_san fields are only applicable for HTTPs traffic
+	// when auto_sni field set as true, it will override the sni set above.
+	// Additional context:
+	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-upstreamhttpprotocoloptions-auto-sni
+	// https://github.com/istio/istio/issues/27847
+	AutoSni              bool     `protobuf:"varint,9,opt,name=auto_sni,json=autoSni,proto3" json:"auto_sni,omitempty"`
+	AutoSan              bool     `protobuf:"varint,10,opt,name=auto_san,json=autoSan,proto3" json:"auto_san,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *ClientTLSSettings) Reset()         { *m = ClientTLSSettings{} }
@@ -2059,6 +2068,20 @@ func (m *ClientTLSSettings) GetInsecureSkipVerify() *types.BoolValue {
 		return m.InsecureSkipVerify
 	}
 	return nil
+}
+
+func (m *ClientTLSSettings) GetAutoSni() bool {
+	if m != nil {
+		return m.AutoSni
+	}
+	return false
+}
+
+func (m *ClientTLSSettings) GetAutoSan() bool {
+	if m != nil {
+		return m.AutoSan
+	}
+	return false
 }
 
 // Locality-weighted load balancing allows administrators to control the
@@ -3471,6 +3494,26 @@ func (m *ClientTLSSettings) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i -= len(m.XXX_unrecognized)
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
+	if m.AutoSan {
+		i--
+		if m.AutoSan {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x50
+	}
+	if m.AutoSni {
+		i--
+		if m.AutoSni {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x48
+	}
 	if m.InsecureSkipVerify != nil {
 		{
 			size, err := m.InsecureSkipVerify.MarshalToSizedBuffer(dAtA[:i])
@@ -4153,6 +4196,12 @@ func (m *ClientTLSSettings) Size() (n int) {
 	if m.InsecureSkipVerify != nil {
 		l = m.InsecureSkipVerify.Size()
 		n += 1 + l + sovDestinationRule(uint64(l))
+	}
+	if m.AutoSni {
+		n += 2
+	}
+	if m.AutoSan {
+		n += 2
 	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -6883,6 +6932,46 @@ func (m *ClientTLSSettings) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AutoSni", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDestinationRule
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AutoSni = bool(v != 0)
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AutoSan", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDestinationRule
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AutoSan = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipDestinationRule(dAtA[iNdEx:])

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1199,6 +1199,32 @@ enabled by default.</p>
 No
 </td>
 </tr>
+<tr id="ClientTLSSettings-auto_sni">
+<td><code>autoSni</code></td>
+<td><code>bool</code></td>
+<td>
+<p>auto<em>sni and auto</em>san could automatically set the outbound SNI
+based on host/authority
+<strong>NOTE:</strong> auto<em>sni and auto</em>san fields are only applicable for HTTPs traffic
+when auto_sni field set as true, it will override the sni set above.
+Additional context:
+https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-upstreamhttpprotocoloptions-auto-sni
+https://github.com/istio/istio/issues/27847</p>
+
+</td>
+<td>
+No
+</td>
+</tr>
+<tr id="ClientTLSSettings-auto_san">
+<td><code>autoSan</code></td>
+<td><code>bool</code></td>
+<td>
+</td>
+<td>
+No
+</td>
+</tr>
 </tbody>
 </table>
 </section>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -1059,6 +1059,16 @@ message ClientTLSSettings {
   // be `true` by default in a later version where, going forward, it will be
   // enabled by default.
   google.protobuf.BoolValue insecure_skip_verify = 8;
+
+  // auto_sni and auto_san could automatically set the outbound SNI
+  // based on host/authority
+  // **NOTE:** auto_sni and auto_san fields are only applicable for HTTPs traffic
+  // when auto_sni field set as true, it will override the sni set above.
+  // Additional context:
+  // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-upstreamhttpprotocoloptions-auto-sni
+  // https://github.com/istio/istio/issues/27847 
+  bool auto_sni = 9;
+  bool auto_san = 10;
 }
 
 // Locality-weighted load balancing allows administrators to control the

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -44,6 +44,13 @@
             "description": "InsecureSkipVerify specifies whether the proxy should skip verifying the CA signature and SAN for the server certificate corresponding to the host. This flag should only be set if global CA signature verifcation is enabled, `VerifyCertAtClient` environmental variable is set to `true`, but no verification is desired for a specific host. If enabled with or without `VerifyCertAtClient` enabled, verification of the CA signature and SAN will be skipped.",
             "type": "boolean",
             "nullable": true
+          },
+          "autoSni": {
+            "description": "auto_sni and auto_san could automatically set the outbound SNI based on host/authority **NOTE:** auto_sni and auto_san fields are only applicable for HTTPs traffic when auto_sni field set as true, it will override the sni set above. Additional context: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-upstreamhttpprotocoloptions-auto-sni https://github.com/istio/istio/issues/27847",
+            "type": "boolean"
+          },
+          "autoSan": {
+            "type": "boolean"
           }
         }
       },

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1917,10 +1917,19 @@ type ClientTLSSettings struct {
 	// `VerifyCertAtClient` is `false` by default in Istio version 1.9 but will
 	// be `true` by default in a later version where, going forward, it will be
 	// enabled by default.
-	InsecureSkipVerify   *types.BoolValue `protobuf:"bytes,8,opt,name=insecure_skip_verify,json=insecureSkipVerify,proto3" json:"insecure_skip_verify,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
-	XXX_unrecognized     []byte           `json:"-"`
-	XXX_sizecache        int32            `json:"-"`
+	InsecureSkipVerify *types.BoolValue `protobuf:"bytes,8,opt,name=insecure_skip_verify,json=insecureSkipVerify,proto3" json:"insecure_skip_verify,omitempty"`
+	// auto_sni and auto_san could automatically set the outbound SNI
+	// based on host/authority
+	// **NOTE:** auto_sni and auto_san fields are only applicable for HTTPs traffic
+	// when auto_sni field set as true, it will override the sni set above.
+	// Additional context:
+	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-upstreamhttpprotocoloptions-auto-sni
+	// https://github.com/istio/istio/issues/27847
+	AutoSni              bool     `protobuf:"varint,9,opt,name=auto_sni,json=autoSni,proto3" json:"auto_sni,omitempty"`
+	AutoSan              bool     `protobuf:"varint,10,opt,name=auto_san,json=autoSan,proto3" json:"auto_san,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *ClientTLSSettings) Reset()         { *m = ClientTLSSettings{} }
@@ -2010,6 +2019,20 @@ func (m *ClientTLSSettings) GetInsecureSkipVerify() *types.BoolValue {
 		return m.InsecureSkipVerify
 	}
 	return nil
+}
+
+func (m *ClientTLSSettings) GetAutoSni() bool {
+	if m != nil {
+		return m.AutoSni
+	}
+	return false
+}
+
+func (m *ClientTLSSettings) GetAutoSan() bool {
+	if m != nil {
+		return m.AutoSan
+	}
+	return false
 }
 
 // Locality-weighted load balancing allows administrators to control the
@@ -3421,6 +3444,26 @@ func (m *ClientTLSSettings) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i -= len(m.XXX_unrecognized)
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
+	if m.AutoSan {
+		i--
+		if m.AutoSan {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x50
+	}
+	if m.AutoSni {
+		i--
+		if m.AutoSni {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x48
+	}
 	if m.InsecureSkipVerify != nil {
 		{
 			size, err := m.InsecureSkipVerify.MarshalToSizedBuffer(dAtA[:i])
@@ -4103,6 +4146,12 @@ func (m *ClientTLSSettings) Size() (n int) {
 	if m.InsecureSkipVerify != nil {
 		l = m.InsecureSkipVerify.Size()
 		n += 1 + l + sovDestinationRule(uint64(l))
+	}
+	if m.AutoSni {
+		n += 2
+	}
+	if m.AutoSan {
+		n += 2
 	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -6833,6 +6882,46 @@ func (m *ClientTLSSettings) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AutoSni", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDestinationRule
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AutoSni = bool(v != 0)
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AutoSan", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDestinationRule
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AutoSan = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipDestinationRule(dAtA[iNdEx:])

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -1011,6 +1011,16 @@ message ClientTLSSettings {
   // be `true` by default in a later version where, going forward, it will be
   // enabled by default.
   google.protobuf.BoolValue insecure_skip_verify = 8;
+
+  // auto_sni and auto_san could automatically set the outbound SNI
+  // based on host/authority
+  // **NOTE:** auto_sni and auto_san fields are only applicable for HTTPs traffic
+  // when auto_sni field set as true, it will override the sni set above.
+  // Additional context:
+  // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-upstreamhttpprotocoloptions-auto-sni
+  // https://github.com/istio/istio/issues/27847 
+  bool auto_sni = 9;
+  bool auto_san = 10;
 }
 
 // Locality-weighted load balancing allows administrators to control the

--- a/proto.lock
+++ b/proto.lock
@@ -39712,6 +39712,16 @@
                 "id": 8,
                 "name": "insecure_skip_verify",
                 "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 9,
+                "name": "auto_sni",
+                "type": "bool"
+              },
+              {
+                "id": 10,
+                "name": "auto_san",
+                "type": "bool"
               }
             ]
           },
@@ -42499,6 +42509,16 @@
                 "id": 8,
                 "name": "insecure_skip_verify",
                 "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 9,
+                "name": "auto_sni",
+                "type": "bool"
+              },
+              {
+                "id": 10,
+                "name": "auto_san",
+                "type": "bool"
               }
             ]
           },


### PR DESCRIPTION
RFC: [auto-sni and auto-san support](https://docs.google.com/document/d/1pTUl-Ng3nXAWJb7UGJtalftznpxQEfID/edit)

Previous activity can be seen in #1773.

Signed-off-by: Faseela K <faseela.k@est.tech>