### PR TITLE
Update ConfigSource.address examples in docs

### DIFF
--- a/mesh/v1alpha1/config.pb.go
+++ b/mesh/v1alpha1/config.pb.go
@@ -1192,7 +1192,8 @@ type ConfigSource struct {
 
 	// Address of the server implementing the Istio Mesh Configuration
 	// protocol (MCP). Can be IP address or a fully qualified DNS name.
-	// Use fs:/// to specify a file-based backend with absolute path to the directory.
+	// Use xds:// to specify a grpc-based xds backend, k8s:// to specify a k8s controller or
+	// fs:/// to specify a file-based backend with absolute path to the directory.
 	Address string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	// Use the tls_settings to specify the tls mode to use. If the MCP server
 	// uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -1190,7 +1190,8 @@ message MeshConfig {
 message ConfigSource {
  // Address of the server implementing the Istio Mesh Configuration
  // protocol (MCP). Can be IP address or a fully qualified DNS name.
- // Use fs:/// to specify a file-based backend with absolute path to the directory.
+ // Use xds:// to specify a grpc-based xds backend, k8s:// to specify a k8s controller or
+ // fs:/// to specify a file-based backend with absolute path to the directory.
  string address = 1;
  // Use the tls_settings to specify the tls mode to use. If the MCP server
  // uses Istio mutual TLS and shares the root CA with Pilot, specify the TLS

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -37,7 +37,7 @@
         "type": "object",
         "properties": {
           "address": {
-            "description": "Address of the server implementing the Istio Mesh Configuration protocol (MCP). Can be IP address or a fully qualified DNS name. Use fs:/// to specify a file-based backend with absolute path to the directory.",
+            "description": "Address of the server implementing the Istio Mesh Configuration protocol (MCP). Can be IP address or a fully qualified DNS name. Use xds:// to specify a grpc-based xds backend, k8s:// to specify a k8s controller or fs:/// to specify a file-based backend with absolute path to the directory.",
             "type": "string"
           },
           "tlsSettings": {

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -671,7 +671,8 @@ sources.</p>
 <td>
 <p>Address of the server implementing the Istio Mesh Configuration
 protocol (MCP). Can be IP address or a fully qualified DNS name.
-Use fs:/// to specify a file-based backend with absolute path to the directory.</p>
+Use xds:// to specify a grpc-based xds backend, k8s:// to specify a k8s controller or
+fs:/// to specify a file-based backend with absolute path to the directory.</p>
 
 </td>
 <td>


### PR DESCRIPTION
The ConfigSource.address field mentions that the MCP backend address can be an IP address but doesn't clarify the protocol that needs to be used (xds:// or k8s://) in the docs.

Just adding a line to the doc to make it clear in the docs so that people don't have to dive into the code to see the possible address formats