### PR TITLE
Add sidecar annotation for Ephemeral Storage

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -500,6 +500,30 @@ var (
 		},
 	}
 
+	SidecarProxyEphemeralStorage = Instance {
+		Name:          "sidecar.istio.io/proxyEphemeralStorage",
+		Description:   "Specifies the requested ephemeral storage setting for the "+
+                        "Envoy sidecar.",
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Pod,
+		},
+	}
+
+	SidecarProxyEphemeralStorageLimit = Instance {
+		Name:          "sidecar.istio.io/proxyEphemeralStorageLimit",
+		Description:   "Specifies the ephemeral storage limit for the Envoy "+
+                        "sidecar.",
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Pod,
+		},
+	}
+
 	SidecarProxyImage = Instance {
 		Name:          "sidecar.istio.io/proxyImage",
 		Description:   "Specifies the Docker image to be used by the Envoy "+
@@ -817,6 +841,8 @@ func AllResourceAnnotations() []*Instance {
 		&SidecarLogLevel,
 		&SidecarProxyCPU,
 		&SidecarProxyCPULimit,
+		&SidecarProxyEphemeralStorage,
+		&SidecarProxyEphemeralStorageLimit,
 		&SidecarProxyImage,
 		&SidecarProxyImageType,
 		&SidecarProxyMemory,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -378,6 +378,32 @@ Istio supports to control its behavior.
 				
 					<tr>
 				
+					<td><code>sidecar.istio.io/proxyEphemeralStorage</code></td>
+				
+					<td>Alpha</td>
+				
+					<td>[Pod]</td>
+					<td>Specifies the requested ephemeral storage setting for the Envoy sidecar.</td>
+				</tr>
+			
+		
+			
+				
+					<tr>
+				
+					<td><code>sidecar.istio.io/proxyEphemeralStorageLimit</code></td>
+				
+					<td>Alpha</td>
+				
+					<td>[Pod]</td>
+					<td>Specifies the ephemeral storage limit for the Envoy sidecar.</td>
+				</tr>
+			
+		
+			
+				
+					<tr>
+				
 					<td><code>sidecar.istio.io/proxyImage</code></td>
 				
 					<td>Alpha</td>

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -504,3 +504,19 @@ annotations:
     hidden: false
     resources:
       - Namespace
+
+  - name: sidecar.istio.io/proxyEphemeralStorage
+    featureStatus: Alpha
+    description: Specifies the requested ephemeral storage setting for the Envoy sidecar.
+    deprecated: false
+    hidden: false
+    resources:
+      - Pod
+
+  - name: sidecar.istio.io/proxyEphemeralStorageLimit
+    featureStatus: Alpha
+    description: Specifies the ephemeral storage limit for the Envoy sidecar.
+    deprecated: false
+    hidden: false
+    resources:
+      - Pod

--- a/releasenotes/notes/ephemeral-storage-annotations.yaml
+++ b/releasenotes/notes/ephemeral-storage-annotations.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: network
+issue:
+  - 2571
+
+releaseNotes:
+  - |
+    **Added** `sidecar.istio.io/proxyEphemeralStorage` and `sidecar.istio.io/proxyEphemeralStorageLimit`
+    annotations to support ephemeral-storage request/limits for the Envoy sidecar.


### PR DESCRIPTION
Implements #2571

Adds `sidecar.istio.io/proxyEphemeralStorage` and `sidecar.istio.io/proxyEphemeralStorageLimit` annotations to support per-pod ephemeral-storage request/limits for the Envoy sidecar.