### PR TITLE
Require uppercase value of tunnel protocol

### DIFF
--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -571,7 +571,7 @@
         "type": "object",
         "properties": {
           "protocol": {
-            "description": "Specifies which protocol to use for tunneling the downstream connection. Supported protocols are: connect - uses HTTP CONNECT; post - uses HTTP POST. HTTP version for upstream requests is determined by the service protocol defined for the proxy.",
+            "description": "Specifies which protocol to use for tunneling the downstream connection. Supported protocols are: CONNECT - uses HTTP CONNECT; POST - uses HTTP POST. HTTP version for upstream requests is determined by the service protocol defined for the proxy.",
             "type": "string"
           },
           "targetHost": {

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1857,8 +1857,8 @@ type TrafficPolicy_TunnelSettings struct {
 
 	// Specifies which protocol to use for tunneling the downstream connection.
 	// Supported protocols are:
-	//   connect - uses HTTP CONNECT;
-	//   post - uses HTTP POST.
+	//   CONNECT - uses HTTP CONNECT;
+	//   POST - uses HTTP POST.
 	// HTTP version for upstream requests is determined by the service protocol defined for the proxy.
 	Protocol string `protobuf:"bytes,1,opt,name=protocol,proto3" json:"protocol,omitempty"`
 	// Specifies a host to which the downstream connection is tunneled.

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1466,8 +1466,8 @@ No
 <td>
 <p>Specifies which protocol to use for tunneling the downstream connection.
 Supported protocols are:
-  connect - uses HTTP CONNECT;
-  post - uses HTTP POST.
+  CONNECT - uses HTTP CONNECT;
+  POST - uses HTTP POST.
 HTTP version for upstream requests is determined by the service protocol defined for the proxy.</p>
 
 </td>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -344,8 +344,8 @@ message TrafficPolicy {
   message TunnelSettings {
     // Specifies which protocol to use for tunneling the downstream connection.
     // Supported protocols are:
-    //   connect - uses HTTP CONNECT;
-    //   post - uses HTTP POST.
+    //   CONNECT - uses HTTP CONNECT;
+    //   POST - uses HTTP POST.
     // HTTP version for upstream requests is determined by the service protocol defined for the proxy.
     string protocol = 1 [(google.api.field_behavior) = REQUIRED];
 

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -571,7 +571,7 @@
         "type": "object",
         "properties": {
           "protocol": {
-            "description": "Specifies which protocol to use for tunneling the downstream connection. Supported protocols are: connect - uses HTTP CONNECT; post - uses HTTP POST. HTTP version for upstream requests is determined by the service protocol defined for the proxy.",
+            "description": "Specifies which protocol to use for tunneling the downstream connection. Supported protocols are: CONNECT - uses HTTP CONNECT; POST - uses HTTP POST. HTTP version for upstream requests is determined by the service protocol defined for the proxy.",
             "type": "string"
           },
           "targetHost": {

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1809,8 +1809,8 @@ type TrafficPolicy_TunnelSettings struct {
 
 	// Specifies which protocol to use for tunneling the downstream connection.
 	// Supported protocols are:
-	//   connect - uses HTTP CONNECT;
-	//   post - uses HTTP POST.
+	//   CONNECT - uses HTTP CONNECT;
+	//   POST - uses HTTP POST.
 	// HTTP version for upstream requests is determined by the service protocol defined for the proxy.
 	Protocol string `protobuf:"bytes,1,opt,name=protocol,proto3" json:"protocol,omitempty"`
 	// Specifies a host to which the downstream connection is tunneled.

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -296,8 +296,8 @@ message TrafficPolicy {
   message TunnelSettings {
     // Specifies which protocol to use for tunneling the downstream connection.
     // Supported protocols are:
-    //   connect - uses HTTP CONNECT;
-    //   post - uses HTTP POST.
+    //   CONNECT - uses HTTP CONNECT;
+    //   POST - uses HTTP POST.
     // HTTP version for upstream requests is determined by the service protocol defined for the proxy.
     string protocol = 1 [(google.api.field_behavior) = REQUIRED];
 


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

It's just an update of `TunnelSettings` documentation. For more context, take a look at this [comment](https://github.com/istio/istio/pull/37968#discussion_r872522202).