### PR TITLE
Add auto-san-validation documentation

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -2076,7 +2076,7 @@
             "type": "string"
           },
           "subjectAltNames": {
-            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry.",
+            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry. If unspecified, automatic validation of upstream presented certificate for new upstream connections will be done based on the downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT` and `ENABLE_AUTO_SNI` environmental variables are set to `true`.",
             "type": "array",
             "items": {
               "type": "string"

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -30,7 +30,7 @@
             "type": "string"
           },
           "subjectAltNames": {
-            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry.",
+            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry. If unspecified, automatic validation of upstream presented certificate for new upstream connections will be done based on the downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT` and `ENABLE_AUTO_SNI` environmental variables are set to `true`.",
             "type": "array",
             "items": {
               "type": "string"

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1490,7 +1490,10 @@ type ClientTLSSettings struct {
 	// certificate. If specified, the proxy will verify that the server
 	// certificate's subject alt name matches one of the specified values.
 	// If specified, this list overrides the value of subject_alt_names
-	// from the ServiceEntry.
+	// from the ServiceEntry. If unspecified, automatic validation of upstream
+	// presented certificate for new upstream connections will be done based on the
+	// downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT`
+	// and `ENABLE_AUTO_SNI` environmental variables are set to `true`.
 	SubjectAltNames []string `protobuf:"bytes,5,rep,name=subject_alt_names,json=subjectAltNames,proto3" json:"subject_alt_names,omitempty"`
 	// SNI string to present to the server during TLS handshake.
 	// If unspecified, SNI will be automatically set based on downstream HTTP

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1177,7 +1177,10 @@ No
 certificate. If specified, the proxy will verify that the server
 certificate&rsquo;s subject alt name matches one of the specified values.
 If specified, this list overrides the value of subject_alt_names
-from the ServiceEntry.</p>
+from the ServiceEntry. If unspecified, automatic validation of upstream
+presented certificate for new upstream connections will be done based on the
+downstream HTTP host/authority header, provided <code>VERIFY_CERT_AT_CLIENT</code>
+and <code>ENABLE_AUTO_SNI</code> environmental variables are set to <code>true</code>.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -1071,7 +1071,10 @@ message ClientTLSSettings {
   // certificate. If specified, the proxy will verify that the server
   // certificate's subject alt name matches one of the specified values.
   // If specified, this list overrides the value of subject_alt_names
-  // from the ServiceEntry.
+  // from the ServiceEntry. If unspecified, automatic validation of upstream
+  // presented certificate for new upstream connections will be done based on the
+  // downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT`
+  // and `ENABLE_AUTO_SNI` environmental variables are set to `true`.
   repeated string subject_alt_names = 5;
 
   // SNI string to present to the server during TLS handshake.

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -30,7 +30,7 @@
             "type": "string"
           },
           "subjectAltNames": {
-            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry.",
+            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry. If unspecified, automatic validation of upstream presented certificate for new upstream connections will be done based on the downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT` and `ENABLE_AUTO_SNI` environmental variables are set to `true`.",
             "type": "array",
             "items": {
               "type": "string"

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1439,7 +1439,10 @@ type ClientTLSSettings struct {
 	// certificate. If specified, the proxy will verify that the server
 	// certificate's subject alt name matches one of the specified values.
 	// If specified, this list overrides the value of subject_alt_names
-	// from the ServiceEntry.
+	// from the ServiceEntry. If unspecified, automatic validation of upstream
+	// presented certificate for new upstream connections will be done based on the
+	// downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT`
+	// and `ENABLE_AUTO_SNI` environmental variables are set to `true`.
 	SubjectAltNames []string `protobuf:"bytes,5,rep,name=subject_alt_names,json=subjectAltNames,proto3" json:"subject_alt_names,omitempty"`
 	// SNI string to present to the server during TLS handshake.
 	// If unspecified, SNI will be automatically set based on downstream HTTP

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -1020,7 +1020,10 @@ message ClientTLSSettings {
   // certificate. If specified, the proxy will verify that the server
   // certificate's subject alt name matches one of the specified values.
   // If specified, this list overrides the value of subject_alt_names
-  // from the ServiceEntry.
+  // from the ServiceEntry. If unspecified, automatic validation of upstream
+  // presented certificate for new upstream connections will be done based on the
+  // downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT`
+  // and `ENABLE_AUTO_SNI` environmental variables are set to `true`.
   repeated string subject_alt_names = 5;
 
   // SNI string to present to the server during TLS handshake.


### PR DESCRIPTION
auto-san-validation feature was introduced in 1.14 release. Enhancing the subject_alt_names description a bit to clarify the behaviour.
Signed-off-by: Faseela K <faseela.k@est.tech>