### PR TITLE
Update DestinationRule docs with correct env variable name

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -2114,7 +2114,7 @@
             "type": "string"
           },
           "subjectAltNames": {
-            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry. If unspecified, automatic validation of upstream presented certificate for new upstream connections will be done based on the downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT` and `ENABLE_AUTO_SNI` environmental variables are set to `true`.",
+            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry. If unspecified, automatic validation of upstream presented certificate for new upstream connections will be done based on the downstream HTTP host/authority header, provided `VERIFY_CERTIFICATE_AT_CLIENT` and `ENABLE_AUTO_SNI` environmental variables are set to `true`.",
             "type": "array",
             "items": {
               "type": "string"

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -30,7 +30,7 @@
             "type": "string"
           },
           "subjectAltNames": {
-            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry. If unspecified, automatic validation of upstream presented certificate for new upstream connections will be done based on the downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT` and `ENABLE_AUTO_SNI` environmental variables are set to `true`.",
+            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry. If unspecified, automatic validation of upstream presented certificate for new upstream connections will be done based on the downstream HTTP host/authority header, provided `VERIFY_CERTIFICATE_AT_CLIENT` and `ENABLE_AUTO_SNI` environmental variables are set to `true`.",
             "type": "array",
             "items": {
               "type": "string"

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1552,7 +1552,7 @@ type ClientTLSSettings struct {
 	// If specified, this list overrides the value of subject_alt_names
 	// from the ServiceEntry. If unspecified, automatic validation of upstream
 	// presented certificate for new upstream connections will be done based on the
-	// downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT`
+	// downstream HTTP host/authority header, provided `VERIFY_CERTIFICATE_AT_CLIENT`
 	// and `ENABLE_AUTO_SNI` environmental variables are set to `true`.
 	SubjectAltNames []string `protobuf:"bytes,5,rep,name=subject_alt_names,json=subjectAltNames,proto3" json:"subject_alt_names,omitempty"`
 	// SNI string to present to the server during TLS handshake.

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1179,7 +1179,7 @@ certificate&rsquo;s subject alt name matches one of the specified values.
 If specified, this list overrides the value of subject_alt_names
 from the ServiceEntry. If unspecified, automatic validation of upstream
 presented certificate for new upstream connections will be done based on the
-downstream HTTP host/authority header, provided <code>VERIFY_CERT_AT_CLIENT</code>
+downstream HTTP host/authority header, provided <code>VERIFY_CERTIFICATE_AT_CLIENT</code>
 and <code>ENABLE_AUTO_SNI</code> environmental variables are set to <code>true</code>.</p>
 
 </td>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -1102,7 +1102,7 @@ message ClientTLSSettings {
   // If specified, this list overrides the value of subject_alt_names
   // from the ServiceEntry. If unspecified, automatic validation of upstream
   // presented certificate for new upstream connections will be done based on the
-  // downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT`
+  // downstream HTTP host/authority header, provided `VERIFY_CERTIFICATE_AT_CLIENT`
   // and `ENABLE_AUTO_SNI` environmental variables are set to `true`.
   repeated string subject_alt_names = 5;
 

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -30,7 +30,7 @@
             "type": "string"
           },
           "subjectAltNames": {
-            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry. If unspecified, automatic validation of upstream presented certificate for new upstream connections will be done based on the downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT` and `ENABLE_AUTO_SNI` environmental variables are set to `true`.",
+            "description": "A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry. If unspecified, automatic validation of upstream presented certificate for new upstream connections will be done based on the downstream HTTP host/authority header, provided `VERIFY_CERTIFICATE_AT_CLIENT` and `ENABLE_AUTO_SNI` environmental variables are set to `true`.",
             "type": "array",
             "items": {
               "type": "string"

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1501,7 +1501,7 @@ type ClientTLSSettings struct {
 	// If specified, this list overrides the value of subject_alt_names
 	// from the ServiceEntry. If unspecified, automatic validation of upstream
 	// presented certificate for new upstream connections will be done based on the
-	// downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT`
+	// downstream HTTP host/authority header, provided `VERIFY_CERTIFICATE_AT_CLIENT`
 	// and `ENABLE_AUTO_SNI` environmental variables are set to `true`.
 	SubjectAltNames []string `protobuf:"bytes,5,rep,name=subject_alt_names,json=subjectAltNames,proto3" json:"subject_alt_names,omitempty"`
 	// SNI string to present to the server during TLS handshake.

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -1051,7 +1051,7 @@ message ClientTLSSettings {
   // If specified, this list overrides the value of subject_alt_names
   // from the ServiceEntry. If unspecified, automatic validation of upstream
   // presented certificate for new upstream connections will be done based on the
-  // downstream HTTP host/authority header, provided `VERIFY_CERT_AT_CLIENT`
+  // downstream HTTP host/authority header, provided `VERIFY_CERTIFICATE_AT_CLIENT`
   // and `ENABLE_AUTO_SNI` environmental variables are set to `true`.
   repeated string subject_alt_names = 5;
 

--- a/releasenotes/notes/fix-destinationrule-doc.yaml
+++ b/releasenotes/notes/fix-destinationrule-doc.yaml
@@ -5,4 +5,4 @@ issue: []
 
 releaseNotes:
 - |
-    **Fixed** Incorrect pilot-discovery environment variable name.
+    **Fixed** incorrect pilot-discovery environment variable name.

--- a/releasenotes/notes/fix-destinationrule-doc.yaml
+++ b/releasenotes/notes/fix-destinationrule-doc.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: documentation
+issue: []
+
+releaseNotes:
+- |
+    **Fixed** Incorrect pilot-discovery environment variable name.


### PR DESCRIPTION
The Destination Rule documentation show that the verify cert at client environment variable name is `VERIFY_CERT_AT_CLIENT` in [ClientTLSSettings](https://istio.io/latest/docs/reference/config/networking/destination-rule/#ClientTLSSettings) but according to the [pilot-discovery](https://istio.io/latest/docs/reference/commands/pilot-discovery/) docs the environment variable is `VERIFY_CERTIFICATE_AT_CLIENT`.  Updating the Destination Rule documentation to use the correct environment variable name.