### PR TITLE
Fix the comments explaining Workload mode of gateways

### DIFF
--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -758,7 +758,7 @@ type WasmPlugin_TrafficSelector struct {
 	// Note that CLIENT and SERVER are analogous to INBOUND and OUTBOUND,
 	// respectively.
 	// For the gateway, the field should be CLIENT or CLIENT_AND_SERVER.
-	// If not specified, CLIENT_AND_SERVER will be the default value.
+	// If not specified, the default value is CLIENT_AND_SERVER.
 	Mode v1beta1.WorkloadMode `protobuf:"varint,1,opt,name=mode,proto3,enum=istio.type.v1beta1.WorkloadMode" json:"mode,omitempty"`
 	// $hide_from_docs
 	// Hide this from the doc until implementing this.

--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -756,9 +756,9 @@ type WasmPlugin_TrafficSelector struct {
 	//
 	// Criteria for selecting traffic by their direction.
 	// Note that CLIENT and SERVER are analogous to INBOUND and OUTBOUND,
-	// respectively. If the selected workload is a gateway, the field is ignored.
-	// If not specified, this condition is evaluated to true for any traffic
-	// direction.
+	// respectively.
+	// For the gateway, the field should be CLIENT or CLIENT_AND_SERVER.
+	// If not specified, CLIENT_AND_SERVER will be the default value.
 	Mode v1beta1.WorkloadMode `protobuf:"varint,1,opt,name=mode,proto3,enum=istio.type.v1beta1.WorkloadMode" json:"mode,omitempty"`
 	// $hide_from_docs
 	// Hide this from the doc until implementing this.

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -330,7 +330,7 @@ message WasmPlugin {
     // Note that CLIENT and SERVER are analogous to INBOUND and OUTBOUND,
     // respectively.
     // For the gateway, the field should be CLIENT or CLIENT_AND_SERVER.
-    // If not specified, CLIENT_AND_SERVER will be the default value.
+    // If not specified, the default value is CLIENT_AND_SERVER.
     istio.type.v1beta1.WorkloadMode mode = 1;
   
     // $hide_from_docs 

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -328,9 +328,9 @@ message WasmPlugin {
     //
     // Criteria for selecting traffic by their direction.
     // Note that CLIENT and SERVER are analogous to INBOUND and OUTBOUND,
-    // respectively. If the selected workload is a gateway, the field is ignored.
-    // If not specified, this condition is evaluated to true for any traffic
-    // direction.
+    // respectively.
+    // For the gateway, the field should be CLIENT or CLIENT_AND_SERVER.
+    // If not specified, CLIENT_AND_SERVER will be the default value.
     istio.type.v1beta1.WorkloadMode mode = 1;
   
     // $hide_from_docs 


### PR DESCRIPTION
Fix the comments describing the workload mode of Gateway.

To have consistency with the existing Telemetry API, we have changed the semantics of Workload mode in Gateway, but there was an omitted comments which had to be changed as well.