### PR TITLE
Clarify credentialName usage in ClientTLSSettings for separate ca secret

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -2140,7 +2140,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -26,7 +26,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1539,6 +1539,8 @@ type ClientTLSSettings struct {
 	// following keys and values: `key: <privateKey>`,
 	// `cert: <clientCert>`, `cacert: <CACertificate>`.
 	// Here CACertificate is used to verify the server certificate.
+	// For mutual TLS, `cacert: <CACertificate>` can be provided in the
+	// same secret or a separate secret named `<secret>-cacert`.
 	// Secret of type tls for client certificates along with
 	// ca.crt key for CA certificates is also supported.
 	// Only one of client certificates and CA certificate

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1067,6 +1067,8 @@ The secret (of type <code>generic</code>)should contain the
 following keys and values: <code>key: &lt;privateKey&gt;</code>,
 <code>cert: &lt;clientCert&gt;</code>, <code>cacert: &lt;CACertificate&gt;</code>.
 Here CACertificate is used to verify the server certificate.
+For mutual TLS, <code>cacert: &lt;CACertificate&gt;</code> can be provided in the
+same secret or a separate secret named <code>&lt;secret&gt;-cacert</code>.
 Secret of type tls for client certificates along with
 ca.crt key for CA certificates is also supported.
 Only one of client certificates and CA certificate

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -1099,6 +1099,8 @@ message ClientTLSSettings {
   // following keys and values: `key: <privateKey>`,
   // `cert: <clientCert>`, `cacert: <CACertificate>`.
   // Here CACertificate is used to verify the server certificate.
+  // For mutual TLS, `cacert: <CACertificate>` can be provided in the
+  // same secret or a separate secret named `<secret>-cacert`.
   // Secret of type tls for client certificates along with
   // ca.crt key for CA certificates is also supported.
   // Only one of client certificates and CA certificate

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -26,7 +26,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1488,6 +1488,8 @@ type ClientTLSSettings struct {
 	// following keys and values: `key: <privateKey>`,
 	// `cert: <clientCert>`, `cacert: <CACertificate>`.
 	// Here CACertificate is used to verify the server certificate.
+	// For mutual TLS, `cacert: <CACertificate>` can be provided in the
+	// same secret or a separate secret named `<secret>-cacert`.
 	// Secret of type tls for client certificates along with
 	// ca.crt key for CA certificates is also supported.
 	// Only one of client certificates and CA certificate

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -1048,6 +1048,8 @@ message ClientTLSSettings {
   // following keys and values: `key: <privateKey>`,
   // `cert: <clientCert>`, `cacert: <CACertificate>`.
   // Here CACertificate is used to verify the server certificate.
+  // For mutual TLS, `cacert: <CACertificate>` can be provided in the
+  // same secret or a separate secret named `<secret>-cacert`.
   // Secret of type tls for client certificates along with
   // ca.crt key for CA certificates is also supported.
   // Only one of client certificates and CA certificate


### PR DESCRIPTION
[ServerTLSSettings](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings) seem to have documented this already.