### PR TITLE
fix proxy-config reference doc

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -2373,7 +2373,7 @@
         }
       },
       "istio.networking.v1beta1.ProxyImage": {
-        "description": "The following values are used to construct proxy image url. $hub/$image_name/$tag-$image_type example: docker.io/istio/proxyv2:1.11.1 or docker.io/istio/proxyv2:1.11.1-distroless This information was previously part of the Values API.",
+        "description": "The following values are used to construct proxy image url. format: `${hub}/${image_name}/${tag}-${image_type}`, example: `docker.io/istio/proxyv2:1.11.1` or `docker.io/istio/proxyv2:1.11.1-distroless`. This information was previously part of the Values API.",
         "type": "object",
         "properties": {
           "imageType": {

--- a/networking/v1beta1/proxy_config.gen.json
+++ b/networking/v1beta1/proxy_config.gen.json
@@ -31,7 +31,7 @@
         }
       },
       "istio.networking.v1beta1.ProxyImage": {
-        "description": "The following values are used to construct proxy image url. $hub/$image_name/$tag-$image_type example: docker.io/istio/proxyv2:1.11.1 or docker.io/istio/proxyv2:1.11.1-distroless This information was previously part of the Values API.",
+        "description": "The following values are used to construct proxy image url. format: `${hub}/${image_name}/${tag}-${image_type}`, example: `docker.io/istio/proxyv2:1.11.1` or `docker.io/istio/proxyv2:1.11.1-distroless`. This information was previously part of the Values API.",
         "type": "object",
         "properties": {
           "imageType": {

--- a/networking/v1beta1/proxy_config.pb.go
+++ b/networking/v1beta1/proxy_config.pb.go
@@ -74,7 +74,7 @@
 //   namespace: example
 // spec:
 //   selector:
-//     labels:
+//     matchLabels:
 //       app: ratings
 //   concurrency: 0
 //   image:
@@ -204,8 +204,8 @@ func (x *ProxyConfig) GetImage() *ProxyImage {
 }
 
 // The following values are used to construct proxy image url.
-// $hub/$image_name/$tag-$image_type
-// example: docker.io/istio/proxyv2:1.11.1 or docker.io/istio/proxyv2:1.11.1-distroless
+// format: `${hub}/${image_name}/${tag}-${image_type}`,
+// example: `docker.io/istio/proxyv2:1.11.1` or `docker.io/istio/proxyv2:1.11.1-distroless`.
 // This information was previously part of the Values API.
 type ProxyImage struct {
 	state         protoimpl.MessageState

--- a/networking/v1beta1/proxy_config.pb.html
+++ b/networking/v1beta1/proxy_config.pb.html
@@ -54,7 +54,7 @@ metadata:
   namespace: example
 spec:
   selector:
-    labels:
+    matchLabels:
       app: ratings
   concurrency: 0
   image:
@@ -133,8 +133,8 @@ No
 <h2 id="ProxyImage">ProxyImage</h2>
 <section>
 <p>The following values are used to construct proxy image url.
-$hub/$image_name/$tag-$image_type
-example: docker.io/istio/proxyv2:1.11.1 or docker.io/istio/proxyv2:1.11.1-distroless
+format: <code>${hub}/${image_name}/${tag}-${image_type}</code>,
+example: <code>docker.io/istio/proxyv2:1.11.1</code> or <code>docker.io/istio/proxyv2:1.11.1-distroless</code>.
 This information was previously part of the Values API.</p>
 
 <table class="message-fields">

--- a/networking/v1beta1/proxy_config.proto
+++ b/networking/v1beta1/proxy_config.proto
@@ -73,7 +73,7 @@ import "type/v1beta1/selector.proto";
 //   namespace: example
 // spec:
 //   selector:
-//     labels:
+//     matchLabels:
 //       app: ratings
 //   concurrency: 0
 //   image:
@@ -127,8 +127,8 @@ message ProxyConfig {
 }
 
 // The following values are used to construct proxy image url.
-// $hub/$image_name/$tag-$image_type
-// example: docker.io/istio/proxyv2:1.11.1 or docker.io/istio/proxyv2:1.11.1-distroless
+// format: `${hub}/${image_name}/${tag}-${image_type}`,
+// example: `docker.io/istio/proxyv2:1.11.1` or `docker.io/istio/proxyv2:1.11.1-distroless`.
 // This information was previously part of the Values API.
 message ProxyImage {
   // The image type of the image.

--- a/releasenotes/notes/fix-proxy-config-doc.yaml
+++ b/releasenotes/notes/fix-proxy-config-doc.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: documentation
+issue: []
+
+releaseNotes:
+- |
+    **Fixed** fix istio proxy-config reference yaml error and formatting the description of `imageType`.


### PR DESCRIPTION
fix proxy-config reference doc:
1.  yaml error: selector.matchLabels
2. formating error 
![image](https://user-images.githubusercontent.com/44200120/170155389-f6e0485d-e1bf-428c-af7f-61e321c85ec1.png)
