### PR TITLE
fix: envoy statistics config documentation

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -2873,14 +2873,15 @@ inclusion annotations
 (<code>sidecar.istio.io/statsInclusionPrefixes</code>,
 <code>sidecar.istio.io/statsInclusionRegexps</code>, and
 <code>sidecar.istio.io/statsInclusionSuffixes</code>). For example, to enable stats
-for circuit breaker, retry, and upstream connections, you can specify stats
-matcher as follow:</p>
+for circuit breaker, retry, upstream connections and request timeout,
+you can specify stats matcher as follow:</p>
 <pre><code class="language-yaml">proxyStatsMatcher:
   inclusionRegexps:
-    - .*circuit_breakers.*
-  inclusionPrefixes:
-    - upstream_rq_retry
-    - upstream_cx
+    - .*outlier_detection.*
+    - .*upstream_rq_retry.*
+    - .*upstream_cx_.*
+  inclusionSuffixes:
+    - upstream_rq_timeout
 </code></pre>
 <p>Note including more Envoy stats might increase number of time series
 collected by prometheus significantly. Care needs to be taken on Prometheus

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -2873,8 +2873,8 @@ inclusion annotations
 (<code>sidecar.istio.io/statsInclusionPrefixes</code>,
 <code>sidecar.istio.io/statsInclusionRegexps</code>, and
 <code>sidecar.istio.io/statsInclusionSuffixes</code>). For example, to enable stats
-for circuit breaker, retry, upstream connections and request timeout,
-you can specify stats matcher as follow:</p>
+for circuit breakers, request retries, upstream connections, and request timeouts,
+you can specify stats matcher as follows:</p>
 <pre><code class="language-yaml">proxyStatsMatcher:
   inclusionRegexps:
     - .*outlier_detection.*

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -925,8 +925,8 @@ type ProxyConfig struct {
 	// (`sidecar.istio.io/statsInclusionPrefixes`,
 	// `sidecar.istio.io/statsInclusionRegexps`, and
 	// `sidecar.istio.io/statsInclusionSuffixes`). For example, to enable stats
-	// for circuit breaker, retry, upstream connections and request timeout,
-	// you can specify stats matcher as follow:
+	// for circuit breakers, request retries, upstream connections, and request timeouts,
+	// you can specify stats matcher as follows:
 	// ```yaml
 	// proxyStatsMatcher:
 	//

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -925,16 +925,17 @@ type ProxyConfig struct {
 	// (`sidecar.istio.io/statsInclusionPrefixes`,
 	// `sidecar.istio.io/statsInclusionRegexps`, and
 	// `sidecar.istio.io/statsInclusionSuffixes`). For example, to enable stats
-	// for circuit breaker, retry, and upstream connections, you can specify stats
-	// matcher as follow:
+	// for circuit breaker, retry, upstream connections and request timeout,
+	// you can specify stats matcher as follow:
 	// ```yaml
 	// proxyStatsMatcher:
 	//
 	//	inclusionRegexps:
-	//	  - .*circuit_breakers.*
-	//	inclusionPrefixes:
-	//	  - upstream_rq_retry
-	//	  - upstream_cx
+	//	  - .*outlier_detection.*
+	//	  - .*upstream_rq_retry.*
+	//	  - .*upstream_cx_.*
+	//	inclusionSuffixes:
+	//	  - upstream_rq_timeout
 	//
 	// ```
 	// Note including more Envoy stats might increase number of time series

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -558,15 +558,16 @@ message ProxyConfig {
   // (`sidecar.istio.io/statsInclusionPrefixes`,
   // `sidecar.istio.io/statsInclusionRegexps`, and
   // `sidecar.istio.io/statsInclusionSuffixes`). For example, to enable stats
-  // for circuit breaker, retry, and upstream connections, you can specify stats
-  // matcher as follow:
+  // for circuit breaker, retry, upstream connections and request timeout,
+  // you can specify stats matcher as follow:
   // ```yaml
   // proxyStatsMatcher:
   //   inclusionRegexps:
-  //     - .*circuit_breakers.*
-  //   inclusionPrefixes:
-  //     - upstream_rq_retry
-  //     - upstream_cx
+  //     - .*outlier_detection.*
+  //     - .*upstream_rq_retry.*
+  //     - .*upstream_cx_.*
+  //   inclusionSuffixes:
+  //     - upstream_rq_timeout
   // ```
   // Note including more Envoy stats might increase number of time series
   // collected by prometheus significantly. Care needs to be taken on Prometheus

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -558,8 +558,8 @@ message ProxyConfig {
   // (`sidecar.istio.io/statsInclusionPrefixes`,
   // `sidecar.istio.io/statsInclusionRegexps`, and
   // `sidecar.istio.io/statsInclusionSuffixes`). For example, to enable stats
-  // for circuit breaker, retry, upstream connections and request timeout,
-  // you can specify stats matcher as follow:
+  // for circuit breakers, request retries, upstream connections, and request timeouts,
+  // you can specify stats matcher as follows:
   // ```yaml
   // proxyStatsMatcher:
   //   inclusionRegexps:


### PR DESCRIPTION
refer: https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_stats
associate to: https://github.com/istio/istio.io/pull/12357

1. Istio uses `outlier_detection` for `circuit_breakers`
2. There are 6 retry metrics (`cluster.<name>.upstream_rq_retry*`) 
3. There are many upstream connections metrics (`cluster.<name>.upstream_cx_*`) 
4. Added `upstream_rq_timeout` suffixed example