### PR TITLE
Remove remnants of old example in ServiceEntry docs

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -3582,7 +3582,7 @@ spec:
       jsonPath: .spec.location
       name: Location
       type: string
-    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
+    - description: Service resolution mode for the hosts (NONE, STATIC, or DNS)
       jsonPath: .spec.resolution
       name: Resolution
       type: string
@@ -3668,7 +3668,7 @@ spec:
                   type: object
                 type: array
               resolution:
-                description: Service discovery mode for the hosts.
+                description: Service resolution mode for the hosts.
                 enum:
                 - NONE
                 - STATIC
@@ -3706,7 +3706,7 @@ spec:
       jsonPath: .spec.location
       name: Location
       type: string
-    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
+    - description: Service resolution mode for the hosts (NONE, STATIC, or DNS)
       jsonPath: .spec.resolution
       name: Resolution
       type: string
@@ -3792,7 +3792,7 @@ spec:
                   type: object
                 type: array
               resolution:
-                description: Service discovery mode for the hosts.
+                description: Service resolution mode for the hosts.
                 enum:
                 - NONE
                 - STATIC

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -445,7 +445,7 @@
 // The following example demonstrates the use of wildcards in the hosts for
 // external services. If the connection has to be routed to the IP address
 // requested by the application (i.e. application resolves DNS and attempts
-// to connect to a specific IP), the discovery mode must be set to `NONE`.
+// to connect to a specific IP), the resolution mode must be set to `NONE`.
 //
 // {{<tabset category-name="example">}}
 // {{<tab name="v1alpha3" category-value="v1alpha3">}}
@@ -662,11 +662,7 @@
 // VM-based instances with sidecars as well as a set of Kubernetes
 // pods managed by a standard deployment object. Consumers of this
 // service in the mesh will be automatically load balanced across the
-// VMs and Kubernetes.  VM for the `details.bookinfo.com`
-// service. This VM has sidecar installed and bootstrapped using the
-// `details-legacy` service account. The sidecar receives HTTP traffic
-// on port 80 (wrapped in istio mutual TLS) and forwards it to the
-// application on the localhost on the same port.
+// VMs and Kubernetes.
 //
 // {{<tabset category-name="example">}}
 // {{<tab name="v1alpha3" category-value="v1alpha3">}}
@@ -947,7 +943,7 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:ServiceEntry:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The hosts associated with the ServiceEntry"
 // +cue-gen:ServiceEntry:printerColumn:name=Location,type=string,JSONPath=.spec.location,description="Whether the service is external to the
 // mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)"
-// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service discovery mode for the hosts
+// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service resolution mode for the hosts
 // (NONE, STATIC, or DNS)"
 // +cue-gen:ServiceEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -987,8 +983,8 @@ type ServiceEntry struct {
 	// supplies its own set of endpoints, the ServiceEntry will be
 	// treated as a decorator of the existing Kubernetes
 	// service. Properties in the service entry will be added to the
-	// Kubernetes service if applicable. Currently, the only the
-	// following additional properties will be considered by `istiod`:
+	// Kubernetes service if applicable. Currently, only the following
+	// additional properties will be considered by `istiod`:
 	//
 	//  1. subjectAltNames: In addition to verifying the SANs of the
 	//     service accounts associated with the pods of the service, the
@@ -1016,7 +1012,7 @@ type ServiceEntry struct {
 	// Specify whether the service should be considered external to the mesh
 	// or part of the mesh.
 	Location ServiceEntry_Location `protobuf:"varint,4,opt,name=location,proto3,enum=istio.networking.v1alpha3.ServiceEntry_Location" json:"location,omitempty"`
-	// Service discovery mode for the hosts. Care must be taken
+	// Service resolution mode for the hosts. Care must be taken
 	// when setting the resolution mode to NONE for a TCP port without
 	// accompanying IP addresses. In such cases, traffic to any IP on
 	// said port will be allowed (i.e. `0.0.0.0:<port>`).

--- a/networking/v1alpha3/service_entry.pb.html
+++ b/networking/v1alpha3/service_entry.pb.html
@@ -387,7 +387,7 @@ spec:
 <p>The following example demonstrates the use of wildcards in the hosts for
 external services. If the connection has to be routed to the IP address
 requested by the application (i.e. application resolves DNS and attempts
-to connect to a specific IP), the discovery mode must be set to <code>NONE</code>.</p>
+to connect to a specific IP), the resolution mode must be set to <code>NONE</code>.</p>
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
@@ -583,11 +583,7 @@ spec:
 VM-based instances with sidecars as well as a set of Kubernetes
 pods managed by a standard deployment object. Consumers of this
 service in the mesh will be automatically load balanced across the
