### PR TITLE
Support CredentialName configuration in DR for sidecars

### DIFF
--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1467,8 +1467,10 @@ type ClientTLSSettings struct {
 	// Only one of client certificates and CA certificate
 	// or credentialName can be specified.
 	//
-	// **NOTE:** This field is currently applicable only at gateways.
-	// Sidecars will continue to use the certificate paths.
+	// **NOTE:** This field is applicable at sidecars only if
+	// `DestinationRule` has a `workloadSelector` specified.
+	// Otherwise the field will be applicable only at gateways, and
+	// sidecars will continue to use the certificate paths.
 	CredentialName string `protobuf:"bytes,7,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`
 	// A list of alternate names to verify the subject identity in the
 	// certificate. If specified, the proxy will verify that the server

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1143,8 +1143,10 @@ ca.crt key for CA certificates is also supported.
 Only one of client certificates and CA certificate
 or credentialName can be specified.</p>
 
-<p><strong>NOTE:</strong> This field is currently applicable only at gateways.
-Sidecars will continue to use the certificate paths.</p>
+<p><strong>NOTE:</strong> This field is applicable at sidecars only if
+<code>DestinationRule</code> has a <code>workloadSelector</code> specified.
+Otherwise the field will be applicable only at gateways, and
+sidecars will continue to use the certificate paths.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -1031,8 +1031,10 @@ message ClientTLSSettings {
   // Only one of client certificates and CA certificate
   // or credentialName can be specified.
   //
-  // **NOTE:** This field is currently applicable only at gateways.
-  // Sidecars will continue to use the certificate paths.
+  // **NOTE:** This field is applicable at sidecars only if
+  // `DestinationRule` has a `workloadSelector` specified.
+  // Otherwise the field will be applicable only at gateways, and
+  // sidecars will continue to use the certificate paths.
   string credential_name = 7;
 
   // A list of alternate names to verify the subject identity in the

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1419,8 +1419,10 @@ type ClientTLSSettings struct {
 	// Only one of client certificates and CA certificate
 	// or credentialName can be specified.
 	//
-	// **NOTE:** This field is currently applicable only at gateways.
-	// Sidecars will continue to use the certificate paths.
+	// **NOTE:** This field is applicable at sidecars only if
+	// `DestinationRule` has a `workloadSelector` specified.
+	// Otherwise the field will be applicable only at gateways, and
+	// sidecars will continue to use the certificate paths.
 	CredentialName string `protobuf:"bytes,7,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`
 	// A list of alternate names to verify the subject identity in the
 	// certificate. If specified, the proxy will verify that the server

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -983,8 +983,10 @@ message ClientTLSSettings {
   // Only one of client certificates and CA certificate
   // or credentialName can be specified.
   //
-  // **NOTE:** This field is currently applicable only at gateways.
-  // Sidecars will continue to use the certificate paths.
+  // **NOTE:** This field is applicable at sidecars only if
+  // `DestinationRule` has a `workloadSelector` specified.
+  // Otherwise the field will be applicable only at gateways, and
+  // sidecars will continue to use the certificate paths.
   string credential_name = 7;
 
   // A list of alternate names to verify the subject identity in the


### PR DESCRIPTION
RFC: [Simplify sidecar egress mTLS](https://docs.google.com/document/d/1UXpT3rZpE2uFeMh5KffAZAPAoZBLNSHc/)

Implementation PR: https://github.com/istio/istio/pull/38324
The description for credentialName attribute in DR needed a little bit of modification to clarify the newly added behaviour.

Signed-off-by: Faseela K <faseela.k@est.tech>