### PR TITLE
Namespace annotation for cluster leaders

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -30,6 +30,7 @@ const (
     Any
     AuthorizationPolicy
     Ingress
+    Namespace
     Pod
     Service
     WorkloadEntry
@@ -44,10 +45,12 @@ func (r ResourceTypes) String() string {
 	case 3:
 		return "Ingress"
 	case 4:
-		return "Pod"
+		return "Namespace"
 	case 5:
-		return "Service"
+		return "Pod"
 	case 6:
+		return "Service"
+	case 7:
 		return "WorkloadEntry"
 	}
 	return "Unknown"
@@ -642,6 +645,19 @@ var (
 		},
 	}
 
+	TopologyIstiodClusters = Instance {
+		Name:          "topology.istio.io/istiodClusters",
+		Description:   "Comma-separated list of clusters (or * for any) with an "+
+                        "istiod that should attempt leader election for a remote "+
+                        "cluster.",
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Namespace,
+		},
+	}
+
 	TrafficNodeSelector = Instance {
 		Name:          "traffic.istio.io/nodeSelector",
 		Description:   "This annotation is a set of node-labels "+
@@ -810,6 +826,7 @@ func AllResourceAnnotations() []*Instance {
 		&SidecarUserVolume,
 		&SidecarUserVolumeMount,
 		&SidecarStatusPort,
+		&TopologyIstiodClusters,
 		&TrafficNodeSelector,
 		&SidecarTrafficExcludeInboundPorts,
 		&SidecarTrafficExcludeInterfaces,
@@ -827,6 +844,7 @@ func AllResourceTypes() []string {
 		"Any",
 		"AuthorizationPolicy",
 		"Ingress",
+		"Namespace",
 		"Pod",
 		"Service",
 		"WorkloadEntry",

--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -649,7 +649,7 @@ var (
 		Name:          "topology.istio.io/istiodClusters",
 		Description:   "A comma-separated list of clusters (or * for any) running "+
                         "istiod that should attempt leader election for a remote "+
-                        "cluster whose system namepace includes this annotation. "+
+                        "cluster whose system namespace includes this annotation. "+
                         "Istiod will not attempt to lead other remote clusters by "+
                         "default.",
 		FeatureStatus: Alpha,

--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -647,9 +647,11 @@ var (
 
 	TopologyIstiodClusters = Instance {
 		Name:          "topology.istio.io/istiodClusters",
-		Description:   "Comma-separated list of clusters (or * for any) with an "+
+		Description:   "A comma-separated list of clusters (or * for any) running "+
                         "istiod that should attempt leader election for a remote "+
-                        "cluster.",
+                        "cluster whose system namepace includes this annotation. "+
+                        "Istiod will not attempt to lead other remote clusters by "+
+                        "default.",
 		FeatureStatus: Alpha,
 		Hidden:        false,
 		Deprecated:    false,

--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -645,8 +645,8 @@ var (
 		},
 	}
 
-	TopologyIstiodClusters = Instance {
-		Name:          "topology.istio.io/istiodClusters",
+	TopologyControlPlaneClusters = Instance {
+		Name:          "topology.istio.io/controlPlaneClusters",
 		Description:   "A comma-separated list of clusters (or * for any) running "+
                         "istiod that should attempt leader election for a remote "+
                         "cluster thats system namespace includes this annotation. "+
@@ -828,7 +828,7 @@ func AllResourceAnnotations() []*Instance {
 		&SidecarUserVolume,
 		&SidecarUserVolumeMount,
 		&SidecarStatusPort,
-		&TopologyIstiodClusters,
+		&TopologyControlPlaneClusters,
 		&TrafficNodeSelector,
 		&SidecarTrafficExcludeInboundPorts,
 		&SidecarTrafficExcludeInterfaces,

--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -650,8 +650,8 @@ var (
 		Description:   "A comma-separated list of clusters (or * for any) running "+
                         "istiod that should attempt leader election for a remote "+
                         "cluster thats system namespace includes this annotation. "+
-                        "Istiod will attempt to lead unannotated remote clusters "+
-                        "by default.",
+                        "Istiod will not attempt to lead unannotated remote "+
+                        "clusters.",
 		FeatureStatus: Alpha,
 		Hidden:        false,
 		Deprecated:    false,

--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -649,9 +649,9 @@ var (
 		Name:          "topology.istio.io/istiodClusters",
 		Description:   "A comma-separated list of clusters (or * for any) running "+
                         "istiod that should attempt leader election for a remote "+
-                        "cluster whose system namespace includes this annotation. "+
-                        "Istiod will not attempt to lead other remote clusters by "+
-                        "default.",
+                        "cluster thats system namespace includes this annotation. "+
+                        "Istiod will attempt to lead unannotated remote clusters "+
+                        "by default.",
 		FeatureStatus: Alpha,
 		Hidden:        false,
 		Deprecated:    false,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -534,7 +534,7 @@ Istio supports to control its behavior.
 				
 					<tr>
 				
-					<td><code>topology.istio.io/istiodClusters</code></td>
+					<td><code>topology.istio.io/controlPlaneClusters</code></td>
 				
 					<td>Alpha</td>
 				

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -534,6 +534,19 @@ Istio supports to control its behavior.
 				
 					<tr>
 				
+					<td><code>topology.istio.io/istiodClusters</code></td>
+				
+					<td>Alpha</td>
+				
+					<td>[Namespace]</td>
+					<td>Comma-separated list of clusters (or * for any) with an istiod that should attempt leader election for a remote cluster.</td>
+				</tr>
+			
+		
+			
+				
+					<tr>
+				
 					<td><code>traffic.istio.io/nodeSelector</code></td>
 				
 					<td>Stable</td>

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -539,7 +539,7 @@ Istio supports to control its behavior.
 					<td>Alpha</td>
 				
 					<td>[Namespace]</td>
-					<td>A comma-separated list of clusters (or * for any) running istiod that should attempt leader election for a remote cluster whose system namespace includes this annotation. Istiod will not attempt to lead other remote clusters by default.</td>
+					<td>A comma-separated list of clusters (or * for any) running istiod that should attempt leader election for a remote cluster thats system namespace includes this annotation. Istiod will attempt to lead unannotated remote clusters by default.</td>
 				</tr>
 			
 		

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -539,7 +539,7 @@ Istio supports to control its behavior.
 					<td>Alpha</td>
 				
 					<td>[Namespace]</td>
-					<td>A comma-separated list of clusters (or * for any) running istiod that should attempt leader election for a remote cluster thats system namespace includes this annotation. Istiod will attempt to lead unannotated remote clusters by default.</td>
+					<td>A comma-separated list of clusters (or * for any) running istiod that should attempt leader election for a remote cluster thats system namespace includes this annotation. Istiod will not attempt to lead unannotated remote clusters.</td>
 				</tr>
 			
 		

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -539,7 +539,7 @@ Istio supports to control its behavior.
 					<td>Alpha</td>
 				
 					<td>[Namespace]</td>
-					<td>A comma-separated list of clusters (or * for any) running istiod that should attempt leader election for a remote cluster whose system namepace includes this annotation. Istiod will not attempt to lead other remote clusters by default.</td>
+					<td>A comma-separated list of clusters (or * for any) running istiod that should attempt leader election for a remote cluster whose system namespace includes this annotation. Istiod will not attempt to lead other remote clusters by default.</td>
 				</tr>
 			
 		

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -539,7 +539,7 @@ Istio supports to control its behavior.
 					<td>Alpha</td>
 				
 					<td>[Namespace]</td>
-					<td>Comma-separated list of clusters (or * for any) with an istiod that should attempt leader election for a remote cluster.</td>
+					<td>A comma-separated list of clusters (or * for any) running istiod that should attempt leader election for a remote cluster whose system namepace includes this annotation. Istiod will not attempt to lead other remote clusters by default.</td>
 				</tr>
 			
 		

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -498,8 +498,8 @@ annotations:
   - name: topology.istio.io/controlPlaneClusters
     featureStatus: Alpha
     description: A comma-separated list of clusters (or * for any) running istiod that should attempt leader election
-      for a remote cluster thats system namespace includes this annotation. Istiod will attempt to lead unannotated
-      remote clusters by default.
+      for a remote cluster thats system namespace includes this annotation. Istiod will not attempt to lead unannotated
+      remote clusters.
     deprecated: false
     hidden: false
     resources:

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -494,3 +494,11 @@ annotations:
     hidden: true
     resources:
       - WorkloadEntry
+
+  - name: topology.istio.io/istiodClusters
+    featureStatus: Alpha
+    description: Comma-separated list of clusters (or * for any) with an istiod that should attempt leader election for a remote cluster.
+    deprecated: false
+    hidden: false
+    resources:
+      - Namespace

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -495,7 +495,7 @@ annotations:
     resources:
       - WorkloadEntry
 
-  - name: topology.istio.io/istiodClusters
+  - name: topology.istio.io/controlPlaneClusters
     featureStatus: Alpha
     description: A comma-separated list of clusters (or * for any) running istiod that should attempt leader election
       for a remote cluster thats system namespace includes this annotation. Istiod will attempt to lead unannotated

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -498,7 +498,7 @@ annotations:
   - name: topology.istio.io/istiodClusters
     featureStatus: Alpha
     description: A comma-separated list of clusters (or * for any) running istiod that should attempt leader election
-      for a remote cluster whose system namepace includes this annotation. Istiod will not attempt to lead other remote
+      for a remote cluster whose system namespace includes this annotation. Istiod will not attempt to lead other remote
       clusters by default.
     deprecated: false
     hidden: false

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -498,8 +498,8 @@ annotations:
   - name: topology.istio.io/istiodClusters
     featureStatus: Alpha
     description: A comma-separated list of clusters (or * for any) running istiod that should attempt leader election
-      for a remote cluster whose system namespace includes this annotation. Istiod will not attempt to lead other remote
-      clusters by default.
+      for a remote cluster thats system namespace includes this annotation. Istiod will attempt to lead unannotated
+      remote clusters by default.
     deprecated: false
     hidden: false
     resources:

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -497,7 +497,9 @@ annotations:
 
   - name: topology.istio.io/istiodClusters
     featureStatus: Alpha
-    description: Comma-separated list of clusters (or * for any) with an istiod that should attempt leader election for a remote cluster.
+    description: A comma-separated list of clusters (or * for any) running istiod that should attempt leader election
+      for a remote cluster whose system namepace includes this annotation. Istiod will not attempt to lead other remote
+      clusters by default.
     deprecated: false
     hidden: false
     resources:

--- a/releasenotes/notes/39157.yaml
+++ b/releasenotes/notes/39157.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - https://github.com/istio/istio/issues/39257
+
+releaseNotes:
+  - |
+    **Added** `topology.istio.io/istiodClusters` namespace annotation to configure remote cluster leaders.

--- a/releasenotes/notes/39157.yaml
+++ b/releasenotes/notes/39157.yaml
@@ -6,4 +6,4 @@ issue:
 
 releaseNotes:
   - |
-    **Added** `topology.istio.io/istiodClusters` namespace annotation to configure remote cluster leaders.
+    **Added** `topology.istio.io/controlPlaneClusters` namespace annotation to configure remote cluster leaders.


### PR DESCRIPTION
New namespace annotation used to configure leader(s) for remote clusters.

See https://github.com/istio/istio/pull/39406