### PR TITLE
remove hide_from_docs for traffic selector

### DIFF
--- a/extensions/v1alpha1/wasm.gen.json
+++ b/extensions/v1alpha1/wasm.gen.json
@@ -107,7 +107,7 @@
             "$ref": "#/components/schemas/istio.extensions.v1alpha1.VmConfig"
           },
           "match": {
-            "description": "Hide this from doc until implementing this.",
+            "description": "Specifies the criteria to determine which traffic is passed to WasmPlugin. If a traffic satisfies any of TrafficSelectors, the traffic passes the WasmPlugin.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/istio.extensions.v1alpha1.WasmPlugin.TrafficSelector"
@@ -116,14 +116,14 @@
         }
       },
       "istio.extensions.v1alpha1.WasmPlugin.TrafficSelector": {
-        "description": "Hide this from doc until implementing this.",
+        "description": "TrafficSelector provides a mechanism to select a specific traffic flow for which this Wasm Plugin will be enabled. When all the sub conditions in the TrafficSelector are satisfied, the traffic will be selected.",
         "type": "object",
         "properties": {
           "mode": {
             "$ref": "#/components/schemas/istio.type.v1beta1.WorkloadMode"
           },
           "ports": {
-            "description": "Hide this from the doc until implementing this.",
+            "description": "Criteria for selecting traffic by their destination port. More specifically, for the outbound traffic, the destination port would be the port of the target service. On the other hand, for the inbound traffic, the destiation port is the port bound by the server process in the same Pod.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/istio.type.v1beta1.PortSelector"

--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -493,9 +493,6 @@ type WasmPlugin struct {
 	// Configuration for a Wasm VM.
 	// more details can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-vmconfig).
 	VmConfig *VmConfig `protobuf:"bytes,11,opt,name=vm_config,json=vmConfig,proto3" json:"vm_config,omitempty"`
-	// $hide_from_docs
-	// Hide this from doc until implementing this.
-	//
 	// Specifies the criteria to determine which traffic is passed to WasmPlugin.
 	// If a traffic satisfies any of TrafficSelectors,
 	// the traffic passes the WasmPlugin.
@@ -739,9 +736,6 @@ func (x *EnvVar) GetValue() string {
 	return ""
 }
 
-// $hide_from_docs
-// Hide this from doc until implementing this.
-//
 // TrafficSelector provides a mechanism to select a specific traffic flow
 // for which this Wasm Plugin will be enabled.
 // When all the sub conditions in the TrafficSelector are satisfied, the
@@ -751,18 +745,12 @@ type WasmPlugin_TrafficSelector struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// $hide_from_docs
-	// Hide this from the doc until implementing this.
-	//
 	// Criteria for selecting traffic by their direction.
 	// Note that CLIENT and SERVER are analogous to INBOUND and OUTBOUND,
 	// respectively.
 	// For the gateway, the field should be CLIENT or CLIENT_AND_SERVER.
 	// If not specified, the default value is CLIENT_AND_SERVER.
 	Mode v1beta1.WorkloadMode `protobuf:"varint,1,opt,name=mode,proto3,enum=istio.type.v1beta1.WorkloadMode" json:"mode,omitempty"`
-	// $hide_from_docs
-	// Hide this from the doc until implementing this.
-	//
 	// Criteria for selecting traffic by their destination port.
 	// More specifically, for the outbound traffic, the destination port would be
 	// the port of the target service. On the other hand, for the inbound traffic,

--- a/extensions/v1alpha1/wasm.pb.html
+++ b/extensions/v1alpha1/wasm.pb.html
@@ -6,7 +6,7 @@ layout: protoc-gen-docs
 generator: protoc-gen-docs
 schema: istio.extensions.v1alpha1.WasmPlugin
 aliases: [/docs/reference/config/extensions/v1alpha1/wasm-plugin]
-number_of_entries: 6
+number_of_entries: 7
 ---
 <p>WasmPlugins provides a mechanism to extend the functionality provided by
 the Istio proxy through WebAssembly filters.</p>
@@ -321,6 +321,19 @@ more details can be found <a href="https://www.envoyproxy.io/docs/envoy/latest/a
 No
 </td>
 </tr>
+<tr id="WasmPlugin-match">
+<td><code>match</code></td>
+<td><code><a href="#WasmPlugin-TrafficSelector">TrafficSelector[]</a></code></td>
+<td>
+<p>Specifies the criteria to determine which traffic is passed to WasmPlugin.
+If a traffic satisfies any of TrafficSelectors,
+the traffic passes the WasmPlugin.</p>
+
+</td>
+<td>
+No
+</td>
+</tr>
 </tbody>
 </table>
 </section>
@@ -397,6 +410,57 @@ No
 <p>Value for the environment variable.
 Note that if <code>value_from</code> is <code>HOST</code>, it will be ignored.
 Defaults to &ldquo;&rdquo;.</p>
+
+</td>
+<td>
+No
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="WasmPlugin-TrafficSelector">WasmPlugin.TrafficSelector</h2>
+<section>
+<p>TrafficSelector provides a mechanism to select a specific traffic flow
+for which this Wasm Plugin will be enabled.
+When all the sub conditions in the TrafficSelector are satisfied, the
+traffic will be selected.</p>
+
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+<th>Required</th>
+</tr>
+</thead>
+<tbody>
+<tr id="WasmPlugin-TrafficSelector-mode">
+<td><code>mode</code></td>
+<td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#WorkloadMode">WorkloadMode</a></code></td>
+<td>
+<p>Criteria for selecting traffic by their direction.
+Note that CLIENT and SERVER are analogous to INBOUND and OUTBOUND,
+respectively.
+For the gateway, the field should be CLIENT or CLIENT_AND_SERVER.
+If not specified, the default value is CLIENT_AND_SERVER.</p>
+
+</td>
+<td>
+No
+</td>
+</tr>
+<tr id="WasmPlugin-TrafficSelector-ports">
+<td><code>ports</code></td>
+<td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#PortSelector">PortSelector[]</a></code></td>
+<td>
+<p>Criteria for selecting traffic by their destination port.
+More specifically, for the outbound traffic, the destination port would be
+the port of the target service. On the other hand, for the inbound traffic,
+the destiation port is the port bound by the server process in the same Pod.</p>
+<p>If one of the given <code>ports</code> is matched, this condition is evaluated to true.
+If not specified, this condition is evaluated to true for any port.</p>
 
 </td>
 <td>

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -315,17 +315,11 @@ message WasmPlugin {
   // more details can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-vmconfig).
   VmConfig vm_config = 11;
 
-  // $hide_from_docs
-  // Hide this from doc until implementing this.
-  //
   // TrafficSelector provides a mechanism to select a specific traffic flow
   // for which this Wasm Plugin will be enabled.
   // When all the sub conditions in the TrafficSelector are satisfied, the
   // traffic will be selected.
   message TrafficSelector {
-    // $hide_from_docs 
-    // Hide this from the doc until implementing this.
-    //
     // Criteria for selecting traffic by their direction.
     // Note that CLIENT and SERVER are analogous to INBOUND and OUTBOUND,
     // respectively.
@@ -333,9 +327,6 @@ message WasmPlugin {
     // If not specified, the default value is CLIENT_AND_SERVER.
     istio.type.v1beta1.WorkloadMode mode = 1;
   
-    // $hide_from_docs 
-    // Hide this from the doc until implementing this.
-    //
     // Criteria for selecting traffic by their destination port.
     // More specifically, for the outbound traffic, the destination port would be 
     // the port of the target service. On the other hand, for the inbound traffic,
@@ -346,9 +337,6 @@ message WasmPlugin {
     repeated istio.type.v1beta1.PortSelector ports = 2;
   }    
 
-  // $hide_from_docs
-  // Hide this from doc until implementing this.
-  //
   // Specifies the criteria to determine which traffic is passed to WasmPlugin.
   // If a traffic satisfies any of TrafficSelectors, 
   // the traffic passes the WasmPlugin.

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -49,9 +49,12 @@ spec:
                 description: Credentials to use for OCI image pulling.
                 type: string
               match:
+                description: Specifies the criteria to determine which traffic is
+                  passed to WasmPlugin.
                 items:
                   properties:
                     mode:
+                      description: Criteria for selecting traffic by their direction.
                       enum:
                       - UNDEFINED
                       - CLIENT
@@ -59,6 +62,8 @@ spec:
                       - CLIENT_AND_SERVER
                       type: string
                     ports:
+                      description: Criteria for selecting traffic by their destination
+                        port.
                       items:
                         properties:
                           number:


### PR DESCRIPTION
Added in https://github.com/istio/api/pull/2412
Implemented by https://github.com/istio/istio/pull/40862

This removes the hide_from_docs annotation to expose the documentation for traffic selector.