### PR TITLE
Fix broken DR documentation

### DIFF
--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -161,6 +161,7 @@
 //         simple: ROUND_ROBIN
 // ```
 // {{</tab>}}
+// {{</tabset>}}
 //
 // Destination Rules can be customized to specific workloads as well.
 // The following example shows how a destination rule can be applied to a

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -150,7 +150,8 @@ spec:
         simple: ROUND_ROBIN
 </code></pre>
 
-<p>{{</tab>}}</p>
+<p>{{</tab>}}
+{{</tabset>}}</p>
 
 <p>Destination Rules can be customized to specific workloads as well.
 The following example shows how a destination rule can be applied to a

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -162,6 +162,7 @@ import "type/v1beta1/selector.proto";
 //         simple: ROUND_ROBIN
 // ```
 // {{</tab>}}
+// {{</tabset>}}
 //
 // Destination Rules can be customized to specific workloads as well.
 // The following example shows how a destination rule can be applied to a


### PR DESCRIPTION
Thanks to @davidhauck 
There was a rendering problem at https://preliminary.istio.io/latest/docs/reference/config/networking/destination-rule/
where most of the content was missing, due to a missing tabset in the document.

Signed-off-by: Faseela K <faseela.k@est.tech>