### PR TITLE
update deprecated field in EnvoyFilter example

### DIFF
--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -139,19 +139,20 @@
 //        name: envoy.filters.http.lua
 //        typed_config:
 //           "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
-//           inlineCode: |
-//             function envoy_on_request(request_handle)
-//               -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
-//               local headers, body = request_handle:httpCall(
-//                "lua_cluster",
-//                {
-//                 [":method"] = "POST",
-//                 [":path"] = "/acl",
-//                 [":authority"] = "internal.org.net"
-//                },
-//               "authorize call",
-//               5000)
-//             end
+//           defaultSourceCode:
+//             inlineString: |
+//               function envoy_on_request(request_handle)
+//                 -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
+//                 local headers, body = request_handle:httpCall(
+//                  "lua_cluster",
+//                  {
+//                   [":method"] = "POST",
+//                   [":path"] = "/acl",
+//                   [":authority"] = "internal.org.net"
+//                  },
+//                 "authorize call",
+//                 5000)
+//               end
 //   # The second patch adds the cluster that is referenced by the lua code
 //   # cds match is omitted as a new cluster is being added
 //   - applyTo: CLUSTER

--- a/networking/v1alpha3/envoy_filter.pb.html
+++ b/networking/v1alpha3/envoy_filter.pb.html
@@ -114,19 +114,20 @@ spec:
        name: envoy.filters.http.lua
        typed_config:
           &quot;@type&quot;: &quot;type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua&quot;
-          inlineCode: |
-            function envoy_on_request(request_handle)
-              -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
-              local headers, body = request_handle:httpCall(
-               &quot;lua_cluster&quot;,
-               {
-                [&quot;:method&quot;] = &quot;POST&quot;,
-                [&quot;:path&quot;] = &quot;/acl&quot;,
-                [&quot;:authority&quot;] = &quot;internal.org.net&quot;
-               },
-              &quot;authorize call&quot;,
-              5000)
-            end
+          defaultSourceCode:
+            inlineString: |
+              function envoy_on_request(request_handle)
+                -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
+                local headers, body = request_handle:httpCall(
+                 &quot;lua_cluster&quot;,
+                 {
+                  [&quot;:method&quot;] = &quot;POST&quot;,
+                  [&quot;:path&quot;] = &quot;/acl&quot;,
+                  [&quot;:authority&quot;] = &quot;internal.org.net&quot;
+                 },
+                &quot;authorize call&quot;,
+                5000)
+              end
   # The second patch adds the cluster that is referenced by the lua code
   # cds match is omitted as a new cluster is being added
   - applyTo: CLUSTER

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -139,19 +139,20 @@ import "networking/v1alpha3/sidecar.proto";
 //        name: envoy.filters.http.lua
 //        typed_config:
 //           "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
-//           inlineCode: |
-//             function envoy_on_request(request_handle)
-//               -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
-//               local headers, body = request_handle:httpCall(
-//                "lua_cluster",
-//                {
-//                 [":method"] = "POST",
-//                 [":path"] = "/acl",
-//                 [":authority"] = "internal.org.net"
-//                },
-//               "authorize call",
-//               5000)
-//             end
+//           defaultSourceCode:
+//             inlineString: |
+//               function envoy_on_request(request_handle)
+//                 -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
+//                 local headers, body = request_handle:httpCall(
+//                  "lua_cluster",
+//                  {
+//                   [":method"] = "POST",
+//                   [":path"] = "/acl",
+//                   [":authority"] = "internal.org.net"
+//                  },
+//                 "authorize call",
+//                 5000)
+//               end
 //   # The second patch adds the cluster that is referenced by the lua code
 //   # cds match is omitted as a new cluster is being added
 //   - applyTo: CLUSTER


### PR DESCRIPTION
`inlineCode` has been deprecated in upstream envoy https://github.com/envoyproxy/envoy/pull/22125. This can be replaced with `defaultSourceCode` which is not deprecated.