### PR TITLE
clarify destination rule docs

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -197,12 +197,11 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
                                   format: int32
                                   type: integer
                                 http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
+                                  description: Maximum number of active requests to
+                                    a destination.
                                   format: int32
                                   type: integer
                                 idleTimeout:
@@ -448,13 +447,11 @@ spec:
                                         - UPGRADE
                                         type: string
                                       http1MaxPendingRequests:
-                                        description: Maximum number of pending HTTP
-                                          requests to a destination.
                                         format: int32
                                         type: integer
                                       http2MaxRequests:
-                                        description: Maximum number of requests to
-                                          a backend.
+                                        description: Maximum number of active requests
+                                          to a destination.
                                         format: int32
                                         type: integer
                                       idleTimeout:
@@ -793,12 +790,10 @@ spec:
                             - UPGRADE
                             type: string
                           http1MaxPendingRequests:
-                            description: Maximum number of pending HTTP requests to
-                              a destination.
                             format: int32
                             type: integer
                           http2MaxRequests:
-                            description: Maximum number of requests to a backend.
+                            description: Maximum number of active requests to a destination.
                             format: int32
                             type: integer
                           idleTimeout:
@@ -1040,12 +1035,11 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
                                   format: int32
                                   type: integer
                                 http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
+                                  description: Maximum number of active requests to
+                                    a destination.
                                   format: int32
                                   type: integer
                                 idleTimeout:
@@ -1434,12 +1428,11 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
                                   format: int32
                                   type: integer
                                 http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
+                                  description: Maximum number of active requests to
+                                    a destination.
                                   format: int32
                                   type: integer
                                 idleTimeout:
@@ -1685,13 +1678,11 @@ spec:
                                         - UPGRADE
                                         type: string
                                       http1MaxPendingRequests:
-                                        description: Maximum number of pending HTTP
-                                          requests to a destination.
                                         format: int32
                                         type: integer
                                       http2MaxRequests:
-                                        description: Maximum number of requests to
-                                          a backend.
+                                        description: Maximum number of active requests
+                                          to a destination.
                                         format: int32
                                         type: integer
                                       idleTimeout:
@@ -2030,12 +2021,10 @@ spec:
                             - UPGRADE
                             type: string
                           http1MaxPendingRequests:
-                            description: Maximum number of pending HTTP requests to
-                              a destination.
                             format: int32
                             type: integer
                           http2MaxRequests:
-                            description: Maximum number of requests to a backend.
+                            description: Maximum number of active requests to a destination.
                             format: int32
                             type: integer
                           idleTimeout:
@@ -2277,12 +2266,11 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests
-                                    to a destination.
                                   format: int32
                                   type: integer
                                 http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