-VMs and Kubernetes.  VM for the <code>details.bookinfo.com</code>
-service. This VM has sidecar installed and bootstrapped using the
-<code>details-legacy</code> service account. The sidecar receives HTTP traffic
-on port 80 (wrapped in istio mutual TLS) and forwards it to the
-application on the localhost on the same port.</p>
+VMs and Kubernetes.</p>
 <p>{{<tabset category-name="example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
@@ -718,8 +714,8 @@ from another service registry such as Kubernetes that also
 supplies its own set of endpoints, the ServiceEntry will be
 treated as a decorator of the existing Kubernetes
 service. Properties in the service entry will be added to the
-Kubernetes service if applicable. Currently, the only the
-following additional properties will be considered by <code>istiod</code>:</p>
+Kubernetes service if applicable. Currently, only the following
+additional properties will be considered by <code>istiod</code>:</p>
 <ol>
 <li>subjectAltNames: In addition to verifying the SANs of the
 service accounts associated with the pods of the service, the
@@ -784,7 +780,7 @@ No
 <td><code>resolution</code></td>
 <td><code><a href="#ServiceEntry-Resolution">Resolution</a></code></td>
 <td>
-<p>Service discovery mode for the hosts. Care must be taken
+<p>Service resolution mode for the hosts. Care must be taken
 when setting the resolution mode to NONE for a TCP port without
 accompanying IP addresses. In such cases, traffic to any IP on
 said port will be allowed (i.e. <code>0.0.0.0:&lt;port&gt;</code>).</p>

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -446,7 +446,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // The following example demonstrates the use of wildcards in the hosts for
 // external services. If the connection has to be routed to the IP address
 // requested by the application (i.e. application resolves DNS and attempts
-// to connect to a specific IP), the discovery mode must be set to `NONE`.
+// to connect to a specific IP), the resolution mode must be set to `NONE`.
 //
 // {{<tabset category-name="example">}}
 // {{<tab name="v1alpha3" category-value="v1alpha3">}}
@@ -663,11 +663,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // VM-based instances with sidecars as well as a set of Kubernetes
 // pods managed by a standard deployment object. Consumers of this
 // service in the mesh will be automatically load balanced across the
-// VMs and Kubernetes.  VM for the `details.bookinfo.com`
-// service. This VM has sidecar installed and bootstrapped using the
-// `details-legacy` service account. The sidecar receives HTTP traffic
-// on port 80 (wrapped in istio mutual TLS) and forwards it to the
-// application on the localhost on the same port.
+// VMs and Kubernetes.
 //
 // {{<tabset category-name="example">}}
 // {{<tab name="v1alpha3" category-value="v1alpha3">}}
@@ -790,7 +786,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:ServiceEntry:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The hosts associated with the ServiceEntry"
 // +cue-gen:ServiceEntry:printerColumn:name=Location,type=string,JSONPath=.spec.location,description="Whether the service is external to the
 // mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)"
-// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service discovery mode for the hosts
+// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service resolution mode for the hosts
 // (NONE, STATIC, or DNS)"
 // +cue-gen:ServiceEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -826,8 +822,8 @@ message ServiceEntry {
   // supplies its own set of endpoints, the ServiceEntry will be
   // treated as a decorator of the existing Kubernetes
   // service. Properties in the service entry will be added to the
-  // Kubernetes service if applicable. Currently, the only the
-  // following additional properties will be considered by `istiod`:
+  // Kubernetes service if applicable. Currently, only the following
+  // additional properties will be considered by `istiod`:
   //
   // 1. subjectAltNames: In addition to verifying the SANs of the
   //    service accounts associated with the pods of the service, the
@@ -922,7 +918,7 @@ message ServiceEntry {
     DNS_ROUND_ROBIN = 3;
   };
 
-  // Service discovery mode for the hosts. Care must be taken
+  // Service resolution mode for the hosts. Care must be taken
   // when setting the resolution mode to NONE for a TCP port without
   // accompanying IP addresses. In such cases, traffic to any IP on
   // said port will be allowed (i.e. `0.0.0.0:<port>`).

--- a/networking/v1beta1/service_entry.pb.go
+++ b/networking/v1beta1/service_entry.pb.go
@@ -446,7 +446,7 @@
 // The following example demonstrates the use of wildcards in the hosts for
 // external services. If the connection has to be routed to the IP address
 // requested by the application (i.e. application resolves DNS and attempts
-// to connect to a specific IP), the discovery mode must be set to `NONE`.
+// to connect to a specific IP), the resolution mode must be set to `NONE`.
 //
 // {{<tabset category-name="example">}}
 // {{<tab name="v1alpha3" category-value="v1alpha3">}}
@@ -663,11 +663,7 @@
 // VM-based instances with sidecars as well as a set of Kubernetes
 // pods managed by a standard deployment object. Consumers of this
 // service in the mesh will be automatically load balanced across the
-// VMs and Kubernetes.  VM for the `details.bookinfo.com`
-// service. This VM has sidecar installed and bootstrapped using the
-// `details-legacy` service account. The sidecar receives HTTP traffic
-// on port 80 (wrapped in istio mutual TLS) and forwards it to the
-// application on the localhost on the same port.
+// VMs and Kubernetes.
 //
 // {{<tabset category-name="example">}}
 // {{<tab name="v1alpha3" category-value="v1alpha3">}}
@@ -947,7 +943,7 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:ServiceEntry:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The hosts associated with the ServiceEntry"
 // +cue-gen:ServiceEntry:printerColumn:name=Location,type=string,JSONPath=.spec.location,description="Whether the service is external to the
 // mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)"
-// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service discovery mode for the hosts
+// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service resolution mode for the hosts
 // (NONE, STATIC, or DNS)"
 // +cue-gen:ServiceEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -987,8 +983,8 @@ type ServiceEntry struct {
 	// supplies its own set of endpoints, the ServiceEntry will be
 	// treated as a decorator of the existing Kubernetes
 	// service. Properties in the service entry will be added to the
-	// Kubernetes service if applicable. Currently, the only the
-	// following additional properties will be considered by `istiod`:
+	// Kubernetes service if applicable. Currently, only the following
+	// additional properties will be considered by `istiod`:
 	//
 	//  1. subjectAltNames: In addition to verifying the SANs of the
 	//     service accounts associated with the pods of the service, the
@@ -1016,7 +1012,7 @@ type ServiceEntry struct {
 	// Specify whether the service should be considered external to the mesh
 	// or part of the mesh.
 	Location ServiceEntry_Location `protobuf:"varint,4,opt,name=location,proto3,enum=istio.networking.v1beta1.ServiceEntry_Location" json:"location,omitempty"`
-	// Service discovery mode for the hosts. Care must be taken
+	// Service resolution mode for the hosts. Care must be taken
 	// when setting the resolution mode to NONE for a TCP port without
 	// accompanying IP addresses. In such cases, traffic to any IP on
 	// said port will be allowed (i.e. `0.0.0.0:<port>`).

--- a/networking/v1beta1/service_entry.proto
+++ b/networking/v1beta1/service_entry.proto
@@ -447,7 +447,7 @@ import "networking/v1beta1/workload_entry.proto";
 // The following example demonstrates the use of wildcards in the hosts for
 // external services. If the connection has to be routed to the IP address
 // requested by the application (i.e. application resolves DNS and attempts
-// to connect to a specific IP), the discovery mode must be set to `NONE`.
+// to connect to a specific IP), the resolution mode must be set to `NONE`.
 //
 // {{<tabset category-name="example">}}
 // {{<tab name="v1alpha3" category-value="v1alpha3">}}
@@ -664,11 +664,7 @@ import "networking/v1beta1/workload_entry.proto";
 // VM-based instances with sidecars as well as a set of Kubernetes
 // pods managed by a standard deployment object. Consumers of this
 // service in the mesh will be automatically load balanced across the
-// VMs and Kubernetes.  VM for the `details.bookinfo.com`
-// service. This VM has sidecar installed and bootstrapped using the
-// `details-legacy` service account. The sidecar receives HTTP traffic
-// on port 80 (wrapped in istio mutual TLS) and forwards it to the
-// application on the localhost on the same port.
+// VMs and Kubernetes.
 //
 // {{<tabset category-name="example">}}
 // {{<tab name="v1alpha3" category-value="v1alpha3">}}
@@ -790,7 +786,7 @@ option go_package = "istio.io/api/networking/v1beta1";
 // +cue-gen:ServiceEntry:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The hosts associated with the ServiceEntry"
 // +cue-gen:ServiceEntry:printerColumn:name=Location,type=string,JSONPath=.spec.location,description="Whether the service is external to the
 // mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)"
-// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service discovery mode for the hosts
+// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service resolution mode for the hosts
 // (NONE, STATIC, or DNS)"
 // +cue-gen:ServiceEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -826,8 +822,8 @@ message ServiceEntry {
   // supplies its own set of endpoints, the ServiceEntry will be
   // treated as a decorator of the existing Kubernetes
   // service. Properties in the service entry will be added to the
-  // Kubernetes service if applicable. Currently, the only the
-  // following additional properties will be considered by `istiod`:
+  // Kubernetes service if applicable. Currently, only the following
+  // additional properties will be considered by `istiod`:
   //
   // 1. subjectAltNames: In addition to verifying the SANs of the
   //    service accounts associated with the pods of the service, the
@@ -922,7 +918,7 @@ message ServiceEntry {
     DNS_ROUND_ROBIN = 3;
   };
 
-  // Service discovery mode for the hosts. Care must be taken
+  // Service resolution mode for the hosts. Care must be taken
   // when setting the resolution mode to NONE for a TCP port without
   // accompanying IP addresses. In such cases, traffic to any IP on
   // said port will be allowed (i.e. `0.0.0.0:<port>`).


### PR DESCRIPTION
I noticed this reference to an unrelated example that was [copied verbatim](https://github.com/istio/api/pull/1331) from `workload_entry.proto` while reading the docs at https://istio.io/v1.15/docs/reference/config/networking/service-entry/.