### PR TITLE
Clarify that EnvoyFileAccessLogProvider labels == JSON

### DIFF
--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -848,11 +848,12 @@ message MeshConfig {
           // Example: `text: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%"`
           string text = 1;
 
-          // Structured format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)
+          // JSON structured format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)
           // can be used as values for fields within the Struct. Values are rendered
           // as strings, numbers, or boolean values, as appropriate
           // (see: [format dictionaries](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-dictionaries)). Nested JSON is
-          // supported for some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
+          // supported for some command operators (e.g. FILTER\_STATE or DYNAMIC\_METADATA).
+          // Use `labels: {}` for default envoy JSON log format.
           //
           // Example:
           // ```


### PR DESCRIPTION
It wasn't obvious at all to me and others that `labels` was equivalent to logformat json in mesh config

This attempts to make it clearer as well as document the `labels: {}` trick
