### PR TITLE
Run `make gen` with the new build-tools to generate new html

### DIFF
--- a/analysis/v1alpha1/message.pb.html
+++ b/analysis/v1alpha1/message.pb.html
@@ -104,7 +104,7 @@ No
 <td><code>template</code></td>
 <td><code>string</code></td>
 <td>
-<p>A go-style template string (https://golang.org/pkg/fmt/#hdr-Printing)
+<p>A go-style template string (<a href="https://golang.org/pkg/fmt/#hdr-Printing">https://golang.org/pkg/fmt/#hdr-Printing</a>)
 defining how to combine the args for a  particular message into a log line.
 Required.</p>
 
@@ -173,10 +173,10 @@ No
 <td><code>string[]</code></td>
 <td>
 <p>A list of strings specifying the resource identifiers that were the cause
-of message generation. A &ldquo;path&rdquo; here is a (NAMESPACE\/)?RESOURCETYPE/NAME
+of message generation. A &ldquo;path&rdquo; here is a (NAMESPACE/)?RESOURCETYPE/NAME
 tuple that uniquely identifies a particular resource. There doesn&rsquo;t seem to
 be a single concept for this, but this is intuitively taken from
-https://kubernetes.io/docs/reference/using-api/api-concepts/#standard-api-terminology
+<a href="https://kubernetes.io/docs/reference/using-api/api-concepts/#standard-api-terminology">https://kubernetes.io/docs/reference/using-api/api-concepts/#standard-api-terminology</a>
 At least one is required.</p>
 
 </td>

--- a/extensions/v1alpha1/wasm.pb.html
+++ b/extensions/v1alpha1/wasm.pb.html
@@ -10,18 +10,14 @@ number_of_entries: 6
 ---
 <p>WasmPlugins provides a mechanism to extend the functionality provided by
 the Istio proxy through WebAssembly filters.</p>
-
 <p>Order of execution (as part of Envoy&rsquo;s filter chain) is determined by
 phase and priority settings, allowing the configuration of complex
 interactions between user-supplied WasmPlugins and Istio&rsquo;s internal
 filters.</p>
-
 <p>Examples:</p>
-
 <p>AuthN Filter deployed to ingress-gateway that implements an OpenID flow
 and populates the <code>Authorization</code> header with a JWT to be consumed by
 Istio AuthN.</p>
-
 <pre><code class="language-yaml">apiVersion: extensions.istio.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -38,9 +34,7 @@ spec:
     openid_server: authn
     openid_realm: ingress
 </code></pre>
-
 <p>This is the same as the last example, but using an OCI image.</p>
-
 <pre><code class="language-yaml">apiVersion: extensions.istio.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -58,9 +52,7 @@ spec:
     openid_server: authn
     openid_realm: ingress
 </code></pre>
-
 <p>This is the same as the last example, but using VmConfig to configure environment variables in the VM.</p>
-
 <pre><code class="language-yaml">apiVersion: extensions.istio.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -84,9 +76,7 @@ spec:
     - name: TRUST_DOMAIN
       value: &quot;cluster.local&quot;
 </code></pre>
-
 <p>This is also the same as the last example, but the Wasm module is pulled via https and updated for each time when this plugin resource is changed.</p>
-
 <pre><code class="language-yaml">apiVersion: extensions.istio.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -109,7 +99,6 @@ spec:
     - name: TRUST_DOMAIN
       value: &quot;cluster.local&quot;
 </code></pre>
-
 <p>And a more complex example that deploys three WasmPlugins and orders them
 using <code>phase</code> and <code>priority</code>. The (hypothetical) setup is that the
 <code>openid-connect</code> filter performs an OpenID Connect flow to authenticate the
@@ -121,10 +110,8 @@ system are available to the user that was previously authenticated. The
 <code>acl-check</code> filter writes this token to a header. Finally, the <code>check-header</code>
 filter verifies the token in that header and makes sure that the token&rsquo;s
 contents (the permitted &lsquo;function&rsquo;) matches its plugin configuration.</p>
-
 <p>The resulting filter chain looks like this:
 -&gt; openid-connect -&gt; istio.authn -&gt; acl-check -&gt; check-header -&gt; router</p>
-
 <pre><code class="language-yaml">apiVersion: extensions.istio.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -142,7 +129,6 @@ spec:
     openid_server: authn
     openid_realm: ingress
 </code></pre>
-
 <pre><code class="language-yaml">apiVersion: extensions.istio.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -161,7 +147,6 @@ spec:
     acl_server: some_server
     set_header: authz_complete
 </code></pre>
-
 <pre><code class="language-yaml">apiVersion: extensions.istio.io/v1alpha1
 kind: WasmPlugin
 metadata:

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -306,11 +306,9 @@ No
 <td>
 <p>The trust domain aliases represent the aliases of <code>trust_domain</code>.
 For example, if we have</p>
-
 <pre><code class="language-yaml">trustDomain: td1
 trustDomainAliases: [&quot;td2&quot;, &quot;td3&quot;]
 </code></pre>
-
 <p>Any service with the identity <code>td1/ns/foo/sa/a-service-account</code>, <code>td2/ns/foo/sa/a-service-account</code>,
 or <code>td3/ns/foo/sa/a-service-account</code> will be treated the same in the Istio mesh.</p>
 
@@ -341,15 +339,12 @@ No
 imported through container registry integrations, e.g. this applies to
 Kubernetes Service resources. The value is a list of namespace names and
 reserved namespace aliases. The allowed namespace aliases are:</p>
-
 <pre><code>* - All Namespaces
 . - Current Namespace
 ~ - No Namespace
 </code></pre>
-
 <p>If not set the system will use &ldquo;*&rdquo; as the default value which implies that
 services are exported to all namespaces.</p>
-
 <p><code>All namespaces</code> is a reasonable default for implementations that don&rsquo;t
 need to restrict access or visibility of services across namespace
 boundaries. If that requirement is present it is generally good practice to
@@ -359,7 +354,6 @@ visibility of services to other namespaces as needed. Use of <code>No Namespace<
 is expected to be rare but can have utility for deployments where
 dependency management needs to be precise even within the scope of a single
 namespace.</p>
-
 <p>For further discussion see the reference documentation for <code>ServiceEntry</code>,
 <code>Sidecar</code>, and <code>Gateway</code>.</p>
 
@@ -374,7 +368,6 @@ No
 <td>
 <p>The default value for the VirtualService.export_to field. Has the same
 syntax as <code>default_service_export_to</code>.</p>
-
 <p>If not set the system will use &ldquo;*&rdquo; as the default value which implies that
 virtual services are exported to all namespaces</p>
 
@@ -389,7 +382,6 @@ No
 <td>
 <p>The default value for the <code>DestinationRule.export_to</code> field. Has the same
 syntax as <code>default_service_export_to</code>.</p>
-
 <p>If not set the system will use &ldquo;*&rdquo; as the default value which implies that
 destination rules are exported to all namespaces</p>
 
@@ -407,7 +399,6 @@ Istio configuration. When processing a leaf namespace Istio will search for
 declarations in that namespace first and if none are found it will
 search in the root namespace. Any matching declaration found in the root
 namespace is processed as if it were declared in the leaf namespace.</p>
-
 <p>The precise semantics of this processing are documented on each resource
 type.</p>
 
@@ -461,18 +452,14 @@ No
 network filters like TCP and Redis.
 By default, Istio emits statistics with the pattern <code>inbound|&lt;port&gt;|&lt;port-name&gt;|&lt;service-FQDN&gt;</code>.
 For example <code>inbound|7443|grpc-reviews|reviews.prod.svc.cluster.local</code>. This can be used to override that pattern.</p>
-
 <p>A Pattern can be composed of various pre-defined variables. The following variables are supported.</p>
-
 <ul>
 <li><code>%SERVICE%</code> - Will be substituted with name of the service.</li>
 <li><code>%SERVICE_FQDN%</code> - Will be substituted with FQDN of the service.</li>
 <li><code>%SERVICE_PORT%</code> - Will be substituted with port of the service.</li>
 <li><code>%SERVICE_PORT_NAME%</code> - Will be substituted with port name of the service.</li>
 </ul>
-
 <p>Following are some examples of supported patterns for reviews:</p>
-
 <ul>
 <li><code>%SERVICE_FQDN%_%SERVICE_PORT%</code> will use reviews.prod.svc.cluster.local_7443 as the stats name.</li>
 <li><code>%SERVICE%</code> will use reviews.prod as the stats name.</li>
@@ -491,9 +478,7 @@ No
 network filters like TCP and Redis.
 By default, Istio emits statistics with the pattern <code>outbound|&lt;port&gt;|&lt;subsetname&gt;|&lt;service-FQDN&gt;</code>.
 For example <code>outbound|8080|v2|reviews.prod.svc.cluster.local</code>. This can be used to override that pattern.</p>
-
 <p>A Pattern can be composed of various pre-defined variables. The following variables are supported.</p>
-
 <ul>
 <li><code>%SERVICE%</code> - Will be substituted with name of the service.</li>
 <li><code>%SERVICE_FQDN%</code> - Will be substituted with FQDN of the service.</li>
@@ -501,9 +486,7 @@ For example <code>outbound|8080|v2|reviews.prod.svc.cluster.local</code>. This c
 <li><code>%SERVICE_PORT_NAME%</code> - Will be substituted with port name of the service.</li>
 <li><code>%SUBSET_NAME%</code> - Will be substituted with subset.</li>
 </ul>
-
 <p>Following are some examples of supported patterns for reviews:</p>
-
 <ul>
 <li><code>%SERVICE_FQDN%_%SERVICE_PORT%</code> will use <code>reviews.prod.svc.cluster.local_7443</code> as the stats name.</li>
 <li><code>%SERVICE%</code> will use reviews.prod as the stats name.</li>
@@ -576,10 +559,11 @@ computing configuration updates for sidecars. This can be used to reduce Istio&r
 by limiting the number of entities (including services, pods, and endpoints) that are watched and processed.
 If omitted, Istio will use the default behavior of processing all namespaces in the cluster.
 Elements in the list are disjunctive (OR semantics), i.e. a namespace will be included if it matches any selector.
-The following example selects any namespace that matches either below:
-1. The namespace has both of these labels: <code>env: prod</code> and <code>region: us-east1</code>
-2. The namespace has label <code>app</code> equal to <code>cassandra</code> or <code>spark</code>.</p>
-
+The following example selects any namespace that matches either below:</p>
+<ol>
+<li>The namespace has both of these labels: <code>env: prod</code> and <code>region: us-east1</code></li>
+<li>The namespace has label <code>app</code> equal to <code>cassandra</code> or <code>spark</code>.</li>
+</ol>
 <pre><code class="language-yaml">discoverySelectors:
   - matchLabels:
       env: prod
@@ -591,7 +575,6 @@ The following example selects any namespace that matches either below:
         - cassandra
         - spark
 </code></pre>
-
 <p>Refer to the <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">kubernetes selector docs</a>
 for additional detail on selector semantics.</p>
 
@@ -623,7 +606,7 @@ No
 <td>
 <p>Configure the default HTTP retry policy.
 The default number of retry attempts is set at 2 for these errors:
-  &ldquo;connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes&rdquo;.
+&ldquo;connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes&rdquo;.
 Setting the number of attempts to 0 disables retry policy globally.
 This setting can be overriden on a per-host basis using the Virtual Service
 API.
@@ -758,9 +741,9 @@ No
 <td><code>string (oneof)</code></td>
 <td>
 <p>The SPIFFE bundle endpoint URL that complies to:
-https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#the-spiffe-trust-domain-and-bundle
+<a href="https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#the-spiffe-trust-domain-and-bundle">https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#the-spiffe-trust-domain-and-bundle</a>
 The endpoint should support authentication based on Web PKI:
-https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#521-web-pki
+<a href="https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#521-web-pki">https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#521-web-pki</a>
 The certificate is retrieved from the endpoint.</p>
 
 </td>
@@ -872,12 +855,14 @@ No
 <td><code><a href="https://istio.io/docs/reference/config/networking/destination-rule.html#ClientTLSSettings">ClientTLSSettings</a></code></td>
 <td>
 <p>Use the tls_settings to specify the tls mode to use.
-Regarding tls_settings:
-- DISABLE MODE is legitimate for the case Istiod is making the request via an Envoy sidecar.
-DISABLE MODE can also be used for testing
-- TLS MUTUAL MODE be on by default. If the CA certificates
+Regarding tls_settings:</p>
+<ul>
+<li>DISABLE MODE is legitimate for the case Istiod is making the request via an Envoy sidecar.
+DISABLE MODE can also be used for testing</li>
+<li>TLS MUTUAL MODE be on by default. If the CA certificates
 (cert bundle to verify the CA server&rsquo;s certificate) is omitted, Istiod will
-use the system root certs to verify the CA server&rsquo;s certificate.</p>
+use the system root certs to verify the CA server&rsquo;s certificate.</li>
+</ul>
 
 </td>
 <td>
@@ -1098,7 +1083,6 @@ No
 <section>
 <p>Holds the name references to the providers that will be used by default
 in other Istio configuration resources if the provider is not specified.</p>
-
 <p>These names must match a provider defined in <code>extension_providers</code> that is
 one of the supported tracing providers.</p>
 
@@ -1226,9 +1210,7 @@ By default, in multi-cluster deployments, the Istio control plane assumes all se
 endpoints to be reachable from any client in any of the clusters which are part of the
 mesh. This configuration option limits the set of service endpoints visible to a client
 to be cluster scoped.</p>
-
 <p>There are some common scenarios when this can be useful:</p>
-
 <ul>
 <li>A service (or group of services) is inherently local to the cluster and has local storage
 for that cluster. For example, the kube-system namespace (e.g. the Kube API Server).</li>
@@ -1237,7 +1219,6 @@ having services cluster-local and then slowly transition them to mesh-wide. They
 this service-by-service (e.g. mysvc.myns.svc.cluster.local) or as a group
 (e.g. *.myns.svc.cluster.local).</li>
 </ul>
-
 <p>By default Istio will consider kubernetes.default.svc (i.e. the API Server) as well as all
 services in the kube-system namespace to be cluster-local, unless explicitly overridden here.</p>
 
@@ -1295,8 +1276,8 @@ No
 <td><code>bool</code></td>
 <td>
 <p>If true, the body sent to the external authorization service in the gRPC authorization request is set with raw bytes
-in the raw_body field (https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L153).
-Otherwise, it will be filled with UTF-8 string in the body field (https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L147).
+in the raw_body field (<a href="https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L153)">https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L153)</a>.
+Otherwise, it will be filled with UTF-8 string in the body field (<a href="https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L147)">https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L147)</a>.
 This field only works with the envoy_ext_authz_grpc provider and has no effect for the envoy_ext_authz_http provider.</p>
 
 </td>
@@ -1327,7 +1308,6 @@ No
 The format is <code>[&lt;Namespace&gt;/]&lt;Hostname&gt;</code>. The specification of <code>&lt;Namespace&gt;</code> is required only when it is insufficient
 to unambiguously resolve a service in the service registry. The <code>&lt;Hostname&gt;</code> is a fully qualified host name of a
 service defined by the Kubernetes service or ServiceEntry.</p>
-
 <p>Example: &ldquo;my-ext-authz.foo.svc.cluster.local&rdquo; or &ldquo;bar/my-ext-authz.example.com&rdquo;.</p>
 
 </td>
@@ -1413,17 +1393,20 @@ No
 <td><code>string[]</code></td>
 <td>
 <p>List of client request headers that should be included in the authorization request sent to the authorization service.
-Note that in addition to the headers specified here following headers are included by default:
-1. <em>Host</em>, <em>Method</em>, <em>Path</em> and <em>Content-Length</em> are automatically sent.
-2. <em>Content-Length</em> will be set to 0 and the request will not have a message body. However, the authorization
+Note that in addition to the headers specified here following headers are included by default:</p>
+<ol>
+<li><em>Host</em>, <em>Method</em>, <em>Path</em> and <em>Content-Length</em> are automatically sent.</li>
+<li><em>Content-Length</em> will be set to 0 and the request will not have a message body. However, the authorization
 request can include the buffered client request body (controlled by include_request_body_in_check setting),
-consequently the value of Content-Length of the authorization request reflects the size of its payload size.</p>
-
+consequently the value of Content-Length of the authorization request reflects the size of its payload size.</li>
+</ol>
 <p>Exact, prefix and suffix matches are supported (similar to the authorization policy rule syntax except the presence match
-https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule):
-- Exact match: &ldquo;abc&rdquo; will match on value &ldquo;abc&rdquo;.
-- Prefix match: &ldquo;abc*&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;abcd&rdquo;.
-- Suffix match: &ldquo;*abc&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;xabc&rdquo;.</p>
+<a href="https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)">https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)</a>:</p>
+<ul>
+<li>Exact match: &ldquo;abc&rdquo; will match on value &ldquo;abc&rdquo;.</li>
+<li>Prefix match: &ldquo;abc*&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;abcd&rdquo;.</li>
+<li>Suffix match: &ldquo;*abc&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;xabc&rdquo;.</li>
+</ul>
 
 </td>
 <td>
@@ -1462,12 +1445,13 @@ No
 forwarded to the upstream when the authorization check result is allowed (HTTP code 200).
 If not specified, the original request will not be modified and forwarded to backend as-is.
 Note, any existing headers will be overridden.</p>
-
 <p>Exact, prefix and suffix matches are supported (similar to the authorization policy rule syntax except the presence match
-https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule):
-- Exact match: &ldquo;abc&rdquo; will match on value &ldquo;abc&rdquo;.
-- Prefix match: &ldquo;abc*&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;abcd&rdquo;.
-- Suffix match: &ldquo;*abc&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;xabc&rdquo;.</p>
+<a href="https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)">https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)</a>:</p>
+<ul>
+<li>Exact match: &ldquo;abc&rdquo; will match on value &ldquo;abc&rdquo;.</li>
+<li>Prefix match: &ldquo;abc*&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;abcd&rdquo;.</li>
+<li>Suffix match: &ldquo;*abc&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;xabc&rdquo;.</li>
+</ul>
 
 </td>
 <td>
@@ -1485,12 +1469,13 @@ the downstream.
 When a header is included in this list, <em>Path</em>, <em>Status</em>, <em>Content-Length</em>, <em>WWWAuthenticate</em> and <em>Location</em> are
 automatically added.
 Note, the body from the authorization service is always included in the response to downstream.</p>
-
 <p>Exact, prefix and suffix matches are supported (similar to the authorization policy rule syntax except the presence match
-https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule):
-- Exact match: &ldquo;abc&rdquo; will match on value &ldquo;abc&rdquo;.
-- Prefix match: &ldquo;abc*&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;abcd&rdquo;.
-- Suffix match: &ldquo;*abc&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;xabc&rdquo;.</p>
+<a href="https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)">https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)</a>:</p>
+<ul>
+<li>Exact match: &ldquo;abc&rdquo; will match on value &ldquo;abc&rdquo;.</li>
+<li>Prefix match: &ldquo;abc*&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;abcd&rdquo;.</li>
+<li>Suffix match: &ldquo;*abc&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;xabc&rdquo;.</li>
+</ul>
 
 </td>
 <td>
@@ -1505,12 +1490,13 @@ No
 check result is allowed (HTTP code 200).
 If not specified, the original response will not be modified and forwarded to downstream as-is.
 Note, any existing headers will be overridden.</p>
-
 <p>Exact, prefix and suffix matches are supported (similar to the authorization policy rule syntax except the presence match
-https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule):
-- Exact match: &ldquo;abc&rdquo; will match on value &ldquo;abc&rdquo;.
-- Prefix match: &ldquo;abc*&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;abcd&rdquo;.
-- Suffix match: &ldquo;*abc&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;xabc&rdquo;.</p>
+<a href="https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)">https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)</a>:</p>
+<ul>
+<li>Exact match: &ldquo;abc&rdquo; will match on value &ldquo;abc&rdquo;.</li>
+<li>Prefix match: &ldquo;abc*&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;abcd&rdquo;.</li>
+<li>Suffix match: &ldquo;*abc&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;xabc&rdquo;.</li>
+</ul>
 
 </td>
 <td>
@@ -1540,7 +1526,6 @@ No
 The format is <code>[&lt;Namespace&gt;/]&lt;Hostname&gt;</code>. The specification of <code>&lt;Namespace&gt;</code> is required only when it is insufficient
 to unambiguously resolve a service in the service registry. The <code>&lt;Hostname&gt;</code> is a fully qualified host name of a
 service defined by the Kubernetes service or ServiceEntry.</p>
-
 <p>Example: &ldquo;my-ext-authz.foo.svc.cluster.local&rdquo; or &ldquo;bar/my-ext-authz.example.com&rdquo;.</p>
 
 </td>
@@ -1633,7 +1618,6 @@ No
 The format is <code>[&lt;Namespace&gt;/]&lt;Hostname&gt;</code>. The specification of <code>&lt;Namespace&gt;</code> is required only when it is insufficient
 to unambiguously resolve a service in the service registry. The <code>&lt;Hostname&gt;</code> is a fully qualified host name of a
 service defined by the Kubernetes service or ServiceEntry.</p>
-
 <p>Example: &ldquo;zipkin.default.svc.cluster.local&rdquo; or &ldquo;bar/zipkin.example.com&rdquo;.</p>
 
 </td>
@@ -1691,7 +1675,6 @@ will generate OpenTelemetry-compatible configuration when using this option.</p>
 The format is <code>[&lt;Namespace&gt;/]&lt;Hostname&gt;</code>. The specification of <code>&lt;Namespace&gt;</code> is required only when it is insufficient
 to unambiguously resolve a service in the service registry. The <code>&lt;Hostname&gt;</code> is a fully qualified host name of a
 service defined by the Kubernetes service or ServiceEntry.</p>
-
 <p>Example: &ldquo;lightstep.default.svc.cluster.local&rdquo; or &ldquo;bar/lightstep.example.com&rdquo;.</p>
 
 </td>
@@ -1758,7 +1741,6 @@ No
 The format is <code>[&lt;Namespace&gt;/]&lt;Hostname&gt;</code>. The specification of <code>&lt;Namespace&gt;</code> is required only when it is insufficient
 to unambiguously resolve a service in the service registry. The <code>&lt;Hostname&gt;</code> is a fully qualified host name of a
 service defined by the Kubernetes service or ServiceEntry.</p>
-
 <p>Example: &ldquo;datadog.default.svc.cluster.local&rdquo; or &ldquo;bar/datadog.example.com&rdquo;.</p>
 
 </td>
@@ -1814,7 +1796,6 @@ No
 The format is <code>[&lt;Namespace&gt;/]&lt;Hostname&gt;</code>. The specification of <code>&lt;Namespace&gt;</code> is required only when it is insufficient
 to unambiguously resolve a service in the service registry. The <code>&lt;Hostname&gt;</code> is a fully qualified host name of a
 service defined by the Kubernetes service or ServiceEntry.</p>
-
 <p>Example: &ldquo;skywalking.default.svc.cluster.local&rdquo; or &ldquo;bar/skywalking.example.com&rdquo;.</p>
 
 </td>
@@ -1850,7 +1831,6 @@ No
 <h2 id="MeshConfig-ExtensionProvider-StackdriverProvider">MeshConfig.ExtensionProvider.StackdriverProvider</h2>
 <section>
 <p>Defines configuration for Stackdriver.</p>
-
 <p>WARNING: Stackdriver tracing uses OpenCensus configuration under the hood and, as a result, cannot be used
 alongside any OpenCensus provider configuration. This is due to a limitation in the implementation of OpenCensus
 driver in Envoy.</p>
@@ -1894,13 +1874,11 @@ No
 <h2 id="MeshConfig-ExtensionProvider-OpenCensusAgentTracingProvider">MeshConfig.ExtensionProvider.OpenCensusAgentTracingProvider</h2>
 <section>
 <p>Defines configuration for an OpenCensus tracer writing to an OpenCensus backend.</p>
-
 <p>WARNING: OpenCensusAgentTracingProviders should be used with extreme care. Configuration of
 OpenCensus providers CANNOT be changed during the course of proxy&rsquo;s lifetime due to a limitation
 in the implementation of OpenCensus driver in Envoy. This means only a single provider configuration
 may be used for OpenCensus at any given time for a proxy or group of proxies AND that any change to the provider
 configuration MUST be accompanied by a restart of all proxies that will use that configuration.</p>
-
 <p>NOTE: Stackdriver tracing uses OpenCensus configuraiton under the hood and, as a result, cannot be used
 alongside OpenCensus provider configuration.</p>
 
@@ -1922,7 +1900,6 @@ alongside OpenCensus provider configuration.</p>
 The format is <code>[&lt;Namespace&gt;/]&lt;Hostname&gt;</code>. The specification of <code>&lt;Namespace&gt;</code> is required only when it is insufficient
 to unambiguously resolve a service in the service registry. The <code>&lt;Hostname&gt;</code> is a fully qualified host name of a
 service defined by the Kubernetes service or ServiceEntry.</p>
-
 <p>Example: &ldquo;ocagent.default.svc.cluster.local&rdquo; or &ldquo;bar/ocagent.example.com&rdquo;.</p>
 
 </td>
@@ -2038,7 +2015,6 @@ integration for HTTP traffic.</p>
 The format is <code>[&lt;Namespace&gt;/]&lt;Hostname&gt;</code>. The specification of <code>&lt;Namespace&gt;</code> is required only when it is insufficient
 to unambiguously resolve a service in the service registry. The <code>&lt;Hostname&gt;</code> is a fully qualified host name of a
 service defined by the Kubernetes service or ServiceEntry.</p>
-
 <p>Example: &ldquo;envoy-als.foo.svc.cluster.local&rdquo; or &ldquo;bar/envoy-als.example.com&rdquo;.</p>
 
 </td>
@@ -2062,9 +2038,11 @@ No
 <td><code>string</code></td>
 <td>
 <p>Optional. The friendly name of the access log.
-Defaults:
--  &ldquo;http_envoy_accesslog&rdquo;
--  &ldquo;listener_envoy_accesslog&rdquo;</p>
+Defaults:</p>
+<ul>
+<li>&ldquo;http_envoy_accesslog&rdquo;</li>
+<li>&ldquo;listener_envoy_accesslog&rdquo;</li>
+</ul>
 
 </td>
 <td>
@@ -2141,7 +2119,6 @@ integration for TCP traffic.</p>
 The format is <code>[&lt;Namespace&gt;/]&lt;Hostname&gt;</code>. The specification of <code>&lt;Namespace&gt;</code> is required only when it is insufficient
 to unambiguously resolve a service in the service registry. The <code>&lt;Hostname&gt;</code> is a fully qualified host name of a
 service defined by the Kubernetes service or ServiceEntry.</p>
-
 <p>Example: &ldquo;envoy-als.foo.svc.cluster.local&rdquo; or &ldquo;bar/envoy-als.example.com&rdquo;.</p>
 
 </td>
@@ -2165,9 +2142,11 @@ No
 <td><code>string</code></td>
 <td>
 <p>Optional. The friendly name of the access log.
-Defaults:
-- &ldquo;tcp_envoy_accesslog&rdquo;
-- &ldquo;listener_envoy_accesslog&rdquo;</p>
+Defaults:</p>
+<ul>
+<li>&ldquo;tcp_envoy_accesslog&rdquo;</li>
+<li>&ldquo;listener_envoy_accesslog&rdquo;</li>
+</ul>
 
 </td>
 <td>
@@ -2210,7 +2189,6 @@ No
 The format is <code>[&lt;Namespace&gt;/]&lt;Hostname&gt;</code>. The specification of <code>&lt;Namespace&gt;</code> is required only when it is insufficient
 to unambiguously resolve a service in the service registry. The <code>&lt;Hostname&gt;</code> is a fully qualified host name of a
 service defined by the Kubernetes service or ServiceEntry.</p>
-
 <p>Example: &ldquo;envoy-als.foo.svc.cluster.local&rdquo; or &ldquo;bar/envoy-als.example.com&rdquo;.</p>
 
 </td>
@@ -2234,8 +2212,10 @@ No
 <td><code>string</code></td>
 <td>
 <p>Optional. The friendly name of the access log.
-Defaults:
-- &ldquo;otel_envoy_accesslog&rdquo;</p>
+Defaults:</p>
+<ul>
+<li>&ldquo;otel_envoy_accesslog&rdquo;</li>
+</ul>
 
 </td>
 <td>
@@ -2276,11 +2256,10 @@ No
 <p>Collection of tag names and tag expressions to include in the log
 entry. Conflicts are resolved by the tag name by overriding previously
 supplied values.</p>
-
 <p>Example:
-  labels:
-    path: request.url_path
-    foo: request.headers[&lsquo;x-foo&rsquo;]</p>
+labels:
+path: request.url_path
+foo: request.headers[&lsquo;x-foo&rsquo;]</p>
 
 </td>
 <td>
@@ -2309,9 +2288,7 @@ No
 <p>Textual format for the envoy access logs. Envoy <a href="https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators">command operators</a> may be
 used in the format. The <a href="https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings">format string documentation</a>
 provides more information.</p>
-
-<p>NOTE: Istio will insert a newline (&lsquo;\n&rsquo;) on all formats (if missing).</p>
-
+<p>NOTE: Istio will insert a newline (&rsquo;\n&rsquo;) on all formats (if missing).</p>
 <p>Example: <code>text: &quot;%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%&quot;</code></p>
 
 </td>
@@ -2329,9 +2306,7 @@ as strings, numbers, or boolean values, as appropriate
 (see: <a href="https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-dictionaries">format dictionaries</a>). Nested JSON is
 supported for some command operators (e.g. <code>FILTER_STATE</code> or <code>DYNAMIC_METADATA</code>).
 Use <code>labels: {}</code> for default envoy JSON log format.</p>
-
 <p>Example:</p>
-
 <pre><code>labels:
   status: &quot;%RESPONSE_CODE%&quot;
   message: &quot;%LOCAL_REPLY_BODY%&quot;
@@ -2383,9 +2358,7 @@ as strings, numbers, or boolean values, as appropriate
 (see: <a href="https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-dictionaries">format dictionaries</a>). Nested JSON is
 supported for some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
 Alias to <code>attributes</code> filed in <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/access_loggers/open_telemetry/v3/logs_service.proto">Open Telemetry</a></p>
-
 <p>Example:</p>
-
 <pre><code>labels:
   status: &quot;%RESPONSE_CODE%&quot;
   message: &quot;%LOCAL_REPLY_BODY%&quot;
@@ -2576,24 +2549,19 @@ No
 <p>ProxyConfig defines variables for individual Envoy instances. This can be configured on a per-workload basis
 as well as by the mesh-wide defaults.
 To set the mesh wide defaults, configure the <code>defaultConfig</code> section of <code>meshConfig</code>. For example:</p>
-
 <pre><code>meshConfig:
   defaultConfig:
     discoveryAddress: istiod:15012
 </code></pre>
-
 <p>This can also be configured on a per-workload basis by configuring the <code>proxy.istio.io/config</code> annotation on the pod. For example:</p>
-
 <pre><code>annotations:
   proxy.istio.io/config: |
     discoveryAddress: istiod:15012
 </code></pre>
-
 <p>If both are configured, the two are merged with per field semantics; the field set in annotation will fully replace the field from mesh config defaults.
 This is different than a deep merge provided by protobuf.
 For example, <code>&quot;tracing&quot;: { &quot;sampling&quot;: 5 }</code> would completely override a setting configuring a tracing provider
 such as <code>&quot;tracing&quot;: { &quot;zipkin&quot;: { &quot;address&quot;: &quot;...&quot; } }</code>.</p>
-
 <p>Note: fields in ProxyConfig are not dynamically configured; changes will require restart of workloads to take effect.</p>
 
 <table class="message-fields">
@@ -2638,7 +2606,6 @@ shared by all Envoy instances. This setting corresponds to
 <code>--service-cluster</code> flag in Envoy.  In a typical Envoy deployment, the
 <code>service-cluster</code> flag is used to identify the caller, for
 source-based routing scenarios.</p>
-
 <p>Since Istio does not assign a local <code>service/service</code> version to each
 Envoy instance, the name is same for all of them.  However, the
 source/caller&rsquo;s identity (e.g., IP address) is encoded in the
@@ -2945,7 +2912,6 @@ inclusion annotations
 <code>sidecar.istio.io/statsInclusionSuffixes</code>). For example, to enable stats
 for circuit breaker, retry, and upstream connections, you can specify stats
 matcher as follow:</p>
-
 <pre><code class="language-yaml">proxyStatsMatcher:
   inclusionRegexps:
     - .*circuit_breakers.*
@@ -2953,7 +2919,6 @@ matcher as follow:</p>
     - upstream_rq_retry
     - upstream_cx
 </code></pre>
-
 <p>Note including more Envoy stats might increase number of time series
 collected by prometheus significantly. Care needs to be taken on Prometheus
 resource provision and configuration to reduce cardinality.</p>
@@ -3339,9 +3304,7 @@ Yes
 <section>
 <p>MeshNetworks (config map) provides information about the set of networks
 inside a mesh and how to route to endpoints in each network. For example</p>
-
 <p>MeshNetworks(file/config map):</p>
-
 <pre><code class="language-yaml">networks:
   network1:
     endpoints:
@@ -3387,24 +3350,23 @@ Yes
 <p>NetworkEndpoints describes how the network associated with an endpoint
 should be inferred. An endpoint will be assigned to a network based on
 the following rules:</p>
-
 <ol>
-<li><p>Implicitly: If the registry explicitly provides information about
+<li>
+<p>Implicitly: If the registry explicitly provides information about
 the network to which the endpoint belongs to. In some cases, its
 possible to indicate the network associated with the endpoint by
-adding the <code>ISTIO_META_NETWORK</code> environment variable to the sidecar.</p></li>
-
-<li><p>Explicitly:</p></li>
-</ol>
-
+adding the <code>ISTIO_META_NETWORK</code> environment variable to the sidecar.</p>
+</li>
+<li>
+<p>Explicitly:</p>
 <p>a. By matching the registry name with one of the &ldquo;fromRegistry&rdquo;
-   in the mesh config. A &ldquo;from_registry&rdquo; can only be assigned to a
-   single network.</p>
-
+in the mesh config. A &ldquo;from_registry&rdquo; can only be assigned to a
+single network.</p>
 <p>b. By matching the IP against one of the CIDR ranges in a mesh
-   config network. The CIDR ranges must not overlap and be assigned to
-   a single network.</p>
-
+config network. The CIDR ranges must not overlap and be assigned to
+a single network.</p>
+</li>
+</ol>
 <p>(2) will override (1) if both are present.</p>
 
 <table class="message-fields">

--- a/meta/v1alpha1/status.pb.html
+++ b/meta/v1alpha1/status.pb.html
@@ -23,7 +23,7 @@ number_of_entries: 2
 <td><code><a href="#IstioCondition">IstioCondition[]</a></code></td>
 <td>
 <p>Current service state of pod.
-More info: https://istio.io/docs/reference/config/config-status/
+More info: <a href="https://istio.io/docs/reference/config/config-status/">https://istio.io/docs/reference/config/config-status/</a>
 +optional
 +patchMergeKey=type
 +patchStrategy=merge</p>
@@ -53,7 +53,7 @@ No
 <td>
 <p>Resource Generation to which the Reconciled Condition refers.
 When this value is not equal to the object&rsquo;s metadata generation, reconciled condition  calculation for the current
-generation is still in progress.  See https://istio.io/latest/docs/reference/config/config-status/ for more info.
+generation is still in progress.  See <a href="https://istio.io/latest/docs/reference/config/config-status/">https://istio.io/latest/docs/reference/config/config-status/</a> for more info.
 +optional</p>
 
 </td>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -14,10 +14,8 @@ for load balancing, connection pool size from the sidecar, and outlier
 detection settings to detect and evict unhealthy hosts from the load
 balancing pool. For example, a simple load balancing policy for the
 ratings service would look as follows:</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -28,11 +26,8 @@ spec:
     loadBalancer:
       simple: LEAST_REQUEST
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -43,19 +38,15 @@ spec:
     loadBalancer:
       simple: LEAST_REQUEST
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>Version specific policies can be specified by defining a named
 <code>subset</code> and overriding the settings specified at the service level. The
 following rule uses a round robin load balancing policy for all traffic
 going to a subset named testversion that is composed of endpoints (e.g.,
 pods) with labels (version:v3).</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -73,11 +64,8 @@ spec:
       loadBalancer:
         simple: ROUND_ROBIN
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -95,21 +83,16 @@ spec:
       loadBalancer:
         simple: ROUND_ROBIN
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p><strong>Note:</strong> Policies specified for subsets will not take effect until
 a route rule explicitly sends traffic to this subset.</p>
-
 <p>Traffic policies can be customized to specific ports as well. The
 following rule uses the least connection load balancing policy for all
 traffic to port 80, while uses a round robin load balancing setting for
 traffic to the port 9080.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -127,11 +110,8 @@ spec:
       loadBalancer:
         simple: ROUND_ROBIN
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -149,17 +129,13 @@ spec:
       loadBalancer:
         simple: ROUND_ROBIN
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>Destination Rules can be customized to specific workloads as well.
 The following example shows how a destination rule can be applied to a
 specific workload using the workloadSelector configuration.</p>
-
 <p>{{<tabset category-name="selector-example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -179,10 +155,8 @@ spec:
         credentialName: client-credential
         mode: MUTUAL
 </code></pre>
-
 <p>{{</tab>}}
 {{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -202,7 +176,6 @@ spec:
         credentialName: client-credential
         mode: MUTUAL
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -230,7 +203,6 @@ names are looked up from the platform&rsquo;s service registry (e.g.,
 Kubernetes services, Consul services, etc.) and from the hosts
 declared by <a href="https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry">ServiceEntries</a>. Rules defined for
 services that do not exist in the service registry will be ignored.</p>
-
 <p><em>Note for Kubernetes users</em>: When short names are used (e.g. &ldquo;reviews&rdquo;
 instead of &ldquo;reviews.default.svc.cluster.local&rdquo;), Istio will interpret
 the short name based on the namespace of the rule, not the service. A
@@ -239,7 +211,6 @@ interpreted as &ldquo;reviews.default.svc.cluster.local&rdquo;, irrespective of
 the actual namespace associated with the reviews service. <em>To avoid
 potential misconfigurations, it is recommended to always use fully
 qualified domain names over short names.</em></p>
-
 <p>Note that the host field applies to both HTTP and TCP services.</p>
 
 </td>
@@ -282,10 +253,8 @@ it to be included in the resolution hierarchy for services in
 other namespaces. This feature provides a mechanism for service owners
 and mesh administrators to control the visibility of destination rules
 across namespace boundaries.</p>
-
 <p>If no namespaces are specified then the destination rule is exported to all
 namespaces by default.</p>
-
 <p>The value &ldquo;.&rdquo; is reserved and defines an export to the same namespace that
 the destination rule is declared in. Similarly, the value &ldquo;*&rdquo; is reserved and
 defines an export to all namespaces.</p>
@@ -300,13 +269,13 @@ No
 <td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>Criteria used to select the specific set of pods/VMs on which this
- <code>DestinationRule</code> configuration should be applied. If specified, the <code>DestinationRule</code>
- configuration will be applied only to the workload instances matching the workload selector
- label in the same namespace. Workload selectors do not apply across namespace boundaries.
- If omitted, the <code>DestinationRule</code> falls back to its default behavior.
- For example, if specific sidecars need to have egress TLS settings for services outside
- of the mesh, instead of every sidecar in the mesh needing to have the
- configuration (which is the default behaviour), a workload selector can be specified.</p>
+<code>DestinationRule</code> configuration should be applied. If specified, the <code>DestinationRule</code>
+configuration will be applied only to the workload instances matching the workload selector
+label in the same namespace. Workload selectors do not apply across namespace boundaries.
+If omitted, the <code>DestinationRule</code> falls back to its default behavior.
+For example, if specific sidecars need to have egress TLS settings for services outside
+of the mesh, instead of every sidecar in the mesh needing to have the
+configuration (which is the default behaviour), a workload selector can be specified.</p>
 
 </td>
 <td>
@@ -416,10 +385,8 @@ service-level can be overridden at a subset-level. The following rule
 uses a round robin load balancing policy for all traffic going to a
 subset named testversion that is composed of endpoints (e.g., pods) with
 labels (version:v3).</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -437,11 +404,8 @@ spec:
       loadBalancer:
         simple: ROUND_ROBIN
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -459,13 +423,10 @@ spec:
       loadBalancer:
         simple: ROUND_ROBIN
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p><strong>Note:</strong> Policies specified for subsets will not take effect until
 a route rule explicitly sends traffic to this subset.</p>
-
 <p>One or more labels are typically required to identify the subset destination,
 however, when the corresponding DestinationRule represents a host that
 supports multiple SNI hosts (e.g., an egress gateway), a subset without labels
@@ -529,13 +490,10 @@ No
 load balancing
 <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancing">documentation</a>
 for more details.</p>
-
 <p>For example, the following rule uses a round robin load balancing policy
 for all traffic going to the ratings service.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -546,11 +504,8 @@ spec:
     loadBalancer:
       simple: ROUND_ROBIN
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -561,17 +516,13 @@ spec:
     loadBalancer:
       simple: ROUND_ROBIN
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following example sets up sticky sessions for the ratings service
 hashing-based load balancer for the same ratings service using the
 the User cookie as the hash key.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -585,11 +536,8 @@ spec:
           name: user
           ttl: 0s
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -603,7 +551,6 @@ spec:
           name: user
           ttl: 0s
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -672,13 +619,10 @@ each individual host in the upstream service.  See Envoy&rsquo;s <a href="https:
 breaker</a>
 for more details. Connection pool settings can be applied at the TCP
 level as well as at HTTP level.</p>
-
 <p>For example, the following rule sets a limit of 100 connections to redis
 service called myredissrv with a connect timeout of 30ms</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -694,11 +638,8 @@ spec:
           time: 7200s
           interval: 75s
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -714,7 +655,6 @@ spec:
           time: 7200s
           interval: 75s
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -764,16 +704,13 @@ failures to a given host counts as an error when measuring the
 consecutive errors metric. See Envoy&rsquo;s <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier">outlier
 detection</a>
 for more details.</p>
-
 <p>The following rule sets a connection pool size of 100 HTTP1 connections
 with no more than 10 req/connection to the &ldquo;reviews&rdquo; service. In addition,
 it sets a limit of 1000 concurrent HTTP2 requests and configures upstream
 hosts to be scanned every 5 mins so that any host that fails 7 consecutive
 times with a 502, 503, or 504 error code will be ejected for 15 minutes.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -792,11 +729,8 @@ spec:
       interval: 5m
       baseEjectionTime: 15m
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -815,7 +749,6 @@ spec:
       interval: 5m
       baseEjectionTime: 15m
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -870,7 +803,6 @@ code qualifies as a gateway error. When the upstream host is accessed over
 an opaque TCP connection, connect timeouts and connection error/failure
 events qualify as a gateway error.
 This feature is disabled by default or when set to the value 0.</p>
-
 <p>Note that consecutive_gateway_errors and consecutive_5xx_errors can be
 used separately or together. Because the errors counted by
 consecutive_gateway_errors are also included in consecutive_5xx_errors,
@@ -892,7 +824,6 @@ When the upstream host is accessed over an opaque TCP connection, connect
 timeouts, connection error/failure and request failure events qualify as a
 5xx error.
 This feature defaults to 5 but can be disabled by setting the value to 0.</p>
-
 <p>Note that consecutive_gateway_errors and consecutive_5xx_errors can be
 used separately or together. Because the errors counted by
 consecutive_gateway_errors are also included in consecutive_5xx_errors,
@@ -969,13 +900,10 @@ No
 <p>SSL/TLS related settings for upstream connections. See Envoy&rsquo;s <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto.html#common-tls-configuration">TLS
 context</a>
 for more details. These settings are common to both HTTP and TCP upstreams.</p>
-
 <p>For example, the following rule configures a client to use mutual TLS
 for connections to upstream database cluster.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -989,11 +917,8 @@ spec:
       privateKey: /etc/certs/client_private_key.pem
       caCertificates: /etc/certs/rootcacerts.pem
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -1007,16 +932,12 @@ spec:
       privateKey: /etc/certs/client_private_key.pem
       caCertificates: /etc/certs/rootcacerts.pem
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following rule configures a client to use TLS when talking to a
 foreign service whose domain matches *.foo.com.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -1027,11 +948,8 @@ spec:
     tls:
       mode: SIMPLE
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -1042,16 +960,12 @@ spec:
     tls:
       mode: SIMPLE
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following rule configures a client to use Istio mutual TLS when talking
 to rating services.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -1062,11 +976,8 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -1077,7 +988,6 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -1158,7 +1068,6 @@ Secret of type tls for client certificates along with
 ca.crt key for CA certificates is also supported.
 Only one of client certificates and CA certificate
 or credentialName can be specified.</p>
-
 <p><strong>NOTE:</strong> This field is applicable at sidecars only if
 <code>DestinationRule</code> has a <code>workloadSelector</code> specified.
 Otherwise the field will be applicable only at gateways, and
@@ -1212,7 +1121,6 @@ enabled, <code>VerifyCertAtClient</code> environmental variable is set to <code>
 but no verification is desired for a specific host. If enabled with or
 without <code>VerifyCertAtClient</code> enabled, verification of the CA signature and
 SAN will be skipped.</p>
-
 <p><code>InsecureSkipVerify</code> is <code>false</code> by default.
 <code>VerifyCertAtClient</code> is <code>false</code> by default in Istio version 1.9 but will
 be <code>true</code> by default in a later version where, going forward, it will be
@@ -1235,7 +1143,6 @@ specified using arbitrary labels that designate a hierarchy of localities in
 {region}/{zone}/{sub-zone} form. For additional detail refer to
 <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/locality_weight">Locality Weight</a>
 The following example shows how to setup locality weights mesh-wide.</p>
-
 <p>Given a mesh with workloads and their service deployed to &ldquo;us-west/zone1/<em>&rdquo;
 and &ldquo;us-west/zone2/</em>&rdquo;. This example specifies that when traffic accessing a
 service originates from workloads in &ldquo;us-west/zone1/<em>&rdquo;, 80% of the traffic
@@ -1243,7 +1150,6 @@ will be sent to endpoints in &ldquo;us-west/zone1/</em>&rdquo;, i.e the same zon
 remaining 20% will go to endpoints in &ldquo;us-west/zone2/<em>&rdquo;. This setup is
 intended to favor routing traffic to endpoints in the same locality.
 A similar setting is specified for traffic originating in &ldquo;us-west/zone2/</em>&rdquo;.</p>
-
 <pre><code class="language-yaml">  distribute:
     - from: us-west/zone1/*
       to:
@@ -1254,25 +1160,21 @@ A similar setting is specified for traffic originating in &ldquo;us-west/zone2/<
         &quot;us-west/zone1/*&quot;: 20
         &quot;us-west/zone2/*&quot;: 80
 </code></pre>
-
 <p>If the goal of the operator is not to distribute load across zones and
 regions but rather to restrict the regionality of failover to meet other
 operational requirements an operator can set a &lsquo;failover&rsquo; policy instead of
 a &lsquo;distribute&rsquo; policy.</p>
-
 <p>The following example sets up a locality failover policy for regions.
 Assume a service resides in zones within us-east, us-west &amp; eu-west
 this example specifies that when endpoints within us-east become unhealthy
 traffic should failover to endpoints in any zone or sub-zone within eu-west
 and similarly us-west should failover to us-east.</p>
-
 <pre><code class="language-yaml"> failover:
    - from: us-east
      to: eu-west
    - from: us-west
      to: us-east
 </code></pre>
-
 <p>Locality load balancing settings.</p>
 
 <table class="message-fields">
@@ -1320,19 +1222,15 @@ No
 <p>failoverPriority is an ordered list of labels used to sort endpoints to do priority based load balancing.
 This is to support traffic failover across different groups of endpoints.
 Suppose there are total N labels specified:</p>
-
 <ol>
 <li>Endpoints matching all N labels with the client proxy have priority P(0) i.e. the highest priority.</li>
 <li>Endpoints matching the first N-1 labels with the client proxy have priority P(1) i.e. second highest priority.</li>
 <li>By extension of this logic, endpoints matching only the first label with the client proxy has priority P(N-1) i.e. second lowest priority.</li>
 <li>All the other endpoints have priority P(N) i.e. lowest priority.</li>
 </ol>
-
 <p>Note: For a label to be considered for match, the previous labels must match, i.e. nth label would be considered matched only if first n-1 labels match.</p>
-
 <p>It can be any label specified on both client and server workloads.
 The following labels which have special semantic meaning are also supported:</p>
-
 <ul>
 <li><code>topology.istio.io/network</code> is used to match the network metadata of an endpoint, which can be specified by pod/namespace label <code>topology.istio.io/network</code>, sidecar env <code>ISTIO_META_NETWORK</code> or MeshNetworks.</li>
 <li><code>topology.istio.io/cluster</code> is used to match the clusterID of an endpoint, which can be specified by pod label <code>topology.istio.io/cluster</code> or pod env <code>ISTIO_META_CLUSTER_ID</code>.</li>
@@ -1340,16 +1238,13 @@ The following labels which have special semantic meaning are also supported:</p>
 <li><code>topology.kubernetes.io/zone</code> is used to match the zone metadata of an endpoint, which maps to Kubernetes node label <code>topology.kubernetes.io/zone</code> or the deprecated label <code>failure-domain.beta.kubernetes.io/zone</code>.</li>
 <li><code>topology.istio.io/subzone</code> is used to match the subzone metadata of an endpoint, which maps to Istio node label <code>topology.istio.io/subzone</code>.</li>
 </ul>
-
 <p>The below topology config indicates the following priority levels:</p>
-
 <pre><code class="language-yaml">failoverPriority:
 - &quot;topology.istio.io/network&quot;
 - &quot;topology.kubernetes.io/region&quot;
 - &quot;topology.kubernetes.io/zone&quot;
 - &quot;topology.istio.io/subzone&quot;
 </code></pre>
-
 <ol>
 <li>endpoints match same [network, region, zone, subzone] label with the client proxy have the highest priority.</li>
 <li>endpoints have same [network, region, zone] label but different [subzone] label with the client proxy have the second highest priority.</li>
@@ -1357,7 +1252,6 @@ The following labels which have special semantic meaning are also supported:</p>
 <li>endpoints have same [network] but different [region] labels with the client proxy have the fourth highest priority.</li>
 <li>all the other endpoints have the same lowest priority.</li>
 </ol>
-
 <p>Optional: only one of distribute, failover or failoverPriority can be set.
 And it should be used together with <code>OutlierDetection</code> to detect unhealthy endpoints, otherwise has no effect.</p>
 
@@ -1472,8 +1366,8 @@ No
 <td>
 <p>Specifies which protocol to use for tunneling the downstream connection.
 Supported protocols are:
-  CONNECT - uses HTTP CONNECT;
-  POST - uses HTTP POST.
+CONNECT - uses HTTP CONNECT;
+POST - uses HTTP POST.
 CONNECT is used by default if not specified.
 HTTP version for upstream requests is determined by the service protocol defined for the proxy.</p>
 
@@ -1801,7 +1695,7 @@ No
 <td>
 <p>Maximum number of requests that will be queued while waiting for
 a ready connection pool connection. Default 1024.
-Refer to https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking
+Refer to <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking">https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking</a>
 under which conditions a new connection is created for HTTP2.
 Please note that this is applicable to both HTTP/1.1 and HTTP2.</p>
 
@@ -1950,14 +1844,11 @@ No
 <h2 id="LocalityLoadBalancerSetting-Distribute">LocalityLoadBalancerSetting.Distribute</h2>
 <section>
 <p>Describes how traffic originating in the &lsquo;from&rsquo; zone or sub-zone is
-distributed over a set of &lsquo;to&rsquo; zones. Syntax for specifying a zone is
+distributed over a set of &rsquo;to&rsquo; zones. Syntax for specifying a zone is
 {region}/{zone}/{sub-zone} and terminal wildcards are allowed on any
 segment of the specification. Examples:</p>
-
 <p><code>*</code> - matches all localities</p>
-
 <p><code>us-west/*</code> - all zones and sub-zones within the us-west region</p>
-
 <p><code>us-west/zone-1/*</code> - all sub-zones within us-west/zone-1</p>
 
 <table class="message-fields">
@@ -2046,7 +1937,6 @@ No
 <h2 id="google-protobuf-UInt32Value">google.protobuf.UInt32Value</h2>
 <section>
 <p>Wrapper message for <code>uint32</code>.</p>
-
 <p>The JSON representation for <code>UInt32Value</code> is JSON number.</p>
 
 <table class="message-fields">

--- a/networking/v1alpha3/envoy_filter.pb.html
+++ b/networking/v1alpha3/envoy_filter.pb.html
@@ -20,7 +20,6 @@ application of these EnvoyFilters is as follows: all EnvoyFilters
 in the config <a href="https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig">root
 namespace</a>,
 followed by all matching EnvoyFilters in the workload&rsquo;s namespace.</p>
-
 <p><strong>NOTE 1</strong>: Some aspects of this API are deeply tied to the internal
 implementation in Istio networking subsystem as well as Envoy&rsquo;s XDS
 API. While the EnvoyFilter API by itself will maintain backward
@@ -28,25 +27,21 @@ compatibility, any envoy configuration provided through this
 mechanism should be carefully monitored across Istio proxy version
 upgrades, to ensure that deprecated fields are removed and replaced
 appropriately.</p>
-
 <p><strong>NOTE 2</strong>: When multiple EnvoyFilters are bound to the same
 workload in a given namespace, all patches will be processed
 sequentially in order of creation time.  The behavior is undefined
 if multiple EnvoyFilter configurations conflict with each other.</p>
-
 <p><strong>NOTE 3</strong>: To apply an EnvoyFilter resource to all workloads
 (sidecars and gateways) in the system, define the resource in the
 config <a href="https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig">root
 namespace</a>,
 without a workloadSelector.</p>
-
 <p>The example below declares a global default EnvoyFilter resource in
 the root namespace called <code>istio-config</code>, that adds a custom
 protocol filter on all sidecars in the system, for outbound port
 9307. The filter should be added before the terminating tcp_proxy
 filter to take effect. In addition, it sets a 30s idle timeout for
 all HTTP connections in both gateways and sidecars.</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -86,14 +81,12 @@ spec:
           common_http_protocol_options:
             idle_timeout: 30s
 </code></pre>
-
 <p>The following example enables Envoy&rsquo;s Lua filter for all inbound
 HTTP calls arriving at service port 8080 of the reviews service pod
 with labels &ldquo;app: reviews&rdquo;, in the bookinfo namespace. The lua
 filter calls out to an external service internal.org.net:8888 that
 requires a special cluster definition in envoy. The cluster is also
 added to the sidecar as part of this configuration.</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -157,12 +150,10 @@ spec:
                     address: &quot;internal.org.net&quot;
                     port_value: 8888
 </code></pre>
-
 <p>The following example overwrites certain fields (HTTP idle timeout
 and X-Forward-For trusted hops) in the HTTP connection manager in a
 listener on the ingress gateway in istio-system namespace for the
 SNI host app.example.com:</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -190,11 +181,9 @@ spec:
           common_http_protocol_options:
             idle_timeout: 30s
 </code></pre>
-
 <p>The following example inserts an attributegen filter
 that produces <code>istio_operationId</code> attribute which is consumed
 by the istio.stats filter. <code>filterClass: STATS</code> encodes this dependency.</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -235,9 +224,7 @@ spec:
                code:
                  local: { inline_string: &quot;envoy.wasm.attributegen&quot; }
 </code></pre>
-
 <p>The following example inserts an http ext_authz filter in the <code>myns</code> namespace.</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -262,12 +249,10 @@ spec:
             - key: foo
               value: myauth.acme # required by local ext auth server.
 </code></pre>
-
 <p>A workload in the <code>myns</code> namespace needs to access a different ext_auth server
 that does not accept initial metadata. Since proto merge cannot remove fields, the
 following configuration uses the <code>REPLACE</code> operation. If you do not need to inherit
 fields, REPLACE is preferred over MERGE.</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -291,9 +276,7 @@ spec:
             envoy_grpc:
               cluster_name: acme-ext-authz-alt
 </code></pre>
-
 <p>The following example deploys a Wasm extension for all inbound sidecar HTTP requests.</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -346,12 +329,10 @@ spec:
             ads: {}
           type_urls: [&quot;type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm&quot;]
 </code></pre>
-
 <p>The following example adds a Wasm service extension for all proxies using a locally available Wasm file.
 The singleton Wasm extension is used to maintain a shared state between workers executing Wasm filters.
 For example, a local rate limit extension would rely on a singleton to limit requests across all workers.
 As another example, an authorization Wasm extension can use a singleton to maintain a database of accounts.</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -435,14 +416,11 @@ is significant. The API provides two primary ways to order patches.
 Patch sets in the root namespace are applied before the patch sets in the
 workload namespace. Patches within a patch set are processed in the order
 that they appear in the <code>configPatches</code> list.</p>
-
 <p>The default value for priority is 0 and the range is [ min-int32, max-int32 ].
 A patch set with a negative priority is processed before the default. A patch
 set with a positive priority is processed after the default.</p>
-
 <p>It is recommended to start with priority values that are multiples of 10
 to leave room for further insertion.</p>
-
 <p>Patch sets are sorted in the following ascending key order:
 priority, creation time, fully qualified resource name.</p>
 
@@ -1039,9 +1017,7 @@ transport protocol to consider when determining a filter
 chain match.  This value will be compared against the
 transport protocol of a new connection, when it&rsquo;s detected by
 the <code>tls_inspector</code> listener filter.</p>
-
 <p>Accepted values include:</p>
-
 <ul>
 <li><code>raw_buffer</code> - default, used when no transport protocol is detected.</li>
 <li><code>tls</code> - set when TLS protocol is detected by the TLS inspector.</li>
@@ -1061,7 +1037,6 @@ of application protocols to consider when determining a
 filter chain match.  This value will be compared against the
 application protocols of a new connection, when it&rsquo;s detected
 by one of the listener filters such as the <code>http_inspector</code>.</p>
-
 <p>Accepted values include: h2, http/1.1, http/1.0</p>
 
 </td>

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -12,18 +12,14 @@ number_of_entries: 6
 receiving incoming or outgoing HTTP/TCP connections. The specification
 describes a set of ports that should be exposed, the type of protocol to
 use, SNI configuration for the load balancer, etc.</p>
-
 <p>For example, the following Gateway configuration sets up a proxy to act
 as a load balancer exposing port 80 and 9080 (http), 443 (https),
 9443(https) and port 2379 (TCP) for ingress.  The gateway will be
-applied to the proxy running on a pod with labels <code>app:
-my-gateway-controller</code>. While Istio will configure the proxy to listen
+applied to the proxy running on a pod with labels <code>app: my-gateway-controller</code>. While Istio will configure the proxy to listen
 on these ports, it is the responsibility of the user to ensure that
 external traffic to these ports are allowed into the mesh.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -75,11 +71,8 @@ spec:
     hosts:
     - &quot;*&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
@@ -131,14 +124,11 @@ spec:
     hosts:
     - &quot;*&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The Gateway specification above describes the L4-L6 properties of a load
 balancer. A <code>VirtualService</code> can then be bound to a gateway to control
 the forwarding of traffic arriving at a particular host or gateway port.</p>
-
 <p>For example, the following VirtualService splits traffic for
 <code>https://uk.bookinfo.com/reviews</code>, <code>https://eu.bookinfo.com/reviews</code>,
 <code>http://uk.bookinfo.com:9080/reviews</code>,
@@ -149,10 +139,8 @@ in the qa version. The same rule is also applicable inside the mesh for
 requests to the &ldquo;reviews.prod.svc.cluster.local&rdquo; service. This rule is
 applicable across ports 443, 9080. Note that <code>http://uk.bookinfo.com</code>
 gets redirected to <code>https://uk.bookinfo.com</code> (i.e. 80 redirects to 443).</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -189,11 +177,8 @@ spec:
         host: reviews.qa.svc.cluster.local
       weight: 20
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -230,18 +215,14 @@ spec:
         host: reviews.qa.svc.cluster.local
       weight: 20
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following VirtualService forwards traffic arriving at (external)
 port 27017 to internal Mongo server on port 5555. This rule is not
 applicable internally in the mesh as the gateway list omits the
 reserved name <code>mesh</code>.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -261,11 +242,8 @@ spec:
         port:
           number: 5555
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -285,19 +263,15 @@ spec:
         port:
           number: 5555
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>It is possible to restrict the set of virtual services that can bind to
 a gateway server using the namespace/hostname syntax in the hosts field.
 For example, the following Gateway allows any virtual service in the ns1
 namespace to bind to it, while restricting only the virtual service with
 foo.bar.com host in the ns2 namespace to bind to it.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -315,11 +289,8 @@ spec:
     - &quot;ns1/*&quot;
     - &quot;ns2/foo.bar.com&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
@@ -337,7 +308,6 @@ spec:
     - &quot;ns1/*&quot;
     - &quot;ns2/foo.bar.com&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -396,10 +366,8 @@ Yes
 <section>
 <p><code>Server</code> describes the properties of the proxy on a given load balancer
 port. For example,</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -415,11 +383,8 @@ spec:
     hosts:
     - &quot;*&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
@@ -435,15 +400,11 @@ spec:
     hosts:
     - &quot;*&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>Another example</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -459,11 +420,8 @@ spec:
     hosts:
     - &quot;*&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
@@ -479,15 +437,11 @@ spec:
     hosts:
     - &quot;*&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following is an example of TLS configuration for port 443</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -506,11 +460,8 @@ spec:
       mode: SIMPLE
       credentialName: tls-cert
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
@@ -529,7 +480,6 @@ spec:
       mode: SIMPLE
       credentialName: tls-cert
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -585,14 +535,12 @@ The <code>dnsName</code> should be specified using FQDN format, optionally inclu
 a wildcard character in the left-most component (e.g., <code>prod/*.example.com</code>).
 Set the <code>dnsName</code> to <code>*</code> to select all <code>VirtualService</code> hosts from the
 specified namespace (e.g.,<code>prod/*</code>).</p>
-
 <p>The <code>namespace</code> can be set to <code>*</code> or <code>.</code>, representing any or the current
 namespace, respectively. For example, <code>*/foo.example.com</code> selects the
 service from any available namespace while <code>./foo.example.com</code> only selects
 the service from the namespace of the sidecar. The default, if no <code>namespace/</code>
 is specified, is <code>*/</code>, that is, select services from any namespace.
 Any associated <code>DestinationRule</code> in the selected namespace will also be used.</p>
-
 <p>A <code>VirtualService</code> must be bound to the gateway and must have one or
 more hosts that match the hosts specified in a server. The match
 could be an exact match or a suffix match with the server&rsquo;s hosts. For
@@ -600,7 +548,6 @@ example, if the server&rsquo;s hosts specifies <code>*.example.com</code>, a
 <code>VirtualService</code> with hosts <code>dev.example.com</code> or <code>prod.example.com</code> will
 match. However, a <code>VirtualService</code> with host <code>example.com</code> or
 <code>newexample.com</code> will not match.</p>
-
 <p>NOTE: Only virtual services exported to the gateway&rsquo;s namespace
 (e.g., <code>exportTo</code> value of <code>*</code>) can be referenced.
 Private configurations (e.g., <code>exportTo</code> set to <code>.</code>) will not be
@@ -787,8 +734,7 @@ No
 <p>For gateways running on Kubernetes, the name of the secret that
 holds the TLS certs including the CA certificates. Applicable
 only on Kubernetes. The secret (of type <code>generic</code>) should
-contain the following keys and values: <code>key:
-&lt;privateKey&gt;</code> and <code>cert: &lt;serverCert&gt;</code>. For mutual TLS,
+contain the following keys and values: <code>key: &lt;privateKey&gt;</code> and <code>cert: &lt;serverCert&gt;</code>. For mutual TLS,
 <code>cacert: &lt;CACertificate&gt;</code> can be provided in the same secret or
 a separate secret named <code>&lt;secret&gt;-cacert</code>.
 Secret of type tls for server certificates along with

--- a/networking/v1alpha3/service_entry.pb.html
+++ b/networking/v1alpha3/service_entry.pb.html
@@ -23,14 +23,11 @@ pods. The ability to select both pods and VMs under a single
 service allows for migration of services from VMs to Kubernetes
 without having to change the existing DNS names associated with the
 services.</p>
-
 <p>The following example declares a few external APIs accessed by internal
 applications over HTTPS. The sidecar inspects the SNI value in the
 ClientHello message to route to the appropriate external service.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -47,11 +44,8 @@ spec:
     protocol: TLS
   resolution: DNS
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -68,18 +62,14 @@ spec:
     protocol: TLS
   resolution: DNS
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following configuration adds a set of MongoDB instances running on
 unmanaged VMs to Istio&rsquo;s registry, so that these services can be treated
 as any other service in the mesh. The associated DestinationRule is used
 to initiate mTLS connections to the database instances.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -99,11 +89,8 @@ spec:
   - address: 2.2.2.2
   - address: 3.3.3.3
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -123,15 +110,11 @@ spec:
   - address: 2.2.2.2
   - address: 3.3.3.3
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>and the associated DestinationRule</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -145,11 +128,8 @@ spec:
       privateKey: /etc/certs/client_private_key.pem
       caCertificates: /etc/certs/rootcacerts.pem
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -163,17 +143,13 @@ spec:
       privateKey: /etc/certs/client_private_key.pem
       caCertificates: /etc/certs/rootcacerts.pem
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following example uses a combination of service entry and TLS
 routing in a virtual service to steer traffic based on the SNI value to
 an internal egress firewall.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -189,11 +165,8 @@ spec:
     protocol: TLS
   resolution: NONE
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -209,15 +182,11 @@ spec:
     protocol: TLS
   resolution: NONE
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>And the associated VirtualService to route based on the SNI value.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -235,11 +204,8 @@ spec:
     - destination:
         host: internal-egress-firewall.ns1.svc.cluster.local
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -257,25 +223,20 @@ spec:
     - destination:
         host: internal-egress-firewall.ns1.svc.cluster.local
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The virtual service with TLS match serves to override the default SNI
 match. In the absence of a virtual service, traffic will be forwarded to
 the wikipedia domains.</p>
-
 <p>The following example demonstrates the use of a dedicated egress gateway
 through which all external service traffic is forwarded.
-The &lsquo;exportTo&rsquo; field allows for control over the visibility of a service
+The &rsquo;exportTo&rsquo; field allows for control over the visibility of a service
 declaration to other namespaces in the mesh. By default, a service is exported
 to all namespaces. The following example restricts the visibility to the
 current namespace, represented by &ldquo;.&rdquo;, so that it cannot be used by other
 namespaces.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -293,11 +254,8 @@ spec:
     protocol: HTTP
   resolution: DNS
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -315,15 +273,11 @@ spec:
     protocol: HTTP
   resolution: DNS
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>Define a gateway to handle all egress traffic.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -340,11 +294,8 @@ spec:
    hosts:
    - &quot;*&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
@@ -361,20 +312,16 @@ spec:
    hosts:
    - &quot;*&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>And the associated <code>VirtualService</code> to route from the sidecar to the
 gateway service (<code>istio-egressgateway.istio-system.svc.cluster.local</code>), as
 well as route from the gateway to the external service. Note that the
 virtual service is exported to all namespaces enabling them to route traffic
 through the gateway to the external service. Forcing traffic to go through
 a managed middle proxy like this is a common practice.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -404,11 +351,8 @@ spec:
     - destination:
         host: example.com
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -438,18 +382,14 @@ spec:
     - destination:
         host: example.com
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following example demonstrates the use of wildcards in the hosts for
 external services. If the connection has to be routed to the IP address
 requested by the application (i.e. application resolves DNS and attempts
 to connect to a specific IP), the discovery mode must be set to <code>NONE</code>.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -464,11 +404,8 @@ spec:
     protocol: HTTP
   resolution: NONE
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -483,17 +420,13 @@ spec:
     protocol: HTTP
   resolution: NONE
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following example demonstrates a service that is available via a
 Unix Domain Socket on the host of the client. The resolution must be
 set to STATIC to use Unix address endpoints.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -510,11 +443,8 @@ spec:
   endpoints:
   - address: unix:///var/run/example/socket
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -531,10 +461,8 @@ spec:
   endpoints:
   - address: unix:///var/run/example/socket
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>For HTTP-based services, it is possible to create a <code>VirtualService</code>
 backed by multiple DNS addressable endpoints. In such a scenario, the
 application can use the <code>HTTP_PROXY</code> environment variable to transparently
@@ -542,10 +470,8 @@ reroute API calls for the <code>VirtualService</code> to a chosen backend. For
 example, the following configuration creates a non-existent external
 service called foo.bar.com backed by three domains: us.foo.bar.com:8080,
 uk.foo.bar.com:9080, and in.foo.bar.com:7080</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -570,11 +496,8 @@ spec:
     ports:
       http: 7080
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -599,22 +522,17 @@ spec:
     ports:
       http: 7080
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>With <code>HTTP_PROXY=http://localhost/</code>, calls from the application to
 <code>http://foo.bar.com</code> will be load balanced across the three domains
 specified above. In other words, a call to <code>http://foo.bar.com/baz</code> would
 be translated to <code>http://uk.foo.bar.com/baz</code>.</p>
-
 <p>The following example illustrates the usage of a <code>ServiceEntry</code>
 containing a subject alternate name
 whose format conforms to the <a href="https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md">SPIFFE standard</a>:</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -635,11 +553,8 @@ spec:
   subjectAltNames:
   - &quot;spiffe://cluster.local/ns/httpbin-ns/sa/httpbin-service-account&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -660,10 +575,8 @@ spec:
   subjectAltNames:
   - &quot;spiffe://cluster.local/ns/httpbin-ns/sa/httpbin-service-account&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following example demonstrates the use of <code>ServiceEntry</code> with a
 <code>workloadSelector</code> to handle the migration of a service
 <code>details.bookinfo.com</code> from VMs to Kubernetes. The service has two
@@ -675,10 +588,8 @@ service. This VM has sidecar installed and bootstrapped using the
 <code>details-legacy</code> service account. The sidecar receives HTTP traffic
 on port 80 (wrapped in istio mutual TLS) and forwards it to the
 application on the localhost on the same port.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
@@ -701,11 +612,8 @@ spec:
     app: details
     instance-id: vm2
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: WorkloadEntry
 metadata:
@@ -728,18 +636,14 @@ spec:
     app: details
     instance-id: vm2
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>Assuming there is also a Kubernetes deployment with pod labels
 <code>app: details</code> using the same service account <code>details</code>, the
 following service entry declares a service spanning both VMs and
 Kubernetes:</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -757,11 +661,8 @@ spec:
     labels:
       app: details
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -779,7 +680,6 @@ spec:
     labels:
       app: details
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -804,18 +704,15 @@ service registry.</p>
 <td>
 <p>The hosts associated with the ServiceEntry. Could be a DNS
 name with wildcard prefix.</p>
-
 <ol>
 <li>The hosts field is used to select matching hosts in VirtualServices and DestinationRules.</li>
 <li>For HTTP traffic the HTTP Host/Authority header will be matched against the hosts field.</li>
 <li>For HTTPs or TLS traffic containing Server Name Indication (SNI), the SNI value
 will be matched against the hosts field.</li>
 </ol>
-
 <p><strong>NOTE 1:</strong> When resolution is set to type DNS and no endpoints
 are specified, the host field will be used as the DNS name of the
 endpoint to route traffic to.</p>
-
 <p><strong>NOTE 2:</strong> If the hostname matches with the name of a service
 from another service registry such as Kubernetes that also
 supplies its own set of endpoints, the ServiceEntry will be
@@ -823,7 +720,6 @@ treated as a decorator of the existing Kubernetes
 service. Properties in the service entry will be added to the
 Kubernetes service if applicable. Currently, the only the
 following additional properties will be considered by <code>istiod</code>:</p>
-
 <ol>
 <li>subjectAltNames: In addition to verifying the SANs of the
 service accounts associated with the pods of the service, the
@@ -935,14 +831,11 @@ allows it to be used by sidecars, gateways and virtual services defined in
 other namespaces. This feature provides a mechanism for service owners
 and mesh administrators to control the visibility of services across
 namespace boundaries.</p>
-
 <p>If no namespaces are specified then the service is exported to all
 namespaces by default.</p>
-
 <p>The value &ldquo;.&rdquo; is reserved and defines an export to the same namespace that
 the service is declared in. Similarly the value &ldquo;*&rdquo; is reserved and
 defines an export to all namespaces.</p>
-
 <p>For a Kubernetes Service, the equivalent effect can be achieved by setting
 the annotation &ldquo;networking.istio.io/exportTo&rdquo; to a comma-separated list
 of namespace names.</p>
@@ -958,7 +851,6 @@ No
 <td>
 <p>If specified, the proxy will verify that the server certificate&rsquo;s
 subject alternate name matches one of the specified values.</p>
-
 <p>NOTE: When using the workloadEntry with workloadSelectors, the
 service account specified in the workloadEntry will also be used
 to derive the additional subject alternate names that should be

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -18,7 +18,6 @@ ports, protocols that the proxy will accept when forwarding traffic to
 and from the workload. In addition, it is possible to restrict the set
 of services that the proxy can reach when forwarding outbound traffic
 from workload instances.</p>
-
 <p>Services and configuration in a mesh are organized into one or more
 namespaces (e.g., a Kubernetes namespace or a CF org/space). A <code>Sidecar</code>
 configuration in a namespace will apply to one or more workload instances in the same
@@ -28,7 +27,6 @@ namespace. When determining the <code>Sidecar</code> configuration to be applied
 workload instance, preference will be given to the resource with a
 <code>workloadSelector</code> that selects this workload instance, over a <code>Sidecar</code> configuration
 without any <code>workloadSelector</code>.</p>
-
 <p><strong>NOTE 1</strong>: <em><em>Each namespace can have only one <code>Sidecar</code>
 configuration without any <code>workloadSelector</code></em> that specifies the
 default for all pods in that namespace</em>. It is recommended to use
@@ -37,22 +35,18 @@ the system is undefined if more than one selector-less <code>Sidecar</code>
 configurations exist in a given namespace. The behavior of the
 system is undefined if two or more <code>Sidecar</code> configurations with a
 <code>workloadSelector</code> select the same workload instance.</p>
-
 <p><strong>NOTE 2</strong>: <em><em>A <code>Sidecar</code> configuration in the <code>MeshConfig</code>
 <a href="https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig">root namespace</a>
 will be applied by default to all namespaces without a <code>Sidecar</code>
 configuration</em></em>. This global default <code>Sidecar</code> configuration should not have
 any <code>workloadSelector</code>.</p>
-
 <p>The example below declares a global default <code>Sidecar</code> configuration
 in the root namespace called <code>istio-config</code>, that configures
 sidecars in all namespaces to allow egress traffic only to other
 workloads in the same namespace as well as to services in the
 <code>istio-system</code> namespace.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
@@ -64,11 +58,8 @@ spec:
     - &quot;./*&quot;
     - &quot;istio-system/*&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -80,19 +71,15 @@ spec:
     - &quot;./*&quot;
     - &quot;istio-system/*&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The example below declares a <code>Sidecar</code> configuration in the
 <code>prod-us1</code> namespace that overrides the global default defined
 above, and configures the sidecars in the namespace to allow egress
 traffic to public services in the <code>prod-us1</code>, <code>prod-apis</code>, and the
 <code>istio-system</code> namespaces.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
@@ -105,11 +92,8 @@ spec:
     - &quot;prod-apis/*&quot;
     - &quot;istio-system/*&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -122,10 +106,8 @@ spec:
     - &quot;prod-apis/*&quot;
     - &quot;istio-system/*&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following example declares a <code>Sidecar</code> configuration in the
 <code>prod-us1</code> namespace for all pods with labels <code>app: ratings</code>
 belonging to the <code>ratings.prod-us1</code> service.  The workload accepts
@@ -134,10 +116,8 @@ the attached workload instance listening on a Unix domain
 socket. In the egress direction, in addition to the <code>istio-system</code>
 namespace, the sidecar proxies only HTTP traffic bound for port
 9080 for services in the <code>prod-us1</code> namespace.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
@@ -163,11 +143,8 @@ spec:
   - hosts:
     - &quot;istio-system/*&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -193,10 +170,8 @@ spec:
   - hosts:
     - &quot;istio-system/*&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>If the workload is deployed without IPTables-based traffic capture,
 the <code>Sidecar</code> configuration is the only way to configure the ports
 on the proxy attached to the workload instance. The following
@@ -211,10 +186,8 @@ it to the application listening on <code>127.0.0.1:8080</code>. It also allows
 the application to communicate with a backing MySQL database on
 <code>127.0.0.1:3306</code>, that then gets proxied to the externally hosted
 MySQL service at <code>mysql.foo.com:3306</code>.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
@@ -241,11 +214,8 @@ spec:
     hosts:
     - &quot;*/mysql.foo.com&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -272,15 +242,11 @@ spec:
     hosts:
     - &quot;*/mysql.foo.com&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>And the associated service entry for routing to <code>mysql.foo.com:3306</code></p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -296,11 +262,8 @@ spec:
   location: MESH_EXTERNAL
   resolution: DNS
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -316,10 +279,8 @@ spec:
   location: MESH_EXTERNAL
   resolution: DNS
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>It is also possible to mix and match traffic capture modes in a single
 proxy. For example, consider a setup where internal services are on the
 <code>192.168.0.0/16</code> subnet. So, IP tables are setup on the VM to capture all
@@ -328,14 +289,11 @@ additional network interface on <code>172.16.0.0/16</code> subnet for inbound
 traffic. The following <code>Sidecar</code> configuration allows the VM to expose a
 listener on <code>172.16.1.32:80</code> (the VM&rsquo;s IP) for traffic arriving from the
 <code>172.16.0.0/16</code> subnet.</p>
-
 <p><strong>NOTE</strong>: The <code>ISTIO_META_INTERCEPTION_MODE</code> metadata on the
 proxy in the VM should contain <code>REDIRECT</code> or <code>TPROXY</code> as its value,
 implying that IP tables based traffic capture is active.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
@@ -362,11 +320,8 @@ spec:
     hosts:
     - &quot;*/*&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -393,10 +348,8 @@ spec:
     hosts:
     - &quot;*/*&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following example declares a <code>Sidecar</code> configuration in the
 <code>prod-us1</code> namespace for all pods with labels <code>app: ratings</code>
 belonging to the <code>ratings.prod-us1</code> service.  The service accepts
@@ -409,10 +362,8 @@ in order to set mTLS mode to &ldquo;DISABLE&rdquo; on specific
 ports.
 In this example, the mTLS mode is disabled on PORT 80.
 This feature is currently experimental.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
@@ -433,11 +384,8 @@ spec:
       privateKey: &quot;/etc/certs/privatekey.pem&quot;
       serverCertificate: &quot;/etc/certs/servercert.pem&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1" category-value="v1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: v1
 kind: Service
 metadata:
@@ -453,11 +401,8 @@ spec:
   selector:
     app: ratings
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -473,7 +418,6 @@ spec:
     80:
       mode: DISABLE
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -719,12 +663,10 @@ The corresponding service can be a service in the service registry
 (e.g., a Kubernetes or cloud foundry service) or a service specified
 using a <code>ServiceEntry</code> or <code>VirtualService</code> configuration. Any
 associated <code>DestinationRule</code> in the same namespace will also be used.</p>
-
 <p>The <code>dnsName</code> should be specified using FQDN format, optionally including
 a wildcard character in the left-most component (e.g., <code>prod/*.example.com</code>).
 Set the <code>dnsName</code> to <code>*</code> to select all services from the specified namespace
 (e.g., <code>prod/*</code>).</p>
-
 <p>The <code>namespace</code> can be set to <code>*</code>, <code>.</code>, or <code>~</code>, representing any, the current,
 or no namespace, respectively. For example, <code>*/foo.example.com</code> selects the
 service from any available namespace while <code>./foo.example.com</code> only selects
@@ -733,7 +675,6 @@ Istio will configure the sidecar to be able to reach every service in the
 mesh that is exported to the sidecar&rsquo;s namespace. The value <code>~/*</code> can be used
 to completely trim the configuration for sidecars that simply receive traffic
 and respond, but make no outbound connections of their own.</p>
-
 <p>NOTE: Only services and configuration artifacts exported to the sidecar&rsquo;s
 namespace (e.g., <code>exportTo</code> value of <code>*</code>) can be referenced.
 Private configurations (e.g., <code>exportTo</code> set to <code>.</code>) will

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -10,11 +10,9 @@ number_of_entries: 27
 ---
 <p>Configuration affecting traffic routing. Here are a few terms useful to define
 in the context of traffic routing.</p>
-
 <p><code>Service</code> a unit of application behavior bound to a unique name in a
 service registry. Services consist of multiple network <em>endpoints</em>
 implemented by workload instances running on pods, containers, VMs etc.</p>
-
 <p><code>Service versions (a.k.a. subsets)</code> - In a continuous deployment
 scenario, for a given service, there can be distinct subsets of
 instances running different variants of the application binary. These
@@ -25,34 +23,26 @@ occurs include A/B testing, canary rollouts, etc. The choice of a
 particular version can be decided based on various criterion (headers,
 url, etc.) and/or by weights assigned to each version. Each service has
 a default version consisting of all its instances.</p>
-
 <p><code>Source</code> - A downstream client calling a service.</p>
-
 <p><code>Host</code> - The address used by a client when attempting to connect to a
 service.</p>
-
 <p><code>Access model</code> - Applications address only the destination service
 (Host) without knowledge of individual service versions (subsets). The
 actual choice of the version is determined by the proxy/sidecar, enabling the
 application code to decouple itself from the evolution of dependent
 services.</p>
-
 <p>A <code>VirtualService</code> defines a set of traffic routing rules to apply when a host is
 addressed. Each routing rule defines matching criteria for traffic of a specific
 protocol. If the traffic is matched, then it is sent to a named destination service
 (or subset/version of it) defined in the registry.</p>
-
 <p>The source of traffic can also be matched in a routing rule. This allows routing
 to be customized for specific client contexts.</p>
-
 <p>The following example on Kubernetes, routes all HTTP traffic by default to
 pods of the reviews service with label &ldquo;version: v1&rdquo;. In addition,
 HTTP requests with path starting with /wpcatalog/ or /consumercatalog/ will
 be rewritten to /newcatalog and sent to pods with label &ldquo;version: v2&rdquo;.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -79,11 +69,8 @@ spec:
         host: reviews.prod.svc.cluster.local
         subset: v1
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -110,17 +97,13 @@ spec:
         host: reviews.prod.svc.cluster.local
         subset: v1
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>A subset/version of a route destination is identified with a reference
 to a named service subset which must be declared in a corresponding
 <code>DestinationRule</code>.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -135,11 +118,8 @@ spec:
     labels:
       version: v2
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -154,7 +134,6 @@ spec:
     labels:
       version: v2
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -181,7 +160,6 @@ be a DNS name with wildcard prefix or an IP address.  Depending on the
 platform, short-names can also be used instead of a FQDN (i.e. has no
 dots in the name). In such a scenario, the FQDN of the host would be
 derived based on the underlying platform.</p>
-
 <p>A single VirtualService can be used to describe all the traffic
 properties of the corresponding hosts, including those for multiple
 HTTP and TCP ports. Alternatively, the traffic properties of a host
@@ -189,7 +167,6 @@ can be defined using more than one VirtualService, with certain
 caveats. Refer to the
 <a href="https://istio.io/docs/ops/best-practices/traffic-management/#split-virtual-services">Operations Guide</a>
 for details.</p>
-
 <p><em>Note for Kubernetes users</em>: When short names are used (e.g. &ldquo;reviews&rdquo;
 instead of &ldquo;reviews.default.svc.cluster.local&rdquo;), Istio will interpret
 the short name based on the namespace of the rule, not the service. A
@@ -198,12 +175,10 @@ interpreted as &ldquo;reviews.default.svc.cluster.local&rdquo;, irrespective of
 the actual namespace associated with the reviews service. <em>To avoid
 potential misconfigurations, it is recommended to always use fully
 qualified domain names over short names.</em></p>
-
 <p>The hosts field applies to both HTTP and TCP services. Service inside
 the mesh, i.e., those found in the service registry, must always be
 referred to using their alphanumeric names. IP addresses are allowed
 only for services defined via the Gateway.</p>
-
 <p><em>Note</em>: It must be empty for a delegate VirtualService.</p>
 
 </td>
@@ -256,10 +231,10 @@ No
 <p>An ordered list of route rule for non-terminated TLS &amp; HTTPS
 traffic. Routing is typically performed using the SNI value presented
 by the ClientHello message. TLS routes will be applied to platform
-service ports named &lsquo;https-<em>&rsquo;, &lsquo;tls-</em>&rsquo;, unterminated gateway ports using
+service ports named &lsquo;https-<em>&rsquo;, &rsquo;tls-</em>&rsquo;, unterminated gateway ports using
 HTTPS/TLS protocols (i.e. with &ldquo;passthrough&rdquo; TLS mode) and service
 entry ports using HTTPS/TLS protocols.  The first rule matching an
-incoming request is used.  NOTE: Traffic &lsquo;https-<em>&rsquo; or &lsquo;tls-</em>&rsquo; ports
+incoming request is used.  NOTE: Traffic &lsquo;https-<em>&rsquo; or &rsquo;tls-</em>&rsquo; ports
 without associated virtual service will be treated as opaque TCP
 traffic.</p>
 
@@ -290,10 +265,8 @@ virtual service allows it to be used by sidecars and gateways defined in
 other namespaces. This feature provides a mechanism for service owners
 and mesh administrators to control the visibility of virtual services
 across namespace boundaries.</p>
-
 <p>If no namespaces are specified then the virtual service is exported to all
 namespaces by default.</p>
-
 <p>The value &ldquo;.&rdquo; is reserved and defines an export to the same namespace that
 the virtual service is declared in. Similarly the value &ldquo;*&rdquo; is reserved and
 defines an export to all namespaces.</p>
@@ -315,7 +288,6 @@ registry. Istio&rsquo;s service registry is composed of all the services found
 in the platform&rsquo;s service registry (e.g., Kubernetes services, Consul
 services), as well as services declared through the
 <a href="https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry">ServiceEntry</a> resource.</p>
-
 <p><em>Note for Kubernetes users</em>: When short names are used (e.g. &ldquo;reviews&rdquo;
 instead of &ldquo;reviews.default.svc.cluster.local&rdquo;), Istio will interpret
 the short name based on the namespace of the rule, not the service. A
@@ -324,14 +296,11 @@ interpreted as &ldquo;reviews.default.svc.cluster.local&rdquo;, irrespective of 
 actual namespace associated with the reviews service. <em>To avoid potential
 misconfigurations, it is recommended to always use fully qualified
 domain names over short names.</em></p>
-
 <p>The following Kubernetes example routes all traffic by default to pods
 of the reviews service with label &ldquo;version: v1&rdquo; (i.e., subset v1), and
 some to subset v2, in a Kubernetes environment.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -357,11 +326,8 @@ spec:
         host: reviews # interpreted as reviews.foo.svc.cluster.local
         subset: v1
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -387,15 +353,11 @@ spec:
         host: reviews # interpreted as reviews.foo.svc.cluster.local
         subset: v1
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>And the associated DestinationRule</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -411,11 +373,8 @@ spec:
     labels:
       version: v2
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -431,10 +390,8 @@ spec:
     labels:
       version: v2
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following VirtualService sets a timeout of 5s for all calls to
 productpage.prod.svc.cluster.local service in Kubernetes. Notice that
 there are no subsets defined in this rule. Istio will fetch all
@@ -444,10 +401,8 @@ that this rule is set in the istio-system namespace but uses the fully
 qualified domain name of the productpage service,
 productpage.prod.svc.cluster.local. Therefore the rule&rsquo;s namespace does
 not have an impact in resolving the name of the productpage service.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -462,11 +417,8 @@ spec:
     - destination:
         host: productpage.prod.svc.cluster.local
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -481,19 +433,15 @@ spec:
     - destination:
         host: productpage.prod.svc.cluster.local
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>To control routing for traffic bound to services outside the mesh, external
 services must first be added to Istio&rsquo;s internal service registry using the
 ServiceEntry resource. VirtualServices can then be defined to control traffic
 bound to these external services. For example, the following rules define a
 Service for wikipedia.org and set a timeout of 5s for HTTP requests.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -521,11 +469,8 @@ spec:
     - destination:
         host: wikipedia.org
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -553,7 +498,6 @@ spec:
     - destination:
         host: wikipedia.org
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -576,7 +520,6 @@ names are looked up from the platform&rsquo;s service registry (e.g.,
 Kubernetes services, Consul services, etc.) and from the hosts
 declared by <a href="https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry">ServiceEntry</a>. Traffic forwarded to
 destinations that are not found in either of the two, will be dropped.</p>
-
 <p><em>Note for Kubernetes users</em>: When short names are used (e.g. &ldquo;reviews&rdquo;
 instead of &ldquo;reviews.default.svc.cluster.local&rdquo;), Istio will interpret
 the short name based on the namespace of the rule, not the service. A
@@ -698,7 +641,6 @@ No
 <p>A HTTP rule can either return a direct_response, redirect or forward (default) traffic.
 Direct Response is used to specify a fixed response that should
 be sent to clients.</p>
-
 <p>It can be set only when <code>Route</code> and <code>Redirect</code> are empty.</p>
 
 </td>
@@ -712,13 +654,10 @@ No
 <td>
 <p>Delegate is used to specify the particular VirtualService which
 can be used to define delegate HTTPRoute.</p>
-
 <p>It can be set only when <code>Route</code> and <code>Redirect</code> are empty, and the route
 rules of the delegate VirtualService will be merged with that in the
 current one.</p>
-
 <p><strong>NOTE</strong>:</p>
-
 <ol>
 <li>Only one level delegation is supported.</li>
 <li>The delegate&rsquo;s HTTPMatchRequest must be a strict subset of the root&rsquo;s,
@@ -838,7 +777,6 @@ No
 <p>Describes the delegate VirtualService.
 The following routing rules forward the traffic to <code>/productpage</code> by a delegate VirtualService named <code>productpage</code>,
 forward the traffic to <code>/reviews</code> by a delegate VirtualService named <code>reviews</code>.</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -862,7 +800,6 @@ spec:
         name: reviews
         namespace: nsB
 </code></pre>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -880,7 +817,6 @@ spec:
     - destination:
         host: productpage.nsA.svc.cluster.local
 </code></pre>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -938,10 +874,8 @@ The following VirtualService adds a <code>test</code> header with the value <cod
 to requests that are routed to any <code>reviews</code> service destination.
 It also removes the <code>foo</code> response header, but only from responses
 coming from the <code>v1</code> subset (version) of the <code>reviews</code> service.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -968,11 +902,8 @@ spec:
           - foo
       weight: 75
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -999,7 +930,6 @@ spec:
           - foo
       weight: 75
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -1046,10 +976,8 @@ No
 traffic (TLS/HTTPS) The following routing rule forwards unterminated TLS
 traffic arriving at port 443 of gateway called &ldquo;mygateway&rdquo; to internal
 services in the mesh based on the SNI value.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -1075,11 +1003,8 @@ spec:
     - destination:
         host: reviews.prod.svc.cluster.local
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -1105,7 +1030,6 @@ spec:
     - destination:
         host: reviews.prod.svc.cluster.local
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -1152,10 +1076,8 @@ No
 <p>Describes match conditions and actions for routing TCP traffic. The
 following routing rule forwards traffic arriving at port 27017 for
 mongo.prod.svc.cluster.local to another Mongo server on port 5555.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -1172,11 +1094,8 @@ spec:
         port:
           number: 5555
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -1193,7 +1112,6 @@ spec:
         port:
           number: 5555
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -1242,10 +1160,8 @@ rule to be applied to the HTTP request. For example, the following
 restricts the rule to match only requests where the URL path
 starts with /ratings/v2/ and the request contains a custom <code>end-user</code> header
 with value <code>jason</code>.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -1265,11 +1181,8 @@ spec:
     - destination:
         host: ratings.prod.svc.cluster.local
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -1289,10 +1202,8 @@ spec:
     - destination:
         host: ratings.prod.svc.cluster.local
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>HTTPMatchRequest CANNOT be empty.
 <strong>Note:</strong> No regex string match can be set when delegate VirtualService is specified.</p>
 
@@ -1325,15 +1236,17 @@ No
 <td>
 <p>URI to match
 values are case-sensitive and formatted as follows:</p>
-
 <ul>
-<li><p><code>exact: &quot;value&quot;</code> for exact string match</p></li>
-
-<li><p><code>prefix: &quot;value&quot;</code> for prefix-based match</p></li>
-
-<li><p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).</p></li>
+<li>
+<p><code>exact: &quot;value&quot;</code> for exact string match</p>
+</li>
+<li>
+<p><code>prefix: &quot;value&quot;</code> for prefix-based match</p>
+</li>
+<li>
+<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+</li>
 </ul>
-
 <p><strong>Note:</strong> Case-insensitive matching could be enabled via the
 <code>ignore_uri_case</code> flag.</p>
 
@@ -1348,13 +1261,16 @@ No
 <td>
 <p>URI Scheme
 values are case-sensitive and formatted as follows:</p>
-
 <ul>
-<li><p><code>exact: &quot;value&quot;</code> for exact string match</p></li>
-
-<li><p><code>prefix: &quot;value&quot;</code> for prefix-based match</p></li>
-
-<li><p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).</p></li>
+<li>
+<p><code>exact: &quot;value&quot;</code> for exact string match</p>
+</li>
+<li>
+<p><code>prefix: &quot;value&quot;</code> for prefix-based match</p>
+</li>
+<li>
+<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+</li>
 </ul>
 
 </td>
@@ -1368,13 +1284,16 @@ No
 <td>
 <p>HTTP Method
 values are case-sensitive and formatted as follows:</p>
-
 <ul>
-<li><p><code>exact: &quot;value&quot;</code> for exact string match</p></li>
-
-<li><p><code>prefix: &quot;value&quot;</code> for prefix-based match</p></li>
-
-<li><p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).</p></li>
+<li>
+<p><code>exact: &quot;value&quot;</code> for exact string match</p>
+</li>
+<li>
+<p><code>prefix: &quot;value&quot;</code> for prefix-based match</p>
+</li>
+<li>
+<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+</li>
 </ul>
 
 </td>
@@ -1388,13 +1307,16 @@ No
 <td>
 <p>HTTP Authority
 values are case-sensitive and formatted as follows:</p>
-
 <ul>
-<li><p><code>exact: &quot;value&quot;</code> for exact string match</p></li>
-
-<li><p><code>prefix: &quot;value&quot;</code> for prefix-based match</p></li>
-
-<li><p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).</p></li>
+<li>
+<p><code>exact: &quot;value&quot;</code> for exact string match</p>
+</li>
+<li>
+<p><code>prefix: &quot;value&quot;</code> for prefix-based match</p>
+</li>
+<li>
+<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+</li>
 </ul>
 
 </td>
@@ -1408,17 +1330,18 @@ No
 <td>
 <p>The header keys must be lowercase and use hyphen as the separator,
 e.g. <em>x-request-id</em>.</p>
-
 <p>Header values are case-sensitive and formatted as follows:</p>
-
 <ul>
-<li><p><code>exact: &quot;value&quot;</code> for exact string match</p></li>
-
-<li><p><code>prefix: &quot;value&quot;</code> for prefix-based match</p></li>
-
-<li><p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).</p></li>
+<li>
+<p><code>exact: &quot;value&quot;</code> for exact string match</p>
+</li>
+<li>
+<p><code>prefix: &quot;value&quot;</code> for prefix-based match</p>
+</li>
+<li>
+<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+</li>
 </ul>
-
 <p>If the value is empty and only the name of header is specfied, presence of the header is checked.
 <strong>Note:</strong> The keys <code>uri</code>, <code>scheme</code>, <code>method</code>, and <code>authority</code> will be ignored.</p>
 
@@ -1472,21 +1395,22 @@ No
 <td><code>map&lt;string,&nbsp;<a href="#StringMatch">StringMatch</a>&gt;</code></td>
 <td>
 <p>Query parameters for matching.</p>
-
 <p>Ex:</p>
-
 <ul>
-<li><p>For a query parameter like &ldquo;?key=true&rdquo;, the map key would be &ldquo;key&rdquo; and
-the string match could be defined as <code>exact: &quot;true&quot;</code>.</p></li>
-
-<li><p>For a query parameter like &ldquo;?key&rdquo;, the map key would be &ldquo;key&rdquo; and the
-string match could be defined as <code>exact: &quot;&quot;</code>.</p></li>
-
-<li><p>For a query parameter like &ldquo;?key=123&rdquo;, the map key would be &ldquo;key&rdquo; and the
+<li>
+<p>For a query parameter like &ldquo;?key=true&rdquo;, the map key would be &ldquo;key&rdquo; and
+the string match could be defined as <code>exact: &quot;true&quot;</code>.</p>
+</li>
+<li>
+<p>For a query parameter like &ldquo;?key&rdquo;, the map key would be &ldquo;key&rdquo; and the
+string match could be defined as <code>exact: &quot;&quot;</code>.</p>
+</li>
+<li>
+<p>For a query parameter like &ldquo;?key=123&rdquo;, the map key would be &ldquo;key&rdquo; and the
 string match could be defined as <code>regex: &quot;\d+$&quot;</code>. Note that this
-configuration will only match values like &ldquo;123&rdquo; but not &ldquo;a123&rdquo; or &ldquo;123a&rdquo;.</p></li>
+configuration will only match values like &ldquo;123&rdquo; but not &ldquo;a123&rdquo; or &ldquo;123a&rdquo;.</p>
+</li>
 </ul>
-
 <p><strong>Note:</strong> <code>prefix</code> matching is currently not supported.</p>
 
 </td>
@@ -1499,7 +1423,6 @@ No
 <td><code>bool</code></td>
 <td>
 <p>Flag to specify whether the URI matching should be case-insensitive.</p>
-
 <p><strong>Note:</strong> The case will be ignored only in the case of <code>exact</code> and <code>prefix</code>
 URI matches.</p>
 
@@ -1538,10 +1461,10 @@ No
 <td><code>string</code></td>
 <td>
 <p>The human readable prefix to use when emitting statistics for this route.
-The statistics are generated with prefix route.<stat_prefix>.
+The statistics are generated with prefix route.&lt;stat_prefix&gt;.
 This should be set for highly critical routes that one wishes to get &ldquo;per-route&rdquo; statistics on.
-This prefix is only for proxy-level statistics (envoy<em>*) and not service-level (istio</em>*) statistics.
-Refer to https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-route-stat-prefix
+This prefix is only for proxy-level statistics (envoy_<em>) and not service-level (istio_</em>) statistics.
+Refer to <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-route-stat-prefix">https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-route-stat-prefix</a>
 for statistics that are generated when this is configured.</p>
 
 </td>
@@ -1560,10 +1483,8 @@ determine the proportion of traffic it receives. For example, the
 following rule will route 25% of traffic for the &ldquo;reviews&rdquo; service to
 instances with the &ldquo;v2&rdquo; tag and the remaining traffic (i.e., 75%) to
 &ldquo;v1&rdquo;.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -1582,11 +1503,8 @@ spec:
         subset: v1
       weight: 75
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -1605,15 +1523,11 @@ spec:
         subset: v1
       weight: 75
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>And the associated DestinationRule</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -1628,11 +1542,8 @@ spec:
     labels:
       version: v2
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -1647,17 +1558,13 @@ spec:
     labels:
       version: v2
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>Traffic can also be split across two entirely different services without
 having to define new subsets. For example, the following rule forwards 25% of
 traffic to reviews.com to dev.reviews.com</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -1674,11 +1581,8 @@ spec:
         host: reviews.com
       weight: 75
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -1695,7 +1599,6 @@ spec:
         host: reviews.com
       weight: 75
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -1977,10 +1880,8 @@ where the Authority/Host and the URI in the response can be swapped with
 the specified values. For example, the following rule redirects
 requests for /v1/getProductRatings API on the ratings service to
 /v1/bookRatings provided by the bookratings service.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -1997,11 +1898,8 @@ spec:
       authority: newratings.default.svc.cluster.local
   ...
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -2018,7 +1916,6 @@ spec:
       authority: newratings.default.svc.cluster.local
   ...
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -2072,9 +1969,11 @@ No
 <td><code>derivePort</code></td>
 <td><code><a href="#HTTPRedirect-RedirectPortSelection">RedirectPortSelection (oneof)</a></code></td>
 <td>
-<p>On a redirect, dynamically set the port:
-* FROM_PROTOCOL_DEFAULT: automatically set to 80 for HTTP and 443 for HTTPS.
-* FROM_REQUEST_PORT: automatically use the port of the request.</p>
+<p>On a redirect, dynamically set the port:</p>
+<ul>
+<li>FROM_PROTOCOL_DEFAULT: automatically set to 80 for HTTP and 443 for HTTPS.</li>
+<li>FROM_REQUEST_PORT: automatically use the port of the request.</li>
+</ul>
 
 </td>
 <td>
@@ -2115,10 +2014,8 @@ No
 <p>HTTPDirectResponse can be used to send a fixed response to clients.
 For example, the following rule returns a fixed 503 status with a body
 to requests for /v1/getProductRatings API.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -2136,11 +2033,8 @@ spec:
         string: &quot;unknown error&quot;
   ...
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -2158,16 +2052,12 @@ spec:
         string: &quot;unknown error&quot;
   ...
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>It is also possible to specify a binary response body.
 This is mostly useful for non text-based protocols such as gRPC.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -2185,11 +2075,8 @@ spec:
         bytes: &quot;dW5rbm93biBlcnJvcg==&quot; # &quot;unknown error&quot; in base64
   ...
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -2207,17 +2094,13 @@ spec:
         bytes: &quot;dW5rbm93biBlcnJvcg==&quot; # &quot;unknown error&quot; in base64
   ...
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>It is good practice to add headers in the HTTPRoute
 as well as the direct_response, for example to specify
 the returned Content-Type.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -2239,11 +2122,8 @@ spec:
           content-type: &quot;appliation/json&quot;
   ...
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -2265,7 +2145,6 @@ spec:
           content-type: &quot;text/plain&quot;
   ...
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -2349,10 +2228,8 @@ before forwarding the request to the destination. Rewrite primitive can
 be used only with HTTPRouteDestination. The following example
 demonstrates how to rewrite the URL prefix for api call (/ratings) to
 ratings service before making the actual API call.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -2371,11 +2248,8 @@ spec:
         host: ratings.prod.svc.cluster.local
         subset: v1
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -2394,7 +2268,6 @@ spec:
         host: ratings.prod.svc.cluster.local
         subset: v1
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -2476,7 +2349,7 @@ No
 <td><code>regex</code></td>
 <td><code>string (oneof)</code></td>
 <td>
-<p>RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).</p>
+<p>RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
 
 </td>
 <td>
@@ -2493,10 +2366,8 @@ example, the following rule sets the maximum number of retries to 3 when
 calling ratings:v1 service, with a 2s timeout per retry attempt.
 A retry will be attempted if there is a connect-failure, refused_stream
 or when the upstream server responds with Service Unavailable(503).</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -2514,11 +2385,8 @@ spec:
       perTryTimeout: 2s
       retryOn: connect-failure,refused-stream,503
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -2536,7 +2404,6 @@ spec:
       perTryTimeout: 2s
       retryOn: gateway-error,connect-failure,refused-stream
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -2618,10 +2485,8 @@ the following rule restricts cross origin requests to those originating
 from example.com domain using HTTP POST/GET, and sets the
 <code>Access-Control-Allow-Credentials</code> header to false. In addition, it only
 exposes <code>X-Foo-bar</code> header and sets an expiry period of 1 day.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -2645,11 +2510,8 @@ spec:
       - X-Foo-Bar
       maxAge: &quot;24h&quot;
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -2673,7 +2535,6 @@ spec:
       - X-Foo-Bar
       maxAge: &quot;24h&quot;
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -2771,7 +2632,6 @@ while forwarding HTTP requests to the destination specified in a route.
 Fault specification is part of a VirtualService rule. Faults include
 aborting the Http request from downstream service, and/or delaying
 proxying of requests. A fault rule MUST HAVE delay or abort or both.</p>
-
 <p><em>Note:</em> Delay and abort faults are independent of one another, even if
 both are specified simultaneously.</p>
 
@@ -2924,10 +2784,8 @@ No
 forwarding path. The following example will introduce a 5 second delay
 in 1 out of every 1000 requests to the &ldquo;v1&rdquo; version of the &ldquo;reviews&rdquo;
 service from all pods with label env: prod</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -2949,11 +2807,8 @@ spec:
           value: 0.1
         fixedDelay: 5s
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -2975,10 +2830,8 @@ spec:
           value: 0.1
         fixedDelay: 5s
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The <em>fixedDelay</em> field is used to indicate the amount of delay in seconds.
 The optional <em>percentage</em> field can be used to only delay a certain
 percentage of requests. If left unspecified, all request will be delayed.</p>
@@ -3037,10 +2890,8 @@ No
 <p>Abort specification is used to prematurely abort a request with a
 pre-specified error code. The following example will return an HTTP 400
 error code for 1 out of every 1000 requests to the &ldquo;ratings&rdquo; service &ldquo;v1&rdquo;.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -3059,11 +2910,8 @@ spec:
           value: 0.1
         httpStatus: 400
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -3082,10 +2930,8 @@ spec:
           value: 0.1
         httpStatus: 400
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The <em>httpStatus</em> field is used to indicate the HTTP status code to
 return to the caller. The optional <em>percentage</em> field can be used to only
 abort a certain percentage of requests. If not specified, all requests are
@@ -3117,7 +2963,7 @@ Yes
 <td><code>string (oneof)</code></td>
 <td>
 <p>GRPC status code to use to abort the request. The supported
-codes are documented in https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+codes are documented in <a href="https://github.com/grpc/grpc/blob/master/doc/statuscodes.md">https://github.com/grpc/grpc/blob/master/doc/statuscodes.md</a>
 Note: If you want to return the status &ldquo;Unavailable&rdquo;, then you should
 specify the code as <code>UNAVAILABLE</code>(all caps), but not <code>14</code>.</p>
 
@@ -3143,7 +2989,6 @@ No
 <h2 id="google-protobuf-UInt32Value">google.protobuf.UInt32Value</h2>
 <section>
 <p>Wrapper message for <code>uint32</code>.</p>
-
 <p>The JSON representation for <code>UInt32Value</code> is JSON number.</p>
 
 <table class="message-fields">

--- a/networking/v1alpha3/workload_entry.pb.html
+++ b/networking/v1alpha3/workload_entry.pb.html
@@ -17,12 +17,10 @@ for a <code>MESH_INTERNAL</code> service (hostnames, port properties, etc.). A
 <code>ServiceEntry</code> object can select multiple workload entries as well
 as Kubernetes pods based on the label selector specified in the
 service entry.</p>
-
 <p>When a workload connects to <code>istiod</code>, the status field in the
 custom resource will be updated to indicate the health of the
 workload along with other details, similar to how Kubernetes
 updates the status of a pod.</p>
-
 <p>The following example declares a workload entry representing a VM
 for the <code>details.bookinfo.com</code> service. This VM has sidecar
 installed and bootstrapped using the <code>details-legacy</code> service
@@ -30,10 +28,8 @@ account. The service is exposed on port 80 to applications in the
 mesh. The HTTP traffic to this service is wrapped in Istio mutual
 TLS and sent to sidecars on VMs on target port 8080, that in turn
 forward it to the application on localhost on the same port.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
@@ -49,11 +45,8 @@ spec:
     app: details-legacy
     instance-id: vm1
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: WorkloadEntry
 metadata:
@@ -69,15 +62,11 @@ spec:
     app: details-legacy
     instance-id: vm1
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>and the associated service entry</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -96,11 +85,8 @@ spec:
     labels:
       app: details-legacy
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -119,19 +105,15 @@ spec:
     labels:
       app: details-legacy
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>The following example declares the same VM workload using
 its fully qualified DNS name. The service entry&rsquo;s resolution
 mode should be changed to DNS to indicate that the client-side
 sidecars should dynamically resolve the DNS name at runtime before
 forwarding the request.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
@@ -147,11 +129,8 @@ spec:
     app: details-legacy
     instance-id: vm1
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: WorkloadEntry
 metadata:
@@ -167,15 +146,11 @@ spec:
     app: details-legacy
     instance-id: vm1
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
-
 <p>and the associated service entry</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -194,11 +169,8 @@ spec:
     labels:
       app: details-legacy
 </code></pre>
-
 <p>{{</tab>}}</p>
-
 <p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
@@ -217,7 +189,6 @@ spec:
     labels:
       app: details-legacy
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 
@@ -263,9 +234,7 @@ to one of the endpoints on the specified <code>targetPort</code>. If both
 the targetPort and endpoint&rsquo;s port map are not specified, traffic
 to a service port will be forwarded to one of the endpoints on
 the same port.</p>
-
 <p><strong>NOTE 1:</strong> Do not use for <code>unix://</code> addresses.</p>
-
 <p><strong>NOTE 2:</strong> endpoint port map takes precedence over targetPort.</p>
 
 </td>

--- a/networking/v1alpha3/workload_group.pb.html
+++ b/networking/v1alpha3/workload_group.pb.html
@@ -14,17 +14,14 @@ their proxies, including the metadata and identity. It is only intended to
 be used with non-k8s workloads like Virtual Machines, and is meant to mimic
 the existing sidecar injection and deployment specification model used for
 Kubernetes workloads to bootstrap Istio proxies.</p>
-
 <p>The following example declares a workload group representing a collection
 of workloads that will be registered under <code>reviews</code> in namespace
 <code>bookinfo</code>. The set of labels will be associated with each workload
 instance during the bootstrap process, and the ports 3550 and 8080
 will be associated with the workload group and use service account <code>default</code>.
 <code>app.kubernetes.io/version</code> is just an arbitrary example of a label.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadGroup
 metadata:
@@ -55,7 +52,6 @@ spec:
      - name: Lit-Header
        value: Im-The-Best
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 

--- a/networking/v1beta1/proxy_config.pb.html
+++ b/networking/v1beta1/proxy_config.pb.html
@@ -11,18 +11,13 @@ number_of_entries: 2
 <p><code>ProxyConfig</code> exposes proxy level configuration options. <code>ProxyConfig</code> can be configured on a per-workload basis,
 a per-namespace basis, or mesh-wide. <code>ProxyConfig</code> is not a required resource; there are default values in place, which are documented
 inline with each field.</p>
-
 <p><strong>NOTE</strong>: fields in ProxyConfig are not dynamically configured - changes will require restart of workloads to take effect.</p>
-
 <p>For any namespace, including the root configuration namespace, it is only valid
 to have a single workload selector-less <code>ProxyConfig</code> resource.</p>
-
 <p>For resources with a workload selector, it is only valid to have one resource selecting
 any given workload.</p>
-
 <p>For mesh level configuration, put the resource in the root configuration namespace for
 your Istio installation <em>without</em> a workload selector:</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ProxyConfig
 metadata:
@@ -33,9 +28,7 @@ spec:
   image:
     imageType: distroless
 </code></pre>
-
 <p>For namespace level configuration, put the resource in the desired namespace without a workload selector:</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ProxyConfig
 metadata:
@@ -44,9 +37,7 @@ metadata:
 spec:
   concurrency: 0
 </code></pre>
-
 <p>For workload level configuration, set the <code>selector</code> field on the <code>ProxyConfig</code> resource:</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
 kind: ProxyConfig
 metadata:
@@ -60,7 +51,6 @@ spec:
   image:
     imageType: debug
 </code></pre>
-
 <p>If a <code>ProxyConfig</code> CR is defined that matches a workload it will merge with its <code>proxy.istio.io/config</code> annotation if present,
 with the CR taking precedence over the annotation for overlapping fields. Similarly, if a mesh wide <code>ProxyConfig</code> CR is defined and
 <code>meshConfig.DefaultConfig</code> is set, the two resources will be merged with the CR taking precedence for overlapping fields.</p>

--- a/networking/v1beta1/workload_group.pb.html
+++ b/networking/v1beta1/workload_group.pb.html
@@ -14,17 +14,14 @@ their proxies, including the metadata and identity. It is only intended to
 be used with non-k8s workloads like Virtual Machines, and is meant to mimic
 the existing sidecar injection and deployment specification model used for
 Kubernetes workloads to bootstrap Istio proxies.</p>
-
 <p>The following example declares a workload group representing a collection
 of workloads that will be registered under <code>reviews</code> in namespace
 <code>bookinfo</code>. The set of labels will be associated with each workload
 instance during the bootstrap process, and the ports 3550 and 8080
 will be associated with the workload group and use service account <code>default</code>.
 <code>app.kubernetes.io/version</code> is just an arbitrary example of a label.</p>
-
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
-
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadGroup
 metadata:
@@ -55,7 +52,6 @@ spec:
      - name: Lit-Header
        value: Im-The-Best
 </code></pre>
-
 <p>{{</tab>}}
 {{</tabset>}}</p>
 

--- a/operator/v1alpha1/istio.operator.v1alpha1.pb.html
+++ b/operator/v1alpha1/istio.operator.v1alpha1.pb.html
@@ -19,7 +19,6 @@ All other usages use jsonpb which does not use the <code>json</code> tag.</p>
 The spec is a used to define a customization of the default profile values that are supplied with each Istio release.
 Because the spec is a customization API, specifying an empty IstioOperatorSpec results in a default Istio
 component values.</p>
-
 <pre><code class="language-yaml">apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
@@ -51,12 +50,10 @@ spec:
 <td><code>string</code></td>
 <td>
 <p>Path or name for the profile e.g.</p>
-
 <ul>
 <li>minimal (looks in profiles dir for a file called minimal.yaml)</li>
 <li>/tmp/istio/install/values/custom/custom-install.yaml (local file path)</li>
 </ul>
-
 <p>default profile is used if this field is unset.</p>
 
 </td>
@@ -69,7 +66,6 @@ No
 <td><code>string</code></td>
 <td>
 <p>Path for the install package. e.g.</p>
-
 <ul>
 <li>/tmp/istio-installer/nightly (local file path)</li>
 </ul>
@@ -222,7 +218,6 @@ No
 <td><code><a href="#InstallStatus-Status">Status</a></code></td>
 <td>
 <p>Overall status of all components controlled by the operator.</p>
-
 <ul>
 <li>If all components have status <code>NONE</code>, overall status is <code>NONE</code>.</li>
 <li>If all components are <code>HEALTHY</code>, overall status is <code>HEALTHY</code>.</li>
@@ -3768,7 +3763,6 @@ No
 null, a number, a string, a boolean, a recursive struct value, or a
 list of values. A producer of value is expected to set one of that
 variants, absence of any variant indicates an error.</p>
-
 <p>The JSON representation for <code>Value</code> is JSON value.</p>
 
 <table class="message-fields">
@@ -3870,7 +3864,7 @@ No
 <td>
 <p>name of the volume.
 Must be a DNS_LABEL and unique within the pod.
-More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</p>
+More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names">https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</a></p>
 
 </td>
 <td>
@@ -3948,7 +3942,7 @@ No
 <td><code>string</code></td>
 <td>
 <p>Path within the volume from which the container&rsquo;s volume should be mounted.
-Defaults to &ldquo;&rdquo; (volume&rsquo;s root).
+Defaults to &quot;&quot; (volume&rsquo;s root).
 +optional</p>
 
 </td>
@@ -3977,7 +3971,7 @@ No
 <td>
 <p>Expanded path within the volume from which the container&rsquo;s volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container&rsquo;s environment.
-Defaults to &ldquo;&rdquo; (volume&rsquo;s root).
+Defaults to &quot;&quot; (volume&rsquo;s root).
 SubPathExpr and SubPath are mutually exclusive.
 +optional</p>
 

--- a/security/v1alpha1/ca.pb.html
+++ b/security/v1alpha1/ca.pb.html
@@ -17,12 +17,14 @@ number_of_entries: 3
 <h2 id="Types">Types</h2>
 <h3 id="IstioCertificateRequest">IstioCertificateRequest</h3>
 <section>
-<p>Certificate request message. The authentication should be based on:
-1. Bearer tokens carried in the side channel;
-2. Client-side certificate via Mutual TLS handshake.
+<p>Certificate request message. The authentication should be based on:</p>
+<ol>
+<li>Bearer tokens carried in the side channel;</li>
+<li>Client-side certificate via Mutual TLS handshake.
 Note: the service implementation is REQUIRED to verify the authenticated caller is authorize to
 all SANs in the CSR. The server side may overwrite any requested certificate field based on its
-policies.</p>
+policies.</li>
+</ol>
 
 <table class="message-fields">
 <thead>

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -10,11 +10,9 @@ aliases: [/docs/reference/config/authorization/authorization-policy]
 number_of_entries: 9
 ---
 <p>Istio Authorization Policy enables access control on workloads in the mesh.</p>
-
 <p>Authorization policy supports CUSTOM, DENY and ALLOW actions for access control. When CUSTOM, DENY and ALLOW actions
 are used for a workload at the same time, the CUSTOM action is evaluated first, then the DENY action, and finally the ALLOW action.
 The evaluation is determined by the following rules:</p>
-
 <ol>
 <li>If there are any CUSTOM policies that match the request, evaluate and deny the request if the evaluation result is deny.</li>
 <li>If there are any DENY policies that match the request, deny the request.</li>
@@ -22,39 +20,28 @@ The evaluation is determined by the following rules:</p>
 <li>If any of the ALLOW policies match the request, allow the request.</li>
 <li>Deny the request.</li>
 </ol>
-
 <p>Istio Authorization Policy also supports the AUDIT action to decide whether to log requests.
 AUDIT policies do not affect whether requests are allowed or denied to the workload.
 Requests will be allowed or denied based solely on CUSTOM, DENY and ALLOW actions.</p>
-
 <p>A request will be internally marked that it should be audited if there is an AUDIT policy on the workload that matches the request.
 A separate plugin must be configured and enabled to actually fulfill the audit decision and complete the audit behavior.
 The request will not be audited if there are no such supporting plugins enabled.
 Currently, the only supported plugin is the <a href="https://istio.io/latest/docs/reference/config/proxy_extensions/stackdriver/">Stackdriver</a> plugin.</p>
-
 <p>Here is an example of Istio Authorization Policy:</p>
-
 <p>It sets the <code>action</code> to &ldquo;ALLOW&rdquo; to create an allow policy. The default action is &ldquo;ALLOW&rdquo;
 but it is useful to be explicit in the policy.</p>
-
 <p>It allows requests from:</p>
-
 <ul>
 <li>service account &ldquo;cluster.local/ns/default/sa/sleep&rdquo; or</li>
 <li>namespace &ldquo;test&rdquo;</li>
 </ul>
-
 <p>to access the workload with:</p>
-
 <ul>
 <li>&ldquo;GET&rdquo; method at paths of prefix &ldquo;/info&rdquo; or,</li>
 <li>&ldquo;POST&rdquo; method at path &ldquo;/data&rdquo;.</li>
 </ul>
-
-<p>when the request has a valid JWT token issued by &ldquo;https://accounts.google.com&rdquo;.</p>
-
+<p>when the request has a valid JWT token issued by &ldquo;<a href="https://accounts.google.com">https://accounts.google.com</a>&rdquo;.</p>
 <p>Any other requests will be denied.</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -79,11 +66,9 @@ spec:
     - key: request.auth.claims[iss]
       values: [&quot;https://accounts.google.com&quot;]
 </code></pre>
-
 <p>The following is another example that sets <code>action</code> to &ldquo;DENY&rdquo; to create a deny policy.
 It denies requests from the &ldquo;dev&rdquo; namespace to the &ldquo;POST&rdquo; method on all workloads
 in the &ldquo;foo&rdquo; namespace.</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -99,10 +84,8 @@ spec:
     - operation:
         methods: [&quot;POST&quot;]
 </code></pre>
-
 <p>The following authorization policy sets the <code>action</code> to &ldquo;AUDIT&rdquo;. It will audit any GET requests to the path with the
 prefix &ldquo;/user/profile&rdquo;.</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -119,21 +102,16 @@ spec:
         methods: [&quot;GET&quot;]
         paths: [&quot;/user/profile/*&quot;]
 </code></pre>
-
 <p>Authorization Policy scope (target) is determined by &ldquo;metadata/namespace&rdquo; and
 an optional &ldquo;selector&rdquo;.</p>
-
 <ul>
 <li>&ldquo;metadata/namespace&rdquo; tells which namespace the policy applies. If set to root
 namespace, the policy applies to all namespaces in a mesh.</li>
 <li>workload &ldquo;selector&rdquo; can be used to further restrict where a policy applies.</li>
 </ul>
-
 <p>For example,</p>
-
 <p>The following authorization policy applies to all workloads in namespace foo. It allows nothing and effectively denies
 all requests to workloads in namespace foo.</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -142,9 +120,7 @@ metadata:
 spec:
   {}
 </code></pre>
-
 <p>The following authorization policy allows all requests to workloads in namespace foo.</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -154,10 +130,8 @@ spec:
  rules:
  - {}
 </code></pre>
-
 <p>The following authorization policy applies to workloads containing label &ldquo;app: httpbin&rdquo; in namespace bar. It allows
 nothing and effectively denies all requests to the selected workloads.</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -168,10 +142,8 @@ spec:
     matchLabels:
       app: httpbin
 </code></pre>
-
 <p>The following authorization policy applies to workloads containing label &ldquo;version: v1&rdquo; in all namespaces in the mesh.
 (Assuming the root namespace is configured to &ldquo;istio-system&rdquo;).</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -204,7 +176,6 @@ spec:
 <p>Optional. The selector decides where to apply the authorization policy. The selector will match with workloads
 in the same namespace as the authorization policy. If the authorization policy is in the root namespace, the selector
 will additionally match with workloads in all namespaces.</p>
-
 <p>If not set, the selector will match all workloads.</p>
 
 </td>
@@ -217,7 +188,6 @@ No
 <td><code><a href="#Rule">Rule[]</a></code></td>
 <td>
 <p>Optional. A list of rules to match the request. A match occurs when at least one rule matches the request.</p>
-
 <p>If not set, the match will never occur. This is equivalent to setting a default of deny for the target workloads if
 the action is ALLOW.</p>
 
@@ -256,9 +226,7 @@ No
 <p>Rule matches requests from a list of sources that perform a list of operations subject to a
 list of conditions. A match occurs when at least one source, one operation and all conditions
 matches the request. An empty rule is always matched.</p>
-
 <p>Any string field in the rule supports Exact, Prefix, Suffix and Presence match:</p>
-
 <ul>
 <li>Exact match: &ldquo;abc&rdquo; will match on value &ldquo;abc&rdquo;.</li>
 <li>Prefix match: &ldquo;abc*&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;abcd&rdquo;.</li>
@@ -281,7 +249,6 @@ matches the request. An empty rule is always matched.</p>
 <td><code><a href="#Rule-From">From[]</a></code></td>
 <td>
 <p>Optional. from specifies the source of a request.</p>
-
 <p>If not set, any source is allowed.</p>
 
 </td>
@@ -294,7 +261,6 @@ No
 <td><code><a href="#Rule-To">To[]</a></code></td>
 <td>
 <p>Optional. to specifies the operation of a request.</p>
-
 <p>If not set, any operation is allowed.</p>
 
 </td>
@@ -307,7 +273,6 @@ No
 <td><code><a href="#Condition">Condition[]</a></code></td>
 <td>
 <p>Optional. when specifies a list of additional conditions of a request.</p>
-
 <p>If not set, any condition is allowed.</p>
 
 </td>
@@ -322,10 +287,8 @@ No
 <section>
 <p>Source specifies the source identities of a request. Fields in the source are
 ANDed together.</p>
-
 <p>For example, the following source matches if the principal is &ldquo;admin&rdquo; or &ldquo;dev&rdquo;
 and the namespace is &ldquo;prod&rdquo; or &ldquo;test&rdquo; and the ip is not &ldquo;1.2.3.4&rdquo;.</p>
-
 <pre><code class="language-yaml">principals: [&quot;admin&quot;, &quot;dev&quot;]
 namespaces: [&quot;prod&quot;, &quot;test&quot;]
 notIpBlocks: [&quot;1.2.3.4&quot;]
@@ -348,7 +311,6 @@ notIpBlocks: [&quot;1.2.3.4&quot;]
 <p>Optional. A list of peer identities derived from the peer certificate. The peer identity is in the format of
 <code>&quot;&lt;TRUST_DOMAIN&gt;/ns/&lt;NAMESPACE&gt;/sa/&lt;SERVICE_ACCOUNT&gt;&quot;</code>, for example, <code>&quot;cluster.local/ns/default/sa/productpage&quot;</code>.
 This field requires mTLS enabled and is the same as the <code>source.principal</code> attribute.</p>
-
 <p>If not set, any principal is allowed.</p>
 
 </td>
@@ -374,7 +336,6 @@ No
 <p>Optional. A list of request identities derived from the JWT. The request identity is in the format of
 <code>&quot;&lt;ISS&gt;/&lt;SUB&gt;&quot;</code>, for example, <code>&quot;example.com/sub-1&quot;</code>. This field requires request authentication enabled and is the
 same as the <code>request.auth.principal</code> attribute.</p>
-
 <p>If not set, any request principal is allowed.</p>
 
 </td>
@@ -399,7 +360,6 @@ No
 <td>
 <p>Optional. A list of namespaces derived from the peer certificate.
 This field requires mTLS enabled and is the same as the <code>source.namespace</code> attribute.</p>
-
 <p>If not set, any namespace is allowed.</p>
 
 </td>
@@ -424,7 +384,6 @@ No
 <td>
 <p>Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. &ldquo;1.2.3.4&rdquo;) and
 CIDR (e.g. &ldquo;1.2.3.0/24&rdquo;) are supported. This is the same as the <code>source.ip</code> attribute.</p>
-
 <p>If not set, any IP is allowed.</p>
 
 </td>
@@ -453,7 +412,6 @@ when you install Istio or using an annotation on the ingress gateway.  See the d
 <a href="https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/">Configuring Gateway Network Topology</a>.
 Single IP (e.g. &ldquo;1.2.3.4&rdquo;) and CIDR (e.g. &ldquo;1.2.3.0/24&rdquo;) are supported.
 This is the same as the <code>remote.ip</code> attribute.</p>
-
 <p>If not set, any IP is allowed.</p>
 
 </td>
@@ -479,10 +437,8 @@ No
 <section>
 <p>Operation specifies the operations of a request. Fields in the operation are
 ANDed together.</p>
-
 <p>For example, the following operation matches if the host has suffix &ldquo;.example.com&rdquo;
 and the method is &ldquo;GET&rdquo; or &ldquo;HEAD&rdquo; and the path doesn&rsquo;t have prefix &ldquo;/admin&rdquo;.</p>
-
 <pre><code class="language-yaml">hosts: [&quot;*.example.com&quot;]
 methods: [&quot;GET&quot;, &quot;HEAD&quot;]
 notPaths: [&quot;/admin*&quot;]
@@ -505,7 +461,6 @@ notPaths: [&quot;/admin*&quot;]
 <p>Optional. A list of hosts as specified in the HTTP request. The match is case-insensitive.
 See the <a href="https://istio.io/latest/docs/ops/best-practices/security/#writing-host-match-policies">security best practices</a> for
 recommended usage of this field.</p>
-
 <p>If not set, any host is allowed. Must be used only with HTTP.</p>
 
 </td>
@@ -529,7 +484,6 @@ No
 <td><code>string[]</code></td>
 <td>
 <p>Optional. A list of ports as specified in the connection.</p>
-
 <p>If not set, any port is allowed.</p>
 
 </td>
@@ -554,7 +508,6 @@ No
 <td>
 <p>Optional. A list of methods as specified in the HTTP request.
 For gRPC service, this will always be &ldquo;POST&rdquo;.</p>
-
 <p>If not set, any method is allowed. Must be used only with HTTP.</p>
 
 </td>
@@ -580,7 +533,6 @@ No
 <p>Optional. A list of paths as specified in the HTTP request. See the <a href="https://istio.io/latest/docs/reference/config/security/normalization/">Authorization Policy Normalization</a>
 for details of the path normalization.
 For gRPC service, this will be the fully-qualified name in the form of &ldquo;/package.service/method&rdquo;.</p>
-
 <p>If not set, any path is allowed. Must be used only with HTTP.</p>
 
 </td>
@@ -782,12 +734,9 @@ Extension behavior is defined by the named providers declared in MeshConfig. The
 the extension by specifying the name of the provider.
 One example use case of the extension is to integrate with a custom external authorization system to delegate
 the authorization decision to it.</p>
-
 <p>Note: The CUSTOM action is currently an <strong>alpha feature</strong> and is subject to breaking changes in later versions.</p>
-
 <p>The following authorization policy applies to an ingress gateway and delegates the authorization check to a named extension
 &ldquo;my-custom-authz&rdquo; if the request path has prefix &ldquo;/admin/&rdquo;.</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:

--- a/security/v1beta1/jwt.pb.html
+++ b/security/v1beta1/jwt.pb.html
@@ -14,23 +14,18 @@ number_of_entries: 2
 <a href="https://tools.ietf.org/html/rfc7519">RFC 7519</a>. See <a href="https://tools.ietf.org/html/rfc6749">OAuth 2.0</a> and
 <a href="http://openid.net/connect">OIDC 1.0</a> for how this is used in the whole
 authentication flow.</p>
-
 <p>Examples:</p>
-
 <p>Spec for a JWT that is issued by <code>https://example.com</code>, with the audience claims must be either
 <code>bookstore_android.apps.example.com</code> or <code>bookstore_web.apps.example.com</code>.
 The token should be presented at the <code>Authorization</code> header (default). The JSON Web Key Set (JWKS)
 will be discovered following OpenID Connect protocol.</p>
-
 <pre><code class="language-yaml">issuer: https://example.com
 audiences:
 - bookstore_android.apps.example.com
   bookstore_web.apps.example.com
 </code></pre>
-
 <p>This example specifies a token in a non-default location (<code>x-goog-iap-jwt-assertion</code> header). It also
 defines the URI to fetch JWKS explicitly.</p>
-
 <pre><code class="language-yaml">issuer: https://example.com
 jwksUri: https://example.com/.secret/jwks.json
 fromHeaders:
@@ -54,9 +49,8 @@ fromHeaders:
 <p>Identifies the issuer that issued the JWT. See
 <a href="https://tools.ietf.org/html/rfc7519#section-4.1.1">issuer</a>
 A JWT with different <code>iss</code> claim will be rejected.</p>
-
-<p>Example: https://foobar.auth0.com
-Example: 1234567-compute@developer.gserviceaccount.com</p>
+<p>Example: <a href="https://foobar.auth0.com">https://foobar.auth0.com</a>
+Example: <a href="mailto:1234567-compute@developer.gserviceaccount.com">1234567-compute@developer.gserviceaccount.com</a></p>
 
 </td>
 <td>
@@ -71,11 +65,8 @@ Yes
 <a href="https://tools.ietf.org/html/rfc7519#section-4.1.3">audiences</a>.
 that are allowed to access. A JWT containing any of these
 audiences will be accepted.</p>
-
 <p>The service name will be accepted if audiences is empty.</p>
-
 <p>Example:</p>
-
 <pre><code class="language-yaml">audiences:
 - bookstore_android.apps.example.com
   bookstore_web.apps.example.com
@@ -92,15 +83,12 @@ No
 <td>
 <p>URL of the provider&rsquo;s public key set to validate signature of the
 JWT. See <a href="https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata">OpenID Discovery</a>.</p>
-
 <p>Optional if the key set document can either (a) be retrieved from
 <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID
 Discovery</a> of
 the issuer or (b) inferred from the email domain of the issuer (e.g. a
 Google service account).</p>
-
 <p>Example: <code>https://www.googleapis.com/oauth2/v1/certs</code></p>
-
 <p>Note: Only one of <code>jwksUri</code> and <code>jwks</code> should be used.</p>
 
 </td>
@@ -113,8 +101,7 @@ No
 <td><code>string</code></td>
 <td>
 <p>JSON Web Key Set of public keys to validate signature of the JWT.
-See https://auth0.com/docs/jwks.</p>
-
+See <a href="https://auth0.com/docs/jwks">https://auth0.com/docs/jwks</a>.</p>
 <p>Note: Only one of <code>jwksUri</code> and <code>jwks</code> should be used.</p>
 
 </td>
@@ -127,13 +114,11 @@ No
 <td><code><a href="#JWTHeader">JWTHeader[]</a></code></td>
 <td>
 <p>List of header locations from which JWT is expected. For example, below is the location spec
-if JWT is expected to be found in <code>x-jwt-assertion</code> header, and have &ldquo;Bearer &rdquo; prefix:</p>
-
+if JWT is expected to be found in <code>x-jwt-assertion</code> header, and have &ldquo;Bearer &quot; prefix:</p>
 <pre><code class="language-yaml">  fromHeaders:
   - name: x-jwt-assertion
     prefix: &quot;Bearer &quot;
 </code></pre>
-
 <p>Note: Requests with multiple tokens (at different locations) are not supported, the output principal of
 such requests is undefined.</p>
 
@@ -148,11 +133,9 @@ No
 <td>
 <p>List of query parameters from which JWT is expected. For example, if JWT is provided via query
 parameter <code>my_token</code> (e.g /path?my_token=<JWT>), the config is:</p>
-
 <pre><code class="language-yaml">  fromParams:
   - &quot;my_token&quot;
 </code></pre>
-
 <p>Note: Requests with multiple tokens (at different locations) are not supported, the output principal of
 such requests is undefined.</p>
 
@@ -218,7 +201,7 @@ Yes
 <td><code>string</code></td>
 <td>
 <p>The prefix that should be stripped before decoding the token.
-For example, for &ldquo;Authorization: Bearer <token>&rdquo;, prefix=&ldquo;Bearer &rdquo; with a space at the end.
+For example, for &ldquo;Authorization: Bearer <token>&rdquo;, prefix=&ldquo;Bearer &quot; with a space at the end.
 If the header doesn&rsquo;t have this exact prefix, it is considered invalid.</p>
 
 </td>

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -11,11 +11,8 @@ number_of_entries: 3
 <h2 id="PeerAuthentication">PeerAuthentication</h2>
 <section>
 <p>PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.</p>
-
 <p>Examples:</p>
-
 <p>Policy to allow mTLS traffic for all workloads under namespace <code>foo</code>:</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -25,12 +22,9 @@ spec:
   mtls:
     mode: STRICT
 </code></pre>
-
 <p>For mesh level, put the policy in root-namespace according to your Istio installation.</p>
-
 <p>Policies to allow both mTLS &amp; plaintext traffic for all workloads under namespace <code>foo</code>, but
 require mTLS for workload <code>finance</code>.</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -52,10 +46,8 @@ spec:
   mtls:
     mode: STRICT
 </code></pre>
-
 <p>Policy to allow mTLS strict for all workloads, but leave port 8080 to
 plaintext:</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -71,10 +63,8 @@ spec:
     8080:
       mode: DISABLE
 </code></pre>
-
 <p>Policy to inherit mTLS mode from namespace (or mesh) settings, and overwrite
 settings for port 8080</p>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -16,11 +16,9 @@ configured authentication rules. A request that does not contain any authenticat
 will be accepted but will not have any authenticated identity. To restrict access to authenticated
 requests only, this should be accompanied by an authorization rule.
 Examples:</p>
-
 <ul>
 <li>Require JWT for all request for workloads that have label <code>app:httpbin</code></li>
 </ul>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
@@ -48,13 +46,11 @@ spec:
     - source:
         requestPrincipals: [&quot;*&quot;]
 </code></pre>
-
 <ul>
 <li>A policy in the root namespace (&ldquo;istio-system&rdquo; by default) applies to workloads in all namespaces
 in a mesh. The following policy makes all workloads only accept requests that contain a
 valid JWT token.</li>
 </ul>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
@@ -76,13 +72,11 @@ spec:
     - source:
         requestPrincipals: [&quot;*&quot;]
 </code></pre>
-
 <ul>
 <li>The next example shows how to set a different JWT requirement for a different <code>host</code>. The <code>RequestAuthentication</code>
 declares it can accept JWTs issued by either <code>issuer-foo</code> or <code>issuer-bar</code> (the public key set is implicitly
 set from the OpenID Connect spec).</li>
 </ul>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
@@ -119,13 +113,11 @@ spec:
     - operation:
         hosts: [&quot;another-host.com&quot;]
 </code></pre>
-
 <ul>
 <li>You can fine tune the authorization policy to set different requirement per path. For example,
 to require JWT on all paths, except /healthz, the same <code>RequestAuthentication</code> can be used, but the
 authorization policy could be:</li>
 </ul>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -143,24 +135,19 @@ spec:
     - operation:
         paths: [&quot;/healthz&quot;]
 </code></pre>
-
 <p>[Experimental] Routing based on derived <a href="https://istio.io/latest/docs/reference/config/security/conditions/">metadata</a>
 is now supported. A prefix &lsquo;@&rsquo; is used to denote a match against internal metadata instead of the headers in the request.
 Currently this feature is only supported for the following metadata:</p>
-
 <ul>
 <li><code>request.auth.claims.{claim-name}[.{sub-claim}]*</code> which are extracted from validated JWT tokens. The claim name
 currently does not support the <code>.</code> character. Examples: <code>request.auth.claims.sub</code> and <code>request.auth.claims.name.givenName</code>.</li>
 </ul>
-
 <p>The use of matches against JWT claim metadata is only supported in Gateways. The following example shows:</p>
-
 <ul>
 <li>RequestAuthentication to decode and validate a JWT. This also makes the <code>@request.auth.claims</code> available for use in the VirtualService.</li>
 <li>AuthorizationPolicy to check for valid principals in the request. This makes the JWT required for the request.</li>
 <li>VirtualService to route the request based on the &ldquo;sub&rdquo; claim.</li>
 </ul>
-
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
@@ -231,7 +218,6 @@ spec:
 <p>Optional. The selector decides where to apply the request authentication policy. The selector will match with workloads
 in the same namespace as the request authentication policy. If the request authentication policy is in the root namespace,
 the selector will additionally match with workloads in all namespaces.</p>
-
 <p>If not set, the selector will match all workloads.</p>
 
 </td>

--- a/telemetry/v1alpha1/telemetry.pb.html
+++ b/telemetry/v1alpha1/telemetry.pb.html
@@ -9,28 +9,20 @@ aliases: [/docs/reference/config/telemetry/v1alpha1/telemetry]
 number_of_entries: 18
 ---
 <p>Telemetry defines how the telemetry is generated for workloads within a mesh.</p>
-
 <p>For mesh level configuration, put the resource in root configuration
 namespace for your Istio installation <em>without</em> a workload selector.</p>
-
 <p>For any namespace, including the root configuration namespace, it is only
 valid to have a single workload selector-less Telemetry resource.</p>
-
 <p>For resources with a workload selector, it is only valid to have one resource
 selecting any given workload.</p>
-
 <p>The hierarchy of Telemetry configuration is as follows:</p>
-
 <ol>
 <li>Workload-specific configuration</li>
 <li>Namespace-specific configuration</li>
 <li>Root namespace configuration</li>
 </ol>
-
 <p>Examples:</p>
-
 <p>Policy to enable random sampling for 10% of traffic:</p>
-
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -41,10 +33,8 @@ spec:
   tracing:
   - randomSamplingPercentage: 10.00
 </code></pre>
-
 <p>Policy to disable trace reporting for the &ldquo;foo&rdquo; workload (note: tracing
 context will still be propagated):</p>
-
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -57,9 +47,7 @@ spec:
   tracing:
   - disableSpanReporting: true
 </code></pre>
-
 <p>Policy to select the alternate zipkin provider for trace reporting:</p>
-
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -74,9 +62,7 @@ spec:
     - name: &quot;zipkin-alternate&quot;
     randomSamplingPercentage: 10.00
 </code></pre>
-
 <p>Policy to add a custom tag from a literal value:</p>
-
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -91,9 +77,7 @@ spec:
         literal:
           value: &quot;foo&quot;
 </code></pre>
-
 <p>Policy to disable server-side metrics for Stackdriver for an entire mesh:</p>
-
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -110,9 +94,7 @@ spec:
         mode: SERVER
       disabled: true
 </code></pre>
-
 <p>Policy to add dimensions to all Prometheus metrics for the <code>foo</code> namespace:</p>
-
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -131,10 +113,8 @@ spec:
         request_host:
           value: &quot;request.host&quot;
 </code></pre>
-
 <p>Policy to remove the response_code dimension on some Prometheus metrics for
 the <code>bar.foo</code> workload:</p>
-
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -169,9 +149,7 @@ spec:
         response_code:
           operation: REMOVE
 </code></pre>
-
 <p>Policy to enable access logging for the entire mesh:</p>
-
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -187,9 +165,7 @@ spec:
     # cases where a parent configuration has marked as `disabled: true`. In
     # those cases, `disabled: false` must be set explicitly to override.
 </code></pre>
-
 <p>Policy to disable access logging for the <code>foo</code> namespace:</p>
-
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -271,7 +247,6 @@ No
 <p>Tracing configures tracing behavior for workloads within a mesh.
 It can be used to enable/disable tracing, as well as to set sampling
 rates and custom tag extraction.</p>
-
 <p>Tracing configuration support overrides of the fields <code>providers</code>,
 <code>random_sampling_percentage</code>, <code>disable_span_reporting</code>, and <code>custom_tags</code> at
 each level in the configuration hierarchy, with missing values filled in
@@ -324,7 +299,6 @@ been made, that decision will be respected. However, if no sampling
 decision has been made (example: no <code>x-b3-sampled</code> tracing header was
 present in the requests), the traffic will be selected for telemetry
 generation at the percentage specified.</p>
-
 <p>Defaults to 0%. Valid values [0.00-100.00]. Can be specified in 0.01%
 increments.</p>
 
@@ -424,14 +398,14 @@ No
 <td><code><a href="#MetricsOverrides">MetricsOverrides[]</a></code></td>
 <td>
 <p>Optional. Ordered list of overrides to metrics generation behavior.</p>
-
 <p>Specified overrides will be applied in order. They will be applied on
 top of inherited overrides from other resources in the hierarchy in the
-following order:
-1. Mesh-scoped overrides
-2. Namespace-scoped overrides
-3. Workload-scoped overrides</p>
-
+following order:</p>
+<ol>
+<li>Mesh-scoped overrides</li>
+<li>Namespace-scoped overrides</li>
+<li>Workload-scoped overrides</li>
+</ol>
 <p>Because overrides are applied in order, users are advised to order their
 overrides from least specific to most specific matches. That is, it is
 a best practice to list any universal overrides first, with tailored
@@ -520,7 +494,6 @@ metric or the set of all standard metrics.</p>
 <p>Match allows provides the scope of the override. It can be used to select
 individual metrics, as well as the workload modes (server and/or client)
 in which the metrics will be generated.</p>
-
 <p>If match is not specified, the overrides will apply to <em>all</em> metrics for
 <em>both</em> modes of operation (client and server).</p>
 
@@ -552,7 +525,7 @@ selected metric(s).
 The key in the map is the name of the tag.
 The value in the map is the operation to perform on the the tag.
 WARNING: some providers may not support adding/removing tags.
-See also: https://istio.io/latest/docs/reference/config/metrics/#labels</p>
+See also: <a href="https://istio.io/latest/docs/reference/config/metrics/#labels">https://istio.io/latest/docs/reference/config/metrics/#labels</a></p>
 
 </td>
 <td>
@@ -668,7 +641,6 @@ No
 an operator-supplied value. This value can either be a hard-coded value,
 a value taken from an environment variable known to the sidecar proxy, or
 from a request header.</p>
-
 <p>NOTE: when specified, <code>custom_tags</code> will fully replace any values provided
 by parent configuration.</p>
 
@@ -922,9 +894,7 @@ No
 <td><code>string</code></td>
 <td>
 <p>CEL expression for selecting when requests/connections should be logged.</p>
-
 <p>Examples:</p>
-
 <ul>
 <li><code>response.code &gt;= 400</code></li>
 <li><code>connection.mtls &amp;&amp; request.url_path.contains('v1beta3')</code></li>
@@ -942,7 +912,7 @@ No
 <section>
 <p>Curated list of known metric types that is supported by Istio metric
 providers. See also:
-https://istio.io/latest/docs/reference/config/metrics/#metrics</p>
+<a href="https://istio.io/latest/docs/reference/config/metrics/#metrics">https://istio.io/latest/docs/reference/config/metrics/#metrics</a></p>
 
 <table class="enum-values">
 <thead>
@@ -965,11 +935,8 @@ default metrics.</p>
 <td>
 <p>Counter of requests to/from an application, generated for HTTP, HTTP/2,
 and GRPC traffic.</p>
-
 <p>The Prometheus provider exports this metric as: <code>istio_requests_total</code>.</p>
-
 <p>The Stackdriver provider exports this metric as:</p>
-
 <ul>
 <li><code>istio.io/service/server/request_count</code> (SERVER mode)</li>
 <li><code>istio.io/service/client/request_count</code> (CLIENT mode)</li>
@@ -982,12 +949,9 @@ and GRPC traffic.</p>
 <td>
 <p>Histogram of request durations, generated for HTTP, HTTP/2, and GRPC
 traffic.</p>
-
 <p>The Prometheus provider exports this metric as:
 <code>istio_request_duration_milliseconds</code>.</p>
-
 <p>The Stackdriver provider exports this metric as:</p>
-
 <ul>
 <li><code>istio.io/service/server/response_latencies</code> (SERVER mode)</li>
 <li><code>istio.io/service/client/roundtrip_latencies</code> (CLIENT mode)</li>
@@ -1000,11 +964,8 @@ traffic.</p>
 <td>
 <p>Histogram of request body sizes, generated for HTTP, HTTP/2, and GRPC
 traffic.</p>
-
 <p>The Prometheus provider exports this metric as: <code>istio_request_bytes</code>.</p>
-
 <p>The Stackdriver provider exports this metric as:</p>
-
 <ul>
 <li><code>istio.io/service/server/request_bytes</code> (SERVER mode)</li>
 <li><code>istio.io/service/client/request_bytes</code> (CLIENT mode)</li>
@@ -1017,11 +978,8 @@ traffic.</p>
 <td>
 <p>Histogram of response body sizes, generated for HTTP, HTTP/2, and GRPC
 traffic.</p>
-
 <p>The Prometheus provider exports this metric as: <code>istio_response_bytes</code>.</p>
-
 <p>The Stackdriver provider exports this metric as:</p>
-
 <ul>
 <li><code>istio.io/service/server/response_bytes</code> (SERVER mode)</li>
 <li><code>istio.io/service/client/response_bytes</code> (CLIENT mode)</li>
@@ -1033,12 +991,9 @@ traffic.</p>
 <td><code>TCP_OPENED_CONNECTIONS</code></td>
 <td>
 <p>Counter of TCP connections opened over lifetime of workload.</p>
-
 <p>The Prometheus provider exports this metric as:
 <code>istio_tcp_connections_opened_total</code>.</p>
-
 <p>The Stackdriver provider exports this metric as:</p>
-
 <ul>
 <li><code>istio.io/service/server/connection_open_count</code> (SERVER mode)</li>
 <li><code>istio.io/service/client/connection_open_count</code> (CLIENT mode)</li>
@@ -1050,12 +1005,9 @@ traffic.</p>
 <td><code>TCP_CLOSED_CONNECTIONS</code></td>
 <td>
 <p>Counter of TCP connections closed over lifetime of workload.</p>
-
 <p>The Prometheus provider exports this metric as:
 <code>istio_tcp_connections_closed_total</code>.</p>
-
 <p>The Stackdriver provider exports this metric as:</p>
-
 <ul>
 <li><code>istio.io/service/server/connection_close_count</code> (SERVER mode)</li>
 <li><code>istio.io/service/client/connection_close_count</code> (CLIENT mode)</li>
@@ -1067,12 +1019,9 @@ traffic.</p>
 <td><code>TCP_SENT_BYTES</code></td>
 <td>
 <p>Counter of bytes sent during a response over a TCP connection.</p>
-
 <p>The Prometheus provider exports this metric as:
 <code>istio_tcp_sent_bytes_total</code>.</p>
-
 <p>The Stackdriver provider exports this metric as:</p>
-
 <ul>
 <li><code>istio.io/service/server/sent_bytes_count</code> (SERVER mode)</li>
 <li><code>istio.io/service/client/sent_bytes_count</code> (CLIENT mode)</li>
@@ -1084,12 +1033,9 @@ traffic.</p>
 <td><code>TCP_RECEIVED_BYTES</code></td>
 <td>
 <p>Counter of bytes received during a request over a TCP connection.</p>
-
 <p>The Prometheus provider exports this metric as:
 <code>istio_tcp_received_bytes_total</code>.</p>
-
 <p>The Stackdriver provider exports this metric as:</p>
-
 <ul>
 <li><code>istio.io/service/server/received_bytes_count</code> (SERVER mode)</li>
 <li><code>istio.io/service/client/received_bytes_count</code> (CLIENT mode)</li>
@@ -1101,7 +1047,6 @@ traffic.</p>
 <td><code>GRPC_REQUEST_MESSAGES</code></td>
 <td>
 <p>Counter incremented for every gRPC messages sent from a client.</p>
-
 <p>The Prometheus provider exports this metric as:
 <code>istio_request_messages_total</code></p>
 
@@ -1111,7 +1056,6 @@ traffic.</p>
 <td><code>GRPC_RESPONSE_MESSAGES</code></td>
 <td>
 <p>Counter incremented for every gRPC messages sent from a server.</p>
-
 <p>The Prometheus provider exports this metric as:
 <code>istio_response_messages_total</code></p>
 


### PR DESCRIPTION
The new build-tools has a new markdown generator for the html files (same as the one used by istio.io. The PR is simply `make gen` with the new build-image to update the html files.

This PR is needed to prevent other PRs from having to check these changes in.