+                                  description: Maximum number of active requests to
+                                    a destination.
                                   format: int32
                                   type: integer
                                 idleTimeout:

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -74,12 +74,12 @@
         "type": "object",
         "properties": {
           "http1MaxPendingRequests": {
-            "description": "Maximum number of pending HTTP requests to a destination. Default 2^32-1.",
+            "description": "Maximum number of pending HTTP requests to a destination. Default 2^32-1. Please note that this is applicable to both HTTP1.1/ and HTTP2.",
             "type": "integer",
             "format": "int32"
           },
           "http2MaxRequests": {
-            "description": "Maximum number of requests to a backend. Default 2^32-1.",
+            "description": "Maximum number of requests to a backend. Default 2^32-1. Please note that this is applicable to both HTTP1.1/ and HTTP2.",
             "type": "integer",
             "format": "int32"
           },

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -74,12 +74,12 @@
         "type": "object",
         "properties": {
           "http1MaxPendingRequests": {
-            "description": "Maximum number of pending HTTP requests to a destination. Default 2^32-1. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
+            "description": "Maximum number of requests that will be queued while waiting for a ready connection pool connection. Default 1024. Refer to https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking under which conditions a new connection is created for HTTP2. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
             "type": "integer",
             "format": "int32"
           },
           "http2MaxRequests": {
-            "description": "Maximum number of requests to a backend. Default 2^32-1. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
+            "description": "Maximum number of active requests to a destination. Default 1024. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
             "type": "integer",
             "format": "int32"
           },

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -74,12 +74,12 @@
         "type": "object",
         "properties": {
           "http1MaxPendingRequests": {
-            "description": "Maximum number of pending HTTP requests to a destination. Default 2^32-1. Please note that this is applicable to both HTTP1.1/ and HTTP2.",
+            "description": "Maximum number of pending HTTP requests to a destination. Default 2^32-1. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
             "type": "integer",
             "format": "int32"
           },
           "http2MaxRequests": {
-            "description": "Maximum number of requests to a backend. Default 2^32-1. Please note that this is applicable to both HTTP1.1/ and HTTP2.",
+            "description": "Maximum number of requests to a backend. Default 2^32-1. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
             "type": "integer",
             "format": "int32"
           },

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -2219,10 +2219,13 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+	// Maximum number of requests that will be queued while waiting for
+	// a ready connection pool connection. Default 1024.
+	// Refer to https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking
+	// under which conditions a new connection is created for HTTP2.
 	// Please note that this is applicable to both HTTP/1.1 and HTTP2.
 	Http1MaxPendingRequests int32 `protobuf:"varint,1,opt,name=http1_max_pending_requests,json=http1MaxPendingRequests,proto3" json:"http1_max_pending_requests,omitempty"`
-	// Maximum number of requests to a backend. Default 2^32-1.
+	// Maximum number of active requests to a destination. Default 1024.
 	// Please note that this is applicable to both HTTP/1.1 and HTTP2.
 	Http2MaxRequests int32 `protobuf:"varint,2,opt,name=http2_max_requests,json=http2MaxRequests,proto3" json:"http2_max_requests,omitempty"`
 	// Maximum number of requests per connection to a backend. Setting this

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -2220,10 +2220,10 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Maximum number of pending HTTP requests to a destination. Default 2^32-1.
-	// Please note that this is applicable to both HTTP1.1/ and HTTP2.
+	// Please note that this is applicable to both HTTP/1.1 and HTTP2.
 	Http1MaxPendingRequests int32 `protobuf:"varint,1,opt,name=http1_max_pending_requests,json=http1MaxPendingRequests,proto3" json:"http1_max_pending_requests,omitempty"`
 	// Maximum number of requests to a backend. Default 2^32-1.
-	// Please note that this is applicable to both HTTP1.1/ and HTTP2.
+	// Please note that this is applicable to both HTTP/1.1 and HTTP2.
 	Http2MaxRequests int32 `protobuf:"varint,2,opt,name=http2_max_requests,json=http2MaxRequests,proto3" json:"http2_max_requests,omitempty"`
 	// Maximum number of requests per connection to a backend. Setting this
 	// parameter to 1 disables keep alive. Default 0, meaning "unlimited",

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -2220,8 +2220,10 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+	// Please note that this is applicable to both HTTP1.1/ and HTTP2.
 	Http1MaxPendingRequests int32 `protobuf:"varint,1,opt,name=http1_max_pending_requests,json=http1MaxPendingRequests,proto3" json:"http1_max_pending_requests,omitempty"`
 	// Maximum number of requests to a backend. Default 2^32-1.
+	// Please note that this is applicable to both HTTP1.1/ and HTTP2.
 	Http2MaxRequests int32 `protobuf:"varint,2,opt,name=http2_max_requests,json=http2MaxRequests,proto3" json:"http2_max_requests,omitempty"`
 	// Maximum number of requests per connection to a backend. Setting this
 	// parameter to 1 disables keep alive. Default 0, meaning "unlimited",

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1723,7 +1723,8 @@ No
 <td><code>http1MaxPendingRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of pending HTTP requests to a destination. Default 2^32-1.</p>
+<p>Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+Please note that this is applicable to both HTTP1.1/ and HTTP2.</p>
 
 </td>
 <td>
@@ -1734,7 +1735,8 @@ No
 <td><code>http2MaxRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of requests to a backend. Default 2^32-1.</p>
+<p>Maximum number of requests to a backend. Default 2^32-1.
+Please note that this is applicable to both HTTP1.1/ and HTTP2.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1723,7 +1723,10 @@ No
 <td><code>http1MaxPendingRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+<p>Maximum number of requests that will be queued while waiting for
+a ready connection pool connection. Default 1024.
+Refer to https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking
+under which conditions a new connection is created for HTTP2.
 Please note that this is applicable to both HTTP/1.1 and HTTP2.</p>
 
 </td>
@@ -1735,7 +1738,7 @@ No
 <td><code>http2MaxRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of requests to a backend. Default 2^32-1.
+<p>Maximum number of active requests to a destination. Default 1024.
 Please note that this is applicable to both HTTP/1.1 and HTTP2.</p>
 
 </td>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1724,7 +1724,7 @@ No
 <td><code>int32</code></td>
 <td>
 <p>Maximum number of pending HTTP requests to a destination. Default 2^32-1.
-Please note that this is applicable to both HTTP1.1/ and HTTP2.</p>
+Please note that this is applicable to both HTTP/1.1 and HTTP2.</p>
 
 </td>
 <td>
@@ -1736,7 +1736,7 @@ No
 <td><code>int32</code></td>
 <td>
 <p>Maximum number of requests to a backend. Default 2^32-1.
-Please note that this is applicable to both HTTP1.1/ and HTTP2.</p>
+Please note that this is applicable to both HTTP/1.1 and HTTP2.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -709,11 +709,14 @@ message ConnectionPoolSettings {
 
   // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
   message HTTPSettings {
-    // Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+    // Maximum number of requests that will be queued while waiting for
+    // a ready connection pool connection. Default 1024.
+    // Refer to https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking
+    // under which conditions a new connection is created for HTTP2.
     // Please note that this is applicable to both HTTP/1.1 and HTTP2.
     int32 http1_max_pending_requests = 1;
 
-    // Maximum number of requests to a backend. Default 2^32-1.
+    // Maximum number of active requests to a destination. Default 1024.
     // Please note that this is applicable to both HTTP/1.1 and HTTP2.
     int32 http2_max_requests = 2;
 

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -710,11 +710,11 @@ message ConnectionPoolSettings {
   // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
   message HTTPSettings {
     // Maximum number of pending HTTP requests to a destination. Default 2^32-1.
-    // Please note that this is applicable to both HTTP1.1/ and HTTP2.
+    // Please note that this is applicable to both HTTP/1.1 and HTTP2.
     int32 http1_max_pending_requests = 1;
 
     // Maximum number of requests to a backend. Default 2^32-1.
-    // Please note that this is applicable to both HTTP1.1/ and HTTP2.
+    // Please note that this is applicable to both HTTP/1.1 and HTTP2.
     int32 http2_max_requests = 2;
 
     // Maximum number of requests per connection to a backend. Setting this

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -710,9 +710,11 @@ message ConnectionPoolSettings {
   // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
   message HTTPSettings {
     // Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+    // Please note that this is applicable to both HTTP1.1/ and HTTP2.
     int32 http1_max_pending_requests = 1;
 
     // Maximum number of requests to a backend. Default 2^32-1.
+    // Please note that this is applicable to both HTTP1.1/ and HTTP2.
     int32 http2_max_requests = 2;
 
     // Maximum number of requests per connection to a backend. Setting this

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -74,12 +74,12 @@
         "type": "object",
         "properties": {
           "http1MaxPendingRequests": {
-            "description": "Maximum number of pending HTTP requests to a destination. Default 2^32-1.",
+            "description": "Maximum number of pending HTTP requests to a destination. Default 2^32-1. Please note that this is applicable to both HTTP1.1/ and HTTP2.",
             "type": "integer",
             "format": "int32"
           },
           "http2MaxRequests": {
-            "description": "Maximum number of requests to a backend. Default 2^32-1.",
+            "description": "Maximum number of requests to a backend. Default 2^32-1. Please note that this is applicable to both HTTP1.1/ and HTTP2.",
             "type": "integer",
             "format": "int32"
           },

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -74,12 +74,12 @@
         "type": "object",
         "properties": {
           "http1MaxPendingRequests": {
-            "description": "Maximum number of pending HTTP requests to a destination. Default 2^32-1. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
+            "description": "Maximum number of requests that will be queued while waiting for a ready connection pool connection. Default 1024. Refer to https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking under which conditions a new connection is created for HTTP2. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
             "type": "integer",
             "format": "int32"
           },
           "http2MaxRequests": {
-            "description": "Maximum number of requests to a backend. Default 2^32-1. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
+            "description": "Maximum number of active requests to a destination. Default 1024. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
             "type": "integer",
             "format": "int32"
           },

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -74,12 +74,12 @@
         "type": "object",
         "properties": {
           "http1MaxPendingRequests": {
-            "description": "Maximum number of pending HTTP requests to a destination. Default 2^32-1. Please note that this is applicable to both HTTP1.1/ and HTTP2.",
+            "description": "Maximum number of pending HTTP requests to a destination. Default 2^32-1. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
             "type": "integer",
             "format": "int32"
           },
           "http2MaxRequests": {
-            "description": "Maximum number of requests to a backend. Default 2^32-1. Please note that this is applicable to both HTTP1.1/ and HTTP2.",
+            "description": "Maximum number of requests to a backend. Default 2^32-1. Please note that this is applicable to both HTTP/1.1 and HTTP2.",
             "type": "integer",
             "format": "int32"
           },

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -2169,8 +2169,10 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+	// Please note that this is applicable to both HTTP1.1/ and HTTP2.
 	Http1MaxPendingRequests int32 `protobuf:"varint,1,opt,name=http1_max_pending_requests,json=http1MaxPendingRequests,proto3" json:"http1_max_pending_requests,omitempty"`
 	// Maximum number of requests to a backend. Default 2^32-1.
+	// Please note that this is applicable to both HTTP1.1/ and HTTP2.
 	Http2MaxRequests int32 `protobuf:"varint,2,opt,name=http2_max_requests,json=http2MaxRequests,proto3" json:"http2_max_requests,omitempty"`
 	// Maximum number of requests per connection to a backend. Setting this
 	// parameter to 1 disables keep alive. Default 0, meaning "unlimited",

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -2168,10 +2168,13 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+	// Maximum number of requests that will be queued while waiting for
+	// a ready connection pool connection. Default 1024.
+	// Refer to https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking
+	// under which conditions a new connection is created for HTTP2.
 	// Please note that this is applicable to both HTTP/1.1 and HTTP2.
 	Http1MaxPendingRequests int32 `protobuf:"varint,1,opt,name=http1_max_pending_requests,json=http1MaxPendingRequests,proto3" json:"http1_max_pending_requests,omitempty"`
-	// Maximum number of requests to a backend. Default 2^32-1.
+	// Maximum number of active requests to a destination. Default 1024.
 	// Please note that this is applicable to both HTTP/1.1 and HTTP2.
 	Http2MaxRequests int32 `protobuf:"varint,2,opt,name=http2_max_requests,json=http2MaxRequests,proto3" json:"http2_max_requests,omitempty"`
 	// Maximum number of requests per connection to a backend. Setting this

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -2169,10 +2169,10 @@ type ConnectionPoolSettings_HTTPSettings struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Maximum number of pending HTTP requests to a destination. Default 2^32-1.
-	// Please note that this is applicable to both HTTP1.1/ and HTTP2.
+	// Please note that this is applicable to both HTTP/1.1 and HTTP2.
 	Http1MaxPendingRequests int32 `protobuf:"varint,1,opt,name=http1_max_pending_requests,json=http1MaxPendingRequests,proto3" json:"http1_max_pending_requests,omitempty"`
 	// Maximum number of requests to a backend. Default 2^32-1.
-	// Please note that this is applicable to both HTTP1.1/ and HTTP2.
+	// Please note that this is applicable to both HTTP/1.1 and HTTP2.
 	Http2MaxRequests int32 `protobuf:"varint,2,opt,name=http2_max_requests,json=http2MaxRequests,proto3" json:"http2_max_requests,omitempty"`
 	// Maximum number of requests per connection to a backend. Setting this
 	// parameter to 1 disables keep alive. Default 0, meaning "unlimited",

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -659,9 +659,11 @@ message ConnectionPoolSettings {
   // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
   message HTTPSettings {
     // Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+    // Please note that this is applicable to both HTTP1.1/ and HTTP2.
     int32 http1_max_pending_requests = 1;
 
     // Maximum number of requests to a backend. Default 2^32-1.
+    // Please note that this is applicable to both HTTP1.1/ and HTTP2.
     int32 http2_max_requests = 2;
 
     // Maximum number of requests per connection to a backend. Setting this

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -658,11 +658,14 @@ message ConnectionPoolSettings {
 
   // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
   message HTTPSettings {
-    // Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+    // Maximum number of requests that will be queued while waiting for
+    // a ready connection pool connection. Default 1024.
+    // Refer to https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking
+    // under which conditions a new connection is created for HTTP2.
     // Please note that this is applicable to both HTTP/1.1 and HTTP2.
     int32 http1_max_pending_requests = 1;
 
-    // Maximum number of requests to a backend. Default 2^32-1.
+    // Maximum number of active requests to a destination. Default 1024.
     // Please note that this is applicable to both HTTP/1.1 and HTTP2.
     int32 http2_max_requests = 2;
 

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -659,11 +659,11 @@ message ConnectionPoolSettings {
   // Settings applicable to HTTP1.1/HTTP2/GRPC connections.
   message HTTPSettings {
     // Maximum number of pending HTTP requests to a destination. Default 2^32-1.
-    // Please note that this is applicable to both HTTP1.1/ and HTTP2.
+    // Please note that this is applicable to both HTTP/1.1 and HTTP2.
     int32 http1_max_pending_requests = 1;
 
     // Maximum number of requests to a backend. Default 2^32-1.
-    // Please note that this is applicable to both HTTP1.1/ and HTTP2.
+    // Please note that this is applicable to both HTTP/1.1 and HTTP2.
     int32 http2_max_requests = 2;
 
     // Maximum number of requests per connection to a backend. Setting this


### PR DESCRIPTION
Clarify Destination Rule docs that Max Pending Requests/ Max Requests apply to both Http1 and Http2

See https://github.com/istio/istio/issues/31548 and https://github.com/envoyproxy/envoy/pull/9668 (See version history and doc updates)