### PR TITLE
Fix workloadSelector example in DestinationRule

### DIFF
--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -173,10 +173,10 @@
 // kind: DestinationRule
 // metadata:
 //   name: configure-client-mtls-dr-with-workloadselector
-//   workloadSelector:
-//     labels:
-//       app: ratings
 //   spec:
+//     workloadSelector:
+//       matchLabels:
+//         app: ratings
 //     trafficPolicy:
 //       loadBalancer:
 //         simple: ROUND_ROBIN
@@ -194,10 +194,10 @@
 // kind: DestinationRule
 // metadata:
 //   name: configure-client-mtls-dr-with-workloadselector
-//   workloadSelector:
-//     labels:
-//       app: ratings
 //   spec:
+//     workloadSelector:
+//       matchLabels:
+//         app: ratings
 //     trafficPolicy:
 //       loadBalancer:
 //         simple: ROUND_ROBIN

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -163,10 +163,10 @@ specific workload using the workloadSelector configuration.</p>
 kind: DestinationRule
 metadata:
   name: configure-client-mtls-dr-with-workloadselector
-  workloadSelector:
-    labels:
-      app: ratings
   spec:
+    workloadSelector:
+      matchLabels:
+        app: ratings
     trafficPolicy:
       loadBalancer:
         simple: ROUND_ROBIN
@@ -185,10 +185,10 @@ metadata:
 kind: DestinationRule
 metadata:
   name: configure-client-mtls-dr-with-workloadselector
-  workloadSelector:
-    labels:
-      app: ratings
   spec:
+    workloadSelector:
+      matchLabels:
+        app: ratings
     trafficPolicy:
       loadBalancer:
         simple: ROUND_ROBIN

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -174,10 +174,10 @@ import "type/v1beta1/selector.proto";
 // kind: DestinationRule
 // metadata:
 //   name: configure-client-mtls-dr-with-workloadselector
-//   workloadSelector:
-//     labels:
-//       app: ratings
 //   spec:
+//     workloadSelector:
+//       matchLabels:
+//         app: ratings
 //     trafficPolicy:
 //       loadBalancer:
 //         simple: ROUND_ROBIN
@@ -195,10 +195,10 @@ import "type/v1beta1/selector.proto";
 // kind: DestinationRule
 // metadata:
 //   name: configure-client-mtls-dr-with-workloadselector
-//   workloadSelector:
-//     labels:
-//       app: ratings
 //   spec:
+//     workloadSelector:
+//       matchLabels:
+//         app: ratings
 //     trafficPolicy:
 //       loadBalancer:
 //         simple: ROUND_ROBIN


### PR DESCRIPTION
The example had a wrong yaml file with workloadSelector under metadata.

Signed-off-by: Faseela K <faseela.k@est.tech>