### PR TITLE
Clarify that Sidecar is not applicable to gateways

### DIFF
--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -60,6 +60,8 @@
 // configuration_*. This global default `Sidecar` configuration should not have
 // any `workloadSelector`.
 //
+// **NOTE 3**: *_A `Sidecar` is not applicable to gateways, even though gateways are istio-proxies_*.
+//
 // The example below declares a global default `Sidecar` configuration
 // in the root namespace called `istio-config`, that configures
 // sidecars in all namespaces to allow egress traffic only to other

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -40,6 +40,7 @@ system is undefined if two or more <code>Sidecar</code> configurations with a
 will be applied by default to all namespaces without a <code>Sidecar</code>
 configuration</em></em>. This global default <code>Sidecar</code> configuration should not have
 any <code>workloadSelector</code>.</p>
+<p><strong>NOTE 3</strong>: <em><em>A <code>Sidecar</code> is not applicable to gateways, even though gateways are istio-proxies</em></em>.</p>
 <p>The example below declares a global default <code>Sidecar</code> configuration
 in the root namespace called <code>istio-config</code>, that configures
 sidecars in all namespaces to allow egress traffic only to other

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -60,6 +60,8 @@ import "networking/v1alpha3/virtual_service.proto";
 // configuration_*. This global default `Sidecar` configuration should not have
 // any `workloadSelector`.
 //
+// **NOTE 3**: *_A `Sidecar` is not applicable to gateways, even though gateways are istio-proxies_*.
+//
 // The example below declares a global default `Sidecar` configuration
 // in the root namespace called `istio-config`, that configures
 // sidecars in all namespaces to allow egress traffic only to other

--- a/networking/v1beta1/sidecar.pb.go
+++ b/networking/v1beta1/sidecar.pb.go
@@ -61,6 +61,8 @@
 // configuration_*. This global default `Sidecar` configuration should not have
 // any `workloadSelector`.
 //
+// **NOTE 3**: *_A `Sidecar` is not applicable to gateways, even though gateways are istio-proxies_*.
+//
 // The example below declares a global default `Sidecar` configuration
 // in the root namespace called `istio-config`, that configures
 // sidecars in all namespaces to allow egress traffic only to other

--- a/networking/v1beta1/sidecar.proto
+++ b/networking/v1beta1/sidecar.proto
@@ -61,6 +61,8 @@ import "networking/v1beta1/virtual_service.proto";
 // configuration_*. This global default `Sidecar` configuration should not have
 // any `workloadSelector`.
 //
+// **NOTE 3**: *_A `Sidecar` is not applicable to gateways, even though gateways are istio-proxies_*.
+//
 // The example below declares a global default `Sidecar` configuration
 // in the root namespace called `istio-config`, that configures
 // sidecars in all namespaces to allow egress traffic only to other


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

To avoid confusion like in this [issue](https://github.com/istio/istio/issues/32041), I think it's worth to clarify that `Sidecar` is not applicable to gateways. Users may guess that `Sidecar` should work for gateways, because both gateway and sidecar proxies are the same istio-proxy.