### PR TITLE
Fix API rendering issue in ServiceEntry.Resolution

### DIFF
--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -877,9 +877,9 @@ const (
 	// domain socket endpoints.
 	ServiceEntry_DNS ServiceEntry_Resolution = 2
 	// Attempt to resolve the IP address by querying the ambient DNS,
-	// asynchronously. Unlike DNS, DNS_ROUND_ROBIN only uses the
+	// asynchronously. Unlike `DNS`, `DNS_ROUND_ROBIN` only uses the
 	// first IP address returned when a new connection needs to be initiated
-	// without relying on complete results of DNS resolution and connections
+	// without relying on complete results of DNS resolution, and connections
 	// made to hosts will be retained even if DNS records change frequently
 	// eliminating draining connection pools and connection cycling.
 	// This is best suited for large web scale services that

--- a/networking/v1alpha3/service_entry.pb.html
+++ b/networking/v1alpha3/service_entry.pb.html
@@ -1067,9 +1067,9 @@ domain socket endpoints.</p>
 <td><code>DNS_ROUND_ROBIN</code></td>
 <td>
 <p>Attempt to resolve the IP address by querying the ambient DNS,
-asynchronously. Unlike DNS, DNS_ROUND_ROBIN only uses the
+asynchronously. Unlike <code>DNS</code>, <code>DNS_ROUND_ROBIN</code> only uses the
 first IP address returned when a new connection needs to be initiated
-without relying on complete results of DNS resolution and connections
+without relying on complete results of DNS resolution, and connections
 made to hosts will be retained even if DNS records change frequently
 eliminating draining connection pools and connection cycling.
 This is best suited for large web scale services that

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -910,9 +910,9 @@ message ServiceEntry {
     DNS = 2;
 
     // Attempt to resolve the IP address by querying the ambient DNS,
-    // asynchronously. Unlike DNS, DNS_ROUND_ROBIN only uses the
+    // asynchronously. Unlike `DNS`, `DNS_ROUND_ROBIN` only uses the
     // first IP address returned when a new connection needs to be initiated
-    // without relying on complete results of DNS resolution and connections
+    // without relying on complete results of DNS resolution, and connections
     // made to hosts will be retained even if DNS records change frequently
     // eliminating draining connection pools and connection cycling.
     // This is best suited for large web scale services that

--- a/networking/v1beta1/service_entry.pb.go
+++ b/networking/v1beta1/service_entry.pb.go
@@ -878,9 +878,9 @@ const (
 	// domain socket endpoints.
 	ServiceEntry_DNS ServiceEntry_Resolution = 2
 	// Attempt to resolve the IP address by querying the ambient DNS,
-	// asynchronously. Unlike DNS, DNS_ROUND_ROBIN only uses the
+	// asynchronously. Unlike `DNS`, `DNS_ROUND_ROBIN` only uses the
 	// first IP address returned when a new connection needs to be initiated
-	// without relying on complete results of DNS resolution and connections
+	// without relying on complete results of DNS resolution, and connections
 	// made to hosts will be retained even if DNS records change frequently
 	// eliminating draining connection pools and connection cycling.
 	// This is best suited for large web scale services that

--- a/networking/v1beta1/service_entry.proto
+++ b/networking/v1beta1/service_entry.proto
@@ -910,9 +910,9 @@ message ServiceEntry {
     DNS = 2;
 
     // Attempt to resolve the IP address by querying the ambient DNS,
-    // asynchronously. Unlike DNS, DNS_ROUND_ROBIN only uses the
+    // asynchronously. Unlike `DNS`, `DNS_ROUND_ROBIN` only uses the
     // first IP address returned when a new connection needs to be initiated
-    // without relying on complete results of DNS resolution and connections
+    // without relying on complete results of DNS resolution, and connections
     // made to hosts will be retained even if DNS records change frequently
     // eliminating draining connection pools and connection cycling.
     // This is best suited for large web scale services that


### PR DESCRIPTION
URL: https://istio.io/latest/docs/reference/config/networking/service-entry/#ServiceEntry-Resolution

ServiceEntry.Resolution description for `DNS_ROUND_ROBIN` does not
wrap `DNS_ROUND_ROBIN` in Markdown backticks, causing the keyword to
show up as italicized DNS<em>ROUND</em>ROBIN due to the underscores.

This change wraps `DNS` and `DNS_ROUND_ROBIN` in backticks, avoiding
this rendering issue.

Also added a comma in the description.