### PR TITLE
VirtualService docs minor formatting fixes

### DIFF
--- a/networking/v1alpha3/virtual_service.gen.json
+++ b/networking/v1alpha3/virtual_service.gen.json
@@ -880,7 +880,7 @@
             }
           },
           "http": {
-            "description": "An ordered list of route rules for HTTP traffic. HTTP routes will be applied to platform service ports named 'http-*'/'http2-*'/'grpc-*', gateway ports with protocol HTTP/HTTP2/GRPC/ TLS-terminated-HTTPS and service entry ports using HTTP/HTTP2/GRPC protocols. The first rule matching an incoming request is used.",
+            "description": "An ordered list of route rules for HTTP traffic. HTTP routes will be applied to platform service ports named 'http-\\*'/'http2-\\*'/'grpc-\\*', gateway ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service entry ports using HTTP/HTTP2/GRPC protocols. The first rule matching an incoming request is used.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/istio.networking.v1alpha3.HTTPRoute"

--- a/networking/v1alpha3/virtual_service.gen.json
+++ b/networking/v1alpha3/virtual_service.gen.json
@@ -880,7 +880,7 @@
             }
           },
           "http": {
-            "description": "An ordered list of route rules for HTTP traffic. HTTP routes will be applied to platform service ports named 'http-\\*'/'http2-\\*'/'grpc-\\*', gateway ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service entry ports using HTTP/HTTP2/GRPC protocols. The first rule matching an incoming request is used.",
+            "description": "An ordered list of route rules for HTTP traffic. HTTP routes will be applied to platform service ports using HTTP/HTTP2/GRPC protocols, gateway ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service entry ports using HTTP/HTTP2/GRPC protocols. The first rule matching an incoming request is used.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/istio.networking.v1alpha3.HTTPRoute"

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -317,7 +317,7 @@ type VirtualService struct {
 	// gateways and sidecars, specify `mesh` as one of the gateway names.
 	Gateways []string `protobuf:"bytes,2,rep,name=gateways,proto3" json:"gateways,omitempty"`
 	// An ordered list of route rules for HTTP traffic. HTTP routes will be
-	// applied to platform service ports named 'http-\*'/'http2-\*'/'grpc-\*', gateway
+	// applied to platform service ports using HTTP/HTTP2/GRPC protocols, gateway
 	// ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service
 	// entry ports using HTTP/HTTP2/GRPC protocols.  The first rule matching
 	// an incoming request is used.

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -317,8 +317,8 @@ type VirtualService struct {
 	// gateways and sidecars, specify `mesh` as one of the gateway names.
 	Gateways []string `protobuf:"bytes,2,rep,name=gateways,proto3" json:"gateways,omitempty"`
 	// An ordered list of route rules for HTTP traffic. HTTP routes will be
-	// applied to platform service ports named 'http-*'/'http2-*'/'grpc-*', gateway
-	// ports with protocol HTTP/HTTP2/GRPC/ TLS-terminated-HTTPS and service
+	// applied to platform service ports named 'http-\*'/'http2-\*'/'grpc-\*', gateway
+	// ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service
 	// entry ports using HTTP/HTTP2/GRPC protocols.  The first rule matching
 	// an incoming request is used.
 	Http []*HTTPRoute `protobuf:"bytes,3,rep,name=http,proto3" json:"http,omitempty"`

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -214,7 +214,7 @@ No
 <td><code><a href="#HTTPRoute">HTTPRoute[]</a></code></td>
 <td>
 <p>An ordered list of route rules for HTTP traffic. HTTP routes will be
-applied to platform service ports named &lsquo;http-*&rsquo;/&lsquo;http2-*&rsquo;/&lsquo;grpc-*&rsquo;, gateway
+applied to platform service ports using HTTP/HTTP2/GRPC protocols, gateway
 ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service
 entry ports using HTTP/HTTP2/GRPC protocols.  The first rule matching
 an incoming request is used.</p>

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -214,8 +214,8 @@ No
 <td><code><a href="#HTTPRoute">HTTPRoute[]</a></code></td>
 <td>
 <p>An ordered list of route rules for HTTP traffic. HTTP routes will be
-applied to platform service ports named &lsquo;http-<em>&rsquo;/&lsquo;http2-</em>&rsquo;/&lsquo;grpc-*&rsquo;, gateway
-ports with protocol HTTP/HTTP2/GRPC/ TLS-terminated-HTTPS and service
+applied to platform service ports named &lsquo;http-*&rsquo;/&lsquo;http2-*&rsquo;/&lsquo;grpc-*&rsquo;, gateway
+ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service
 entry ports using HTTP/HTTP2/GRPC protocols.  The first rule matching
 an incoming request is used.</p>
 

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -253,7 +253,7 @@ message VirtualService {
   repeated string gateways = 2;
 
   // An ordered list of route rules for HTTP traffic. HTTP routes will be
-  // applied to platform service ports named 'http-\*'/'http2-\*'/'grpc-\*', gateway
+  // applied to platform service ports using HTTP/HTTP2/GRPC protocols, gateway
   // ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service
   // entry ports using HTTP/HTTP2/GRPC protocols.  The first rule matching
   // an incoming request is used.

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -253,8 +253,8 @@ message VirtualService {
   repeated string gateways = 2;
 
   // An ordered list of route rules for HTTP traffic. HTTP routes will be
-  // applied to platform service ports named 'http-*'/'http2-*'/'grpc-*', gateway
-  // ports with protocol HTTP/HTTP2/GRPC/ TLS-terminated-HTTPS and service
+  // applied to platform service ports named 'http-\*'/'http2-\*'/'grpc-\*', gateway
+  // ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service
   // entry ports using HTTP/HTTP2/GRPC protocols.  The first rule matching
   // an incoming request is used.
   repeated HTTPRoute http = 3;

--- a/networking/v1beta1/virtual_service.gen.json
+++ b/networking/v1beta1/virtual_service.gen.json
@@ -880,7 +880,7 @@
             }
           },
           "http": {
-            "description": "An ordered list of route rules for HTTP traffic. HTTP routes will be applied to platform service ports named 'http-\\*'/'http2-\\*'/'grpc-\\*', gateway ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service entry ports using HTTP/HTTP2/GRPC protocols. The first rule matching an incoming request is used.",
+            "description": "An ordered list of route rules for HTTP traffic. HTTP routes will be applied to platform service ports using HTTP/HTTP2/GRPC protocols, gateway ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service entry ports using HTTP/HTTP2/GRPC protocols. The first rule matching an incoming request is used.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/istio.networking.v1beta1.HTTPRoute"

--- a/networking/v1beta1/virtual_service.gen.json
+++ b/networking/v1beta1/virtual_service.gen.json
@@ -880,7 +880,7 @@
             }
           },
           "http": {
-            "description": "An ordered list of route rules for HTTP traffic. HTTP routes will be applied to platform service ports named 'http-*'/'http2-*'/'grpc-*', gateway ports with protocol HTTP/HTTP2/GRPC/ TLS-terminated-HTTPS and service entry ports using HTTP/HTTP2/GRPC protocols. The first rule matching an incoming request is used.",
+            "description": "An ordered list of route rules for HTTP traffic. HTTP routes will be applied to platform service ports named 'http-\\*'/'http2-\\*'/'grpc-\\*', gateway ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service entry ports using HTTP/HTTP2/GRPC protocols. The first rule matching an incoming request is used.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/istio.networking.v1beta1.HTTPRoute"

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -317,7 +317,7 @@ type VirtualService struct {
 	// gateways and sidecars, specify `mesh` as one of the gateway names.
 	Gateways []string `protobuf:"bytes,2,rep,name=gateways,proto3" json:"gateways,omitempty"`
 	// An ordered list of route rules for HTTP traffic. HTTP routes will be
-	// applied to platform service ports named 'http-\*'/'http2-\*'/'grpc-\*', gateway
+	// applied to platform service ports using HTTP/HTTP2/GRPC protocols, gateway
 	// ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service
 	// entry ports using HTTP/HTTP2/GRPC protocols.  The first rule matching
 	// an incoming request is used.

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -317,8 +317,8 @@ type VirtualService struct {
 	// gateways and sidecars, specify `mesh` as one of the gateway names.
 	Gateways []string `protobuf:"bytes,2,rep,name=gateways,proto3" json:"gateways,omitempty"`
 	// An ordered list of route rules for HTTP traffic. HTTP routes will be
-	// applied to platform service ports named 'http-*'/'http2-*'/'grpc-*', gateway
-	// ports with protocol HTTP/HTTP2/GRPC/ TLS-terminated-HTTPS and service
+	// applied to platform service ports named 'http-\*'/'http2-\*'/'grpc-\*', gateway
+	// ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service
 	// entry ports using HTTP/HTTP2/GRPC protocols.  The first rule matching
 	// an incoming request is used.
 	Http []*HTTPRoute `protobuf:"bytes,3,rep,name=http,proto3" json:"http,omitempty"`

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -253,7 +253,7 @@ message VirtualService {
   repeated string gateways = 2;
 
   // An ordered list of route rules for HTTP traffic. HTTP routes will be
-  // applied to platform service ports named 'http-\*'/'http2-\*'/'grpc-\*', gateway
+  // applied to platform service ports using HTTP/HTTP2/GRPC protocols, gateway
   // ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service
   // entry ports using HTTP/HTTP2/GRPC protocols.  The first rule matching
   // an incoming request is used.

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -253,8 +253,8 @@ message VirtualService {
   repeated string gateways = 2;
 
   // An ordered list of route rules for HTTP traffic. HTTP routes will be
-  // applied to platform service ports named 'http-*'/'http2-*'/'grpc-*', gateway
-  // ports with protocol HTTP/HTTP2/GRPC/ TLS-terminated-HTTPS and service
+  // applied to platform service ports named 'http-\*'/'http2-\*'/'grpc-\*', gateway
+  // ports with protocol HTTP/HTTP2/GRPC/TLS-terminated-HTTPS and service
   // entry ports using HTTP/HTTP2/GRPC protocols.  The first rule matching
   // an incoming request is used.
   repeated HTTPRoute http = 3;


### PR DESCRIPTION
The double asterisks currently cause the text to be italicized instead of showing as expected