### PR TITLE
Hide verification_key from documentation

### DIFF
--- a/extensions/v1alpha1/wasm.gen.json
+++ b/extensions/v1alpha1/wasm.gen.json
@@ -84,7 +84,7 @@
             "type": "string"
           },
           "verificationKey": {
-            "description": "Public key that will be used to verify signatures of signed OCI images or Wasm modules. Must be supplied in PEM format.",
+            "description": "Public key that will be used to verify signatures of signed OCI images or Wasm modules.",
             "type": "string"
           },
           "pluginConfig": {

--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -430,8 +430,26 @@ type WasmPlugin struct {
 	// contains a docker pull secret which is to be used to authenticate
 	// against the registry when pulling the image.
 	ImagePullSecret string `protobuf:"bytes,5,opt,name=image_pull_secret,json=imagePullSecret,proto3" json:"image_pull_secret,omitempty"`
+	// $hide_from_docs
 	// Public key that will be used to verify signatures of signed OCI images
-	// or Wasm modules. Must be supplied in PEM format.
+	// or Wasm modules.
+	//
+	// At this moment, various ways for signing/verifying are emerging and being proposed.
+	// We can observe two major streams for signing OCI images: Cosign from Sigstore and Notary,
+	// which is used in Docker Content Trust.
+	// In case of Wasm module, multiple approaches are still in discussion.
+	//  * https://github.com/WebAssembly/design/issues/1413
+	//  * https://github.com/wasm-signatures/design (various signing tools are enumerated)
+	//
+	// In addition, for each method for signing&verifying, we may need to consider to provide
+	// additional data or configuration (e.g., key rolling, KMS, root certs, ...) as well.
+	//
+	// To deal with this situation, we need to elaborate more generic way to describe
+	// how to sign and verify the image or wasm binary, and how to specify relevant data,
+	// including this `verification_key`.
+	//
+	// Therefore, this field will not be implemented until the detailed design is established.
+	// For the future use, just keep this field in proto and hide from documentation.
 	VerificationKey string `protobuf:"bytes,6,opt,name=verification_key,json=verificationKey,proto3" json:"verification_key,omitempty"`
 	// The configuration that will be passed on to the plugin.
 	PluginConfig *_struct.Struct `protobuf:"bytes,7,opt,name=plugin_config,json=pluginConfig,proto3" json:"plugin_config,omitempty"`

--- a/extensions/v1alpha1/wasm.pb.html
+++ b/extensions/v1alpha1/wasm.pb.html
@@ -249,18 +249,6 @@ against the registry when pulling the image.</p>
 No
 </td>
 </tr>
-<tr id="WasmPlugin-verification_key">
-<td><code>verificationKey</code></td>
-<td><code>string</code></td>
-<td>
-<p>Public key that will be used to verify signatures of signed OCI images
-or Wasm modules. Must be supplied in PEM format.</p>
-
-</td>
-<td>
-No
-</td>
-</tr>
 <tr id="WasmPlugin-plugin_config">
 <td><code>pluginConfig</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#struct">Struct</a></code></td>

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -246,8 +246,26 @@ message WasmPlugin {
   // against the registry when pulling the image.
   string image_pull_secret = 5;
 
+  // $hide_from_docs
   // Public key that will be used to verify signatures of signed OCI images
-  // or Wasm modules. Must be supplied in PEM format.
+  // or Wasm modules.
+  //
+  // At this moment, various ways for signing/verifying are emerging and being proposed. 
+  // We can observe two major streams for signing OCI images: Cosign from Sigstore and Notary, 
+  // which is used in Docker Content Trust.
+  // In case of Wasm module, multiple approaches are still in discussion.
+  //  * https://github.com/WebAssembly/design/issues/1413
+  //  * https://github.com/wasm-signatures/design (various signing tools are enumerated)
+  //
+  // In addition, for each method for signing&verifying, we may need to consider to provide
+  // additional data or configuration (e.g., key rolling, KMS, root certs, ...) as well.
+  // 
+  // To deal with this situation, we need to elaborate more generic way to describe 
+  // how to sign and verify the image or wasm binary, and how to specify relevant data,
+  // including this `verification_key`.
+  //
+  // Therefore, this field will not be implemented until the detailed design is established.
+  // For the future use, just keep this field in proto and hide from documentation.
   string verification_key = 6;
 
   // The configuration that will be passed on to the plugin.


### PR DESCRIPTION
This PR proposes to hide `verification_key` field from documentation, and declare that the field will be not implemented until the detailed design is elaborated.

In current situation, there are two major stream for signing/verifying the OCI image. On the other hand, it seems to be no apparent major stream for signing and verifying Wasm binary. 
In this case, we can think of more generalized API interface to deal with such multiple mechanisms, and it need to be designed more general way rather than providing just a `verification_key` field.

Therefore, I would like to propose to hold this field at this time and get it back later.

cc: @dgn @mathetake @PiotrSikora @mandarjog @bianpengyuan 