### PR TITLE
Update sidecar bind description to include IPv6

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -3866,7 +3866,8 @@ spec:
                 items:
                   properties:
                     bind:
-                      description: The IP to which the listener should be bound.
+                      description: The IP(IPv4 or IPv6) to which the listener should
+                        be bound.
                       type: string
                     captureMode:
                       enum:
@@ -4038,7 +4039,8 @@ spec:
                 items:
                   properties:
                     bind:
-                      description: The IP to which the listener should be bound.
+                      description: The IP(IPv4 or IPv6) to which the listener should
+                        be bound.
                       type: string
                     captureMode:
                       enum:

--- a/networking/v1alpha3/sidecar.gen.json
+++ b/networking/v1alpha3/sidecar.gen.json
@@ -40,7 +40,7 @@
             "$ref": "#/components/schemas/istio.networking.v1alpha3.Port"
           },
           "bind": {
-            "description": "The IP or the Unix domain socket to which the listener should be bound to. Port MUST be specified if bind is not empty. Format: `x.x.x.x` or `unix:///path/to/uds` or `unix://@foobar` (Linux abstract namespace). If omitted, Istio will automatically configure the defaults based on imported services, the workload instances to which this configuration is applied to and the captureMode. If captureMode is `NONE`, bind will default to 127.0.0.1.",
+            "description": "The IP(IPv4 or IPv6) or the Unix domain socket to which the listener should be bound to. Port MUST be specified if bind is not empty. Format: IPv4 or IPv6 address formats or `unix:///path/to/uds` or `unix://@foobar` (Linux abstract namespace). If omitted, Istio will automatically configure the defaults based on imported services, the workload instances to which this configuration is applied to and the captureMode. If captureMode is `NONE`, bind will default to 127.0.0.1.",
             "type": "string"
           },
           "captureMode": {
@@ -63,14 +63,14 @@
             "$ref": "#/components/schemas/istio.networking.v1alpha3.Port"
           },
           "bind": {
-            "description": "The IP to which the listener should be bound. Must be in the format `x.x.x.x`. Unix domain socket addresses are not allowed in the bind field for ingress listeners. If omitted, Istio will automatically configure the defaults based on imported services and the workload instances to which this configuration is applied to.",
+            "description": "The IP(IPv4 or IPv6) to which the listener should be bound. Unix domain socket addresses are not allowed in the bind field for ingress listeners. If omitted, Istio will automatically configure the defaults based on imported services and the workload instances to which this configuration is applied to.",
             "type": "string"
           },
           "captureMode": {
             "$ref": "#/components/schemas/istio.networking.v1alpha3.CaptureMode"
           },
           "defaultEndpoint": {
-            "description": "The IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost), `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP), or `unix:///path/to/socket` (forward to Unix domain socket).",
+            "description": "The IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost), `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP), or `unix:///path/to/socket` (forward to Unix domain socket)",
             "type": "string"
           },
           "tls": {

--- a/networking/v1alpha3/sidecar.gen.json
+++ b/networking/v1alpha3/sidecar.gen.json
@@ -70,7 +70,7 @@
             "$ref": "#/components/schemas/istio.networking.v1alpha3.CaptureMode"
           },
           "defaultEndpoint": {
-            "description": "The IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost), `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP), or `unix:///path/to/socket` (forward to Unix domain socket)",
+            "description": "The IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost), `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP), or `unix:///path/to/socket` (forward to Unix domain socket).",
             "type": "string"
           },
           "tls": {

--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -728,8 +728,8 @@ type IstioIngressListener struct {
 
 	// The port associated with the listener.
 	Port *Port `protobuf:"bytes,1,opt,name=port,proto3" json:"port,omitempty"`
-	// The IP to which the listener should be bound. Must be in the
-	// format `x.x.x.x`. Unix domain socket addresses are not allowed in
+	// The IP(IPv4 or IPv6) to which the listener should be bound.
+	// Unix domain socket addresses are not allowed in
 	// the bind field for ingress listeners. If omitted, Istio will
 	// automatically configure the defaults based on imported services
 	// and the workload instances to which this configuration is applied
@@ -745,7 +745,7 @@ type IstioIngressListener struct {
 	// connections. Arbitrary IPs are not supported. Format should be one of
 	// `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost),
 	// `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP),
-	// or `unix:///path/to/socket` (forward to Unix domain socket).
+	// or `unix:///path/to/socket` (forward to Unix domain socket)
 	DefaultEndpoint string `protobuf:"bytes,4,opt,name=default_endpoint,json=defaultEndpoint,proto3" json:"default_endpoint,omitempty"`
 	// Set of TLS related options that will enable TLS termination on the
 	// sidecar for requests originating from outside the mesh.
@@ -837,8 +837,8 @@ type IstioEgressListener struct {
 	// listener port will be based on the listener with the most specific
 	// port.
 	Port *Port `protobuf:"bytes,1,opt,name=port,proto3" json:"port,omitempty"`
-	// The IP or the Unix domain socket to which the listener should be bound
-	// to. Port MUST be specified if bind is not empty. Format: `x.x.x.x` or
+	// The IP(IPv4 or IPv6) or the Unix domain socket to which the listener should be bound
+	// to. Port MUST be specified if bind is not empty. Format: IPv4 or IPv6 address formats or
 	// `unix:///path/to/uds` or `unix://@foobar` (Linux abstract namespace). If
 	// omitted, Istio will automatically configure the defaults based on imported
 	// services, the workload instances to which this configuration is applied to and

--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -745,7 +745,7 @@ type IstioIngressListener struct {
 	// connections. Arbitrary IPs are not supported. Format should be one of
 	// `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost),
 	// `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP),
-	// or `unix:///path/to/socket` (forward to Unix domain socket)
+	// or `unix:///path/to/socket` (forward to Unix domain socket).
 	DefaultEndpoint string `protobuf:"bytes,4,opt,name=default_endpoint,json=defaultEndpoint,proto3" json:"default_endpoint,omitempty"`
 	// Set of TLS related options that will enable TLS termination on the
 	// sidecar for requests originating from outside the mesh.

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -586,8 +586,8 @@ Yes
 <td><code>bind</code></td>
 <td><code>string</code></td>
 <td>
-<p>The IP to which the listener should be bound. Must be in the
-format <code>x.x.x.x</code>. Unix domain socket addresses are not allowed in
+<p>The IP(IPv4 or IPv6) to which the listener should be bound.
+Unix domain socket addresses are not allowed in
 the bind field for ingress listeners. If omitted, Istio will
 automatically configure the defaults based on imported services
 and the workload instances to which this configuration is applied
@@ -621,7 +621,7 @@ or Unix domain socket where the application workload instance is listening for
 connections. Arbitrary IPs are not supported. Format should be one of
 <code>127.0.0.1:PORT</code>, <code>[::1]:PORT</code> (forward to localhost),
 <code>0.0.0.0:PORT</code>, <code>[::]:PORT</code> (forward to the instance IP),
-or <code>unix:///path/to/socket</code> (forward to Unix domain socket).</p>
+or <code>unix:///path/to/socket</code> (forward to Unix domain socket)</p>
 
 </td>
 <td>
@@ -682,8 +682,8 @@ No
 <td><code>bind</code></td>
 <td><code>string</code></td>
 <td>
-<p>The IP or the Unix domain socket to which the listener should be bound
-to. Port MUST be specified if bind is not empty. Format: <code>x.x.x.x</code> or
+<p>The IP(IPv4 or IPv6) or the Unix domain socket to which the listener should be bound
+to. Port MUST be specified if bind is not empty. Format: IPv4 or IPv6 address formats or
 <code>unix:///path/to/uds</code> or <code>unix://@foobar</code> (Linux abstract namespace). If
 omitted, Istio will automatically configure the defaults based on imported
 services, the workload instances to which this configuration is applied to and

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -621,7 +621,7 @@ or Unix domain socket where the application workload instance is listening for
 connections. Arbitrary IPs are not supported. Format should be one of
 <code>127.0.0.1:PORT</code>, <code>[::1]:PORT</code> (forward to localhost),
 <code>0.0.0.0:PORT</code>, <code>[::]:PORT</code> (forward to the instance IP),
-or <code>unix:///path/to/socket</code> (forward to Unix domain socket)</p>
+or <code>unix:///path/to/socket</code> (forward to Unix domain socket).</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -564,7 +564,7 @@ message IstioIngressListener {
   // connections. Arbitrary IPs are not supported. Format should be one of
   // `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost),
   // `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP),
-  // or `unix:///path/to/socket` (forward to Unix domain socket)
+  // or `unix:///path/to/socket` (forward to Unix domain socket).
   string default_endpoint = 4 [(google.api.field_behavior) = REQUIRED];
 
   reserved "localhost_client_tls";

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -545,8 +545,8 @@ message IstioIngressListener {
   // The port associated with the listener.
   Port port = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // The IP to which the listener should be bound. Must be in the
-  // format `x.x.x.x`. Unix domain socket addresses are not allowed in
+  // The IP(IPv4 or IPv6) to which the listener should be bound.
+  // Unix domain socket addresses are not allowed in
   // the bind field for ingress listeners. If omitted, Istio will
   // automatically configure the defaults based on imported services
   // and the workload instances to which this configuration is applied
@@ -564,7 +564,7 @@ message IstioIngressListener {
   // connections. Arbitrary IPs are not supported. Format should be one of
   // `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost),
   // `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP),
-  // or `unix:///path/to/socket` (forward to Unix domain socket).
+  // or `unix:///path/to/socket` (forward to Unix domain socket)
   string default_endpoint = 4 [(google.api.field_behavior) = REQUIRED];
 
   reserved "localhost_client_tls";
@@ -590,8 +590,8 @@ message IstioEgressListener {
   // port.
   Port port = 1;
 
-  // The IP or the Unix domain socket to which the listener should be bound
-  // to. Port MUST be specified if bind is not empty. Format: `x.x.x.x` or
+  // The IP(IPv4 or IPv6) or the Unix domain socket to which the listener should be bound
+  // to. Port MUST be specified if bind is not empty. Format: IPv4 or IPv6 address formats or
   // `unix:///path/to/uds` or `unix://@foobar` (Linux abstract namespace). If
   // omitted, Istio will automatically configure the defaults based on imported
   // services, the workload instances to which this configuration is applied to and

--- a/networking/v1beta1/sidecar.gen.json
+++ b/networking/v1beta1/sidecar.gen.json
@@ -40,7 +40,7 @@
             "$ref": "#/components/schemas/istio.networking.v1beta1.Port"
           },
           "bind": {
-            "description": "The IP or the Unix domain socket to which the listener should be bound to. Port MUST be specified if bind is not empty. Format: `x.x.x.x` or `unix:///path/to/uds` or `unix://@foobar` (Linux abstract namespace). If omitted, Istio will automatically configure the defaults based on imported services, the workload instances to which this configuration is applied to and the captureMode. If captureMode is `NONE`, bind will default to 127.0.0.1.",
+            "description": "The IP(IPv4 or IPv6) or the Unix domain socket to which the listener should be bound to. Port MUST be specified if bind is not empty. Format: IPv4 or IPv6 address formats or `unix:///path/to/uds` or `unix://@foobar` (Linux abstract namespace). If omitted, Istio will automatically configure the defaults based on imported services, the workload instances to which this configuration is applied to and the captureMode. If captureMode is `NONE`, bind will default to 127.0.0.1.",
             "type": "string"
           },
           "captureMode": {
@@ -63,14 +63,14 @@
             "$ref": "#/components/schemas/istio.networking.v1beta1.Port"
           },
           "bind": {
-            "description": "The IP to which the listener should be bound. Must be in the format `x.x.x.x`. Unix domain socket addresses are not allowed in the bind field for ingress listeners. If omitted, Istio will automatically configure the defaults based on imported services and the workload instances to which this configuration is applied to.",
+            "description": "The IP(IPv4 or IPv6) to which the listener should be bound. Unix domain socket addresses are not allowed in the bind field for ingress listeners. If omitted, Istio will automatically configure the defaults based on imported services and the workload instances to which this configuration is applied to.",
             "type": "string"
           },
           "captureMode": {
             "$ref": "#/components/schemas/istio.networking.v1beta1.CaptureMode"
           },
           "defaultEndpoint": {
-            "description": "The IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost), `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP), or `unix:///path/to/socket` (forward to Unix domain socket).",
+            "description": "The IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost), `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP), or `unix:///path/to/socket` (forward to Unix domain socket)",
             "type": "string"
           },
           "tls": {

--- a/networking/v1beta1/sidecar.gen.json
+++ b/networking/v1beta1/sidecar.gen.json
@@ -70,7 +70,7 @@
             "$ref": "#/components/schemas/istio.networking.v1beta1.CaptureMode"
           },
           "defaultEndpoint": {
-            "description": "The IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost), `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP), or `unix:///path/to/socket` (forward to Unix domain socket)",
+            "description": "The IP endpoint or Unix domain socket to which traffic should be forwarded to. This configuration can be used to redirect traffic arriving at the bind `IP:Port` on the sidecar to a `localhost:port` or Unix domain socket where the application workload instance is listening for connections. Arbitrary IPs are not supported. Format should be one of `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost), `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP), or `unix:///path/to/socket` (forward to Unix domain socket).",
             "type": "string"
           },
           "tls": {

--- a/networking/v1beta1/sidecar.pb.go
+++ b/networking/v1beta1/sidecar.pb.go
@@ -669,7 +669,7 @@ type IstioIngressListener struct {
 	// connections. Arbitrary IPs are not supported. Format should be one of
 	// `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost),
 	// `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP),
-	// or `unix:///path/to/socket` (forward to Unix domain socket)
+	// or `unix:///path/to/socket` (forward to Unix domain socket).
 	DefaultEndpoint string `protobuf:"bytes,4,opt,name=default_endpoint,json=defaultEndpoint,proto3" json:"default_endpoint,omitempty"`
 	// Set of TLS related options that will enable TLS termination on the
 	// sidecar for requests originating from outside the mesh.

--- a/networking/v1beta1/sidecar.pb.go
+++ b/networking/v1beta1/sidecar.pb.go
@@ -652,8 +652,8 @@ type IstioIngressListener struct {
 
 	// The port associated with the listener.
 	Port *Port `protobuf:"bytes,1,opt,name=port,proto3" json:"port,omitempty"`
-	// The IP to which the listener should be bound. Must be in the
-	// format `x.x.x.x`. Unix domain socket addresses are not allowed in
+	// The IP(IPv4 or IPv6) to which the listener should be bound.
+	// Unix domain socket addresses are not allowed in
 	// the bind field for ingress listeners. If omitted, Istio will
 	// automatically configure the defaults based on imported services
 	// and the workload instances to which this configuration is applied
@@ -669,7 +669,7 @@ type IstioIngressListener struct {
 	// connections. Arbitrary IPs are not supported. Format should be one of
 	// `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost),
 	// `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP),
-	// or `unix:///path/to/socket` (forward to Unix domain socket).
+	// or `unix:///path/to/socket` (forward to Unix domain socket)
 	DefaultEndpoint string `protobuf:"bytes,4,opt,name=default_endpoint,json=defaultEndpoint,proto3" json:"default_endpoint,omitempty"`
 	// Set of TLS related options that will enable TLS termination on the
 	// sidecar for requests originating from outside the mesh.
@@ -761,8 +761,8 @@ type IstioEgressListener struct {
 	// listener port will be based on the listener with the most specific
 	// port.
 	Port *Port `protobuf:"bytes,1,opt,name=port,proto3" json:"port,omitempty"`
-	// The IP or the Unix domain socket to which the listener should be bound
-	// to. Port MUST be specified if bind is not empty. Format: `x.x.x.x` or
+	// The IP(IPv4 or IPv6) or the Unix domain socket to which the listener should be bound
+	// to. Port MUST be specified if bind is not empty. Format: IPv4 or IPv6 address formats or
 	// `unix:///path/to/uds` or `unix://@foobar` (Linux abstract namespace). If
 	// omitted, Istio will automatically configure the defaults based on imported
 	// services, the workload instances to which this configuration is applied to and

--- a/networking/v1beta1/sidecar.proto
+++ b/networking/v1beta1/sidecar.proto
@@ -469,8 +469,8 @@ message IstioIngressListener {
   // The port associated with the listener.
   Port port = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // The IP to which the listener should be bound. Must be in the
-  // format `x.x.x.x`. Unix domain socket addresses are not allowed in
+  // The IP(IPv4 or IPv6) to which the listener should be bound.
+  // Unix domain socket addresses are not allowed in
   // the bind field for ingress listeners. If omitted, Istio will
   // automatically configure the defaults based on imported services
   // and the workload instances to which this configuration is applied
@@ -488,7 +488,7 @@ message IstioIngressListener {
   // connections. Arbitrary IPs are not supported. Format should be one of
   // `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost),
   // `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP),
-  // or `unix:///path/to/socket` (forward to Unix domain socket).
+  // or `unix:///path/to/socket` (forward to Unix domain socket)
   string default_endpoint = 4 [(google.api.field_behavior) = REQUIRED];
 
   reserved "localhost_client_tls";
@@ -514,8 +514,8 @@ message IstioEgressListener {
   // port.
   Port port = 1;
 
-  // The IP or the Unix domain socket to which the listener should be bound
-  // to. Port MUST be specified if bind is not empty. Format: `x.x.x.x` or
+  // The IP(IPv4 or IPv6) or the Unix domain socket to which the listener should be bound
+  // to. Port MUST be specified if bind is not empty. Format: IPv4 or IPv6 address formats or
   // `unix:///path/to/uds` or `unix://@foobar` (Linux abstract namespace). If
   // omitted, Istio will automatically configure the defaults based on imported
   // services, the workload instances to which this configuration is applied to and

--- a/networking/v1beta1/sidecar.proto
+++ b/networking/v1beta1/sidecar.proto
@@ -488,7 +488,7 @@ message IstioIngressListener {
   // connections. Arbitrary IPs are not supported. Format should be one of
   // `127.0.0.1:PORT`, `[::1]:PORT` (forward to localhost),
   // `0.0.0.0:PORT`, `[::]:PORT` (forward to the instance IP),
-  // or `unix:///path/to/socket` (forward to Unix domain socket)
+  // or `unix:///path/to/socket` (forward to Unix domain socket).
   string default_endpoint = 4 [(google.api.field_behavior) = REQUIRED];
 
   reserved "localhost_client_tls";


### PR DESCRIPTION
The bind attribute already works with IPv6, but somehow
the documentation seems to be not updated.

Signed-off-by: Faseela K <faseela.k@est.tech>