### PR TITLE
Fix link

### DIFF
--- a/security/v1/authorization_policy.pb.go
+++ b/security/v1/authorization_policy.pb.go
@@ -134,7 +134,7 @@
 // When this rule is applied to TCP traffic, the `method` field (as will all HTTP based attributes) cannot be processed.
 // For a `DENY` rule, missing attributes are treated as matches. This means all TCP traffic on port 8080 would be denied in the example above.
 // If we were to remove the `ports` match, all TCP traffic would be denied. As a result, it is recommended to always scope `DENY` policies to a specific port,
-// especially when using HTTP attributes [Authorization Policy for TCP Ports] (https://istio.io/latest/docs/tasks/security/authorization/authz-tcp/).
+// especially when using HTTP attributes [Authorization Policy for TCP Ports](https://istio.io/latest/docs/tasks/security/authorization/authz-tcp/).
 //
 // The following authorization policy sets the `action` to "AUDIT". It will audit any GET requests to the path with the
 // prefix "/user/profile".

--- a/security/v1/authorization_policy.pb.html
+++ b/security/v1/authorization_policy.pb.html
@@ -103,7 +103,7 @@ spec:
 <p>When this rule is applied to TCP traffic, the <code>method</code> field (as will all HTTP based attributes) cannot be processed.
 For a <code>DENY</code> rule, missing attributes are treated as matches. This means all TCP traffic on port 8080 would be denied in the example above.
 If we were to remove the <code>ports</code> match, all TCP traffic would be denied. As a result, it is recommended to always scope <code>DENY</code> policies to a specific port,
-especially when using HTTP attributes [Authorization Policy for TCP Ports] (<a href="https://istio.io/latest/docs/tasks/security/authorization/authz-tcp/)">https://istio.io/latest/docs/tasks/security/authorization/authz-tcp/)</a>.</p>
+especially when using HTTP attributes <a href="https://istio.io/latest/docs/tasks/security/authorization/authz-tcp/">Authorization Policy for TCP Ports</a>.</p>
 <p>The following authorization policy sets the <code>action</code> to &ldquo;AUDIT&rdquo;. It will audit any GET requests to the path with the
 prefix &ldquo;/user/profile&rdquo;.</p>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1

--- a/security/v1/authorization_policy.proto
+++ b/security/v1/authorization_policy.proto
@@ -129,10 +129,10 @@ import "type/v1beta1/selector.proto";
 //         ports: ["8080"]
 // ```
 //
-// When this rule is applied to TCP traffic, the `method` field (as will all HTTP based attributes) cannot be processed. 
+// When this rule is applied to TCP traffic, the `method` field (as will all HTTP based attributes) cannot be processed.
 // For a `DENY` rule, missing attributes are treated as matches. This means all TCP traffic on port 8080 would be denied in the example above.
-// If we were to remove the `ports` match, all TCP traffic would be denied. As a result, it is recommended to always scope `DENY` policies to a specific port, 
-// especially when using HTTP attributes [Authorization Policy for TCP Ports] (https://istio.io/latest/docs/tasks/security/authorization/authz-tcp/).
+// If we were to remove the `ports` match, all TCP traffic would be denied. As a result, it is recommended to always scope `DENY` policies to a specific port,
+// especially when using HTTP attributes [Authorization Policy for TCP Ports](https://istio.io/latest/docs/tasks/security/authorization/authz-tcp/).
 //
 // The following authorization policy sets the `action` to "AUDIT". It will audit any GET requests to the path with the
 // prefix "/user/profile".


### PR DESCRIPTION
There is an extra space at the end of a line which ends up between the link and it's reference causing a failure when we try and pull this into the istio.io: https://github.com/istio/istio.io/pull/12684.