### PR TITLE
update credentialName docs for DestinationRule and Gateway

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -2140,7 +2140,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. This secret must exist in the namespace of the proxy using the certificates. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for client certificates along with `ca.crt` key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. This secret must exist in the namespace of the proxy using the certificates. An Opaque secret should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A TLS secret for client certificates with an additional `ca.crt` key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.gen.json
@@ -2140,7 +2140,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. This secret must exist in the namespace of the proxy using the certificates. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for client certificates along with `ca.crt` key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -26,7 +26,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. This secret must exist in the namespace of the proxy using the certificates. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for client certificates along with `ca.crt` key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. This secret must exist in the namespace of the proxy using the certificates. An Opaque secret should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A TLS secret for client certificates with an additional `ca.crt` key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1alpha3/destination_rule.gen.json
+++ b/networking/v1alpha3/destination_rule.gen.json
@@ -26,7 +26,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. This secret must exist in the namespace of the proxy using the certificates. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for client certificates along with `ca.crt` key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1533,16 +1533,16 @@ type ClientTLSSettings struct {
 	// Should be empty if mode is `ISTIO_MUTUAL`.
 	CaCertificates string `protobuf:"bytes,4,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// The name of the secret that holds the TLS certs for the
-	// client including the CA certificates. Secret must exist in the
-	// same namespace with the proxy using the certificates.
-	// The secret (of type `generic`)should contain the
+	// client including the CA certificates. This secret must exist in
+	// the namespace of the proxy using the certificates.
+	// A secret of type `Opaque` should contain the
 	// following keys and values: `key: <privateKey>`,
 	// `cert: <clientCert>`, `cacert: <CACertificate>`.
 	// Here CACertificate is used to verify the server certificate.
 	// For mutual TLS, `cacert: <CACertificate>` can be provided in the
 	// same secret or a separate secret named `<secret>-cacert`.
-	// Secret of type tls for client certificates along with
-	// ca.crt key for CA certificates is also supported.
+	// A secret of type `kubernetes.io/tls` for client certificates along
+	// with `ca.crt` key for CA certificates is also supported.
 	// Only one of client certificates and CA certificate
 	// or credentialName can be specified.
 	//

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1535,14 +1535,13 @@ type ClientTLSSettings struct {
 	// The name of the secret that holds the TLS certs for the
 	// client including the CA certificates. This secret must exist in
 	// the namespace of the proxy using the certificates.
-	// A secret of type `Opaque` should contain the
-	// following keys and values: `key: <privateKey>`,
-	// `cert: <clientCert>`, `cacert: <CACertificate>`.
+	// An Opaque secret should contain the following keys and values:
+	// `key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`.
 	// Here CACertificate is used to verify the server certificate.
 	// For mutual TLS, `cacert: <CACertificate>` can be provided in the
 	// same secret or a separate secret named `<secret>-cacert`.
-	// A secret of type `kubernetes.io/tls` for client certificates along
-	// with `ca.crt` key for CA certificates is also supported.
+	// A TLS secret for client certificates with an additional
+	// `ca.crt` key for CA certificates is also supported.
 	// Only one of client certificates and CA certificate
 	// or credentialName can be specified.
 	//

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1061,16 +1061,16 @@ No
 <td><code>string</code></td>
 <td>
 <p>The name of the secret that holds the TLS certs for the
-client including the CA certificates. Secret must exist in the
-same namespace with the proxy using the certificates.
-The secret (of type <code>generic</code>)should contain the
+client including the CA certificates. This secret must exist in
+the namespace of the proxy using the certificates.
+A secret of type <code>Opaque</code> should contain the
 following keys and values: <code>key: &lt;privateKey&gt;</code>,
 <code>cert: &lt;clientCert&gt;</code>, <code>cacert: &lt;CACertificate&gt;</code>.
 Here CACertificate is used to verify the server certificate.
 For mutual TLS, <code>cacert: &lt;CACertificate&gt;</code> can be provided in the
 same secret or a separate secret named <code>&lt;secret&gt;-cacert</code>.
-Secret of type tls for client certificates along with
-ca.crt key for CA certificates is also supported.
+A secret of type <code>kubernetes.io/tls</code> for client certificates along
+with <code>ca.crt</code> key for CA certificates is also supported.
 Only one of client certificates and CA certificate
 or credentialName can be specified.</p>
 <p><strong>NOTE:</strong> This field is applicable at sidecars only if

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1063,14 +1063,13 @@ No
 <p>The name of the secret that holds the TLS certs for the
 client including the CA certificates. This secret must exist in
 the namespace of the proxy using the certificates.
-A secret of type <code>Opaque</code> should contain the
-following keys and values: <code>key: &lt;privateKey&gt;</code>,
-<code>cert: &lt;clientCert&gt;</code>, <code>cacert: &lt;CACertificate&gt;</code>.
+An Opaque secret should contain the following keys and values:
+<code>key: &lt;privateKey&gt;</code>, <code>cert: &lt;clientCert&gt;</code>, <code>cacert: &lt;CACertificate&gt;</code>.
 Here CACertificate is used to verify the server certificate.
 For mutual TLS, <code>cacert: &lt;CACertificate&gt;</code> can be provided in the
 same secret or a separate secret named <code>&lt;secret&gt;-cacert</code>.
-A secret of type <code>kubernetes.io/tls</code> for client certificates along
-with <code>ca.crt</code> key for CA certificates is also supported.
+A TLS secret for client certificates with an additional
+<code>ca.crt</code> key for CA certificates is also supported.
 Only one of client certificates and CA certificate
 or credentialName can be specified.</p>
 <p><strong>NOTE:</strong> This field is applicable at sidecars only if

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -1093,16 +1093,16 @@ message ClientTLSSettings {
   string ca_certificates = 4;
 
   // The name of the secret that holds the TLS certs for the
-  // client including the CA certificates. Secret must exist in the
-  // same namespace with the proxy using the certificates.
-  // The secret (of type `generic`)should contain the
+  // client including the CA certificates. This secret must exist in
+  // the namespace of the proxy using the certificates.
+  // A secret of type `Opaque` should contain the
   // following keys and values: `key: <privateKey>`,
   // `cert: <clientCert>`, `cacert: <CACertificate>`.
   // Here CACertificate is used to verify the server certificate.
   // For mutual TLS, `cacert: <CACertificate>` can be provided in the
   // same secret or a separate secret named `<secret>-cacert`.
-  // Secret of type tls for client certificates along with
-  // ca.crt key for CA certificates is also supported.
+  // A secret of type `kubernetes.io/tls` for client certificates along
+  // with `ca.crt` key for CA certificates is also supported.
   // Only one of client certificates and CA certificate
   // or credentialName can be specified.
   //

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -1095,14 +1095,13 @@ message ClientTLSSettings {
   // The name of the secret that holds the TLS certs for the
   // client including the CA certificates. This secret must exist in
   // the namespace of the proxy using the certificates.
-  // A secret of type `Opaque` should contain the
-  // following keys and values: `key: <privateKey>`,
-  // `cert: <clientCert>`, `cacert: <CACertificate>`.
+  // An Opaque secret should contain the following keys and values:
+  // `key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`.
   // Here CACertificate is used to verify the server certificate.
   // For mutual TLS, `cacert: <CACertificate>` can be provided in the
   // same secret or a separate secret named `<secret>-cacert`.
-  // A secret of type `kubernetes.io/tls` for client certificates along
-  // with `ca.crt` key for CA certificates is also supported.
+  // A TLS secret for client certificates with an additional
+  // `ca.crt` key for CA certificates is also supported.
   // Only one of client certificates and CA certificate
   // or credentialName can be specified.
   //

--- a/networking/v1alpha3/gateway.gen.json
+++ b/networking/v1alpha3/gateway.gen.json
@@ -103,7 +103,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for server certificates along with `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. An Opaque secret should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A TLS secret for server certificates with an additional `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1alpha3/gateway.gen.json
+++ b/networking/v1alpha3/gateway.gen.json
@@ -103,7 +103,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. The secret (of type `generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for server certificates along with `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -1000,13 +1000,13 @@ type ServerTLSSettings struct {
 	CaCertificates string `protobuf:"bytes,5,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// For gateways running on Kubernetes, the name of the secret that
 	// holds the TLS certs including the CA certificates. Applicable
-	// only on Kubernetes. The secret (of type `generic`) should
+	// only on Kubernetes. A secret of type `Opaque` should
 	// contain the following keys and values: `key:
 	// <privateKey>` and `cert: <serverCert>`. For mutual TLS,
 	// `cacert: <CACertificate>` can be provided in the same secret or
 	// a separate secret named `<secret>-cacert`.
-	// Secret of type tls for server certificates along with
-	// ca.crt key for CA certificates is also supported.
+	// A secret of type `kubernetes.io/tls` for server certificates along
+	// with `ca.crt` key for CA certificates is also supported.
 	// Only one of server certificates and CA certificate
 	// or credentialName can be specified.
 	CredentialName string `protobuf:"bytes,10,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -1000,13 +1000,12 @@ type ServerTLSSettings struct {
 	CaCertificates string `protobuf:"bytes,5,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// For gateways running on Kubernetes, the name of the secret that
 	// holds the TLS certs including the CA certificates. Applicable
-	// only on Kubernetes. A secret of type `Opaque` should
-	// contain the following keys and values: `key:
-	// <privateKey>` and `cert: <serverCert>`. For mutual TLS,
-	// `cacert: <CACertificate>` can be provided in the same secret or
-	// a separate secret named `<secret>-cacert`.
-	// A secret of type `kubernetes.io/tls` for server certificates along
-	// with `ca.crt` key for CA certificates is also supported.
+	// only on Kubernetes. An Opaque secret should contain the following
+	// keys and values: `key: <privateKey>` and `cert: <serverCert>`.
+	// For mutual TLS, `cacert: <CACertificate>` can be provided in the
+	// same secret or a separate secret named `<secret>-cacert`.
+	// A TLS secret for server certificates with an additional `ca.crt`
+	// key for CA certificates is also supported.
 	// Only one of server certificates and CA certificate
 	// or credentialName can be specified.
 	CredentialName string `protobuf:"bytes,10,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -721,12 +721,12 @@ No
 <td>
 <p>For gateways running on Kubernetes, the name of the secret that
 holds the TLS certs including the CA certificates. Applicable
-only on Kubernetes. A secret of type <code>Opaque</code> should
-contain the following keys and values: <code>key: &lt;privateKey&gt;</code> and <code>cert: &lt;serverCert&gt;</code>. For mutual TLS,
-<code>cacert: &lt;CACertificate&gt;</code> can be provided in the same secret or
-a separate secret named <code>&lt;secret&gt;-cacert</code>.
-A secret of type <code>kubernetes.io/tls</code> for server certificates along
-with <code>ca.crt</code> key for CA certificates is also supported.
+only on Kubernetes. An Opaque secret should contain the following
+keys and values: <code>key: &lt;privateKey&gt;</code> and <code>cert: &lt;serverCert&gt;</code>.
+For mutual TLS, <code>cacert: &lt;CACertificate&gt;</code> can be provided in the
+same secret or a separate secret named <code>&lt;secret&gt;-cacert</code>.
+A TLS secret for server certificates with an additional <code>ca.crt</code>
+key for CA certificates is also supported.
 Only one of server certificates and CA certificate
 or credentialName can be specified.</p>
 

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -721,12 +721,12 @@ No
 <td>
 <p>For gateways running on Kubernetes, the name of the secret that
 holds the TLS certs including the CA certificates. Applicable
-only on Kubernetes. The secret (of type <code>generic</code>) should
+only on Kubernetes. A secret of type <code>Opaque</code> should
 contain the following keys and values: <code>key: &lt;privateKey&gt;</code> and <code>cert: &lt;serverCert&gt;</code>. For mutual TLS,
 <code>cacert: &lt;CACertificate&gt;</code> can be provided in the same secret or
 a separate secret named <code>&lt;secret&gt;-cacert</code>.
-Secret of type tls for server certificates along with
-ca.crt key for CA certificates is also supported.
+A secret of type <code>kubernetes.io/tls</code> for server certificates along
+with <code>ca.crt</code> key for CA certificates is also supported.
 Only one of server certificates and CA certificate
 or credentialName can be specified.</p>
 

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -672,13 +672,12 @@ message ServerTLSSettings {
 
   // For gateways running on Kubernetes, the name of the secret that
   // holds the TLS certs including the CA certificates. Applicable
-  // only on Kubernetes. A secret of type `Opaque` should
-  // contain the following keys and values: `key:
-  // <privateKey>` and `cert: <serverCert>`. For mutual TLS,
-  // `cacert: <CACertificate>` can be provided in the same secret or
-  // a separate secret named `<secret>-cacert`.
-  // A secret of type `kubernetes.io/tls` for server certificates along
-  // with `ca.crt` key for CA certificates is also supported.
+  // only on Kubernetes. An Opaque secret should contain the following
+  // keys and values: `key: <privateKey>` and `cert: <serverCert>`.
+  // For mutual TLS, `cacert: <CACertificate>` can be provided in the 
+  // same secret or a separate secret named `<secret>-cacert`.
+  // A TLS secret for server certificates with an additional `ca.crt`
+  // key for CA certificates is also supported.
   // Only one of server certificates and CA certificate
   // or credentialName can be specified.
   string credential_name = 10;

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -672,13 +672,13 @@ message ServerTLSSettings {
 
   // For gateways running on Kubernetes, the name of the secret that
   // holds the TLS certs including the CA certificates. Applicable
-  // only on Kubernetes. The secret (of type `generic`) should
+  // only on Kubernetes. A secret of type `Opaque` should
   // contain the following keys and values: `key:
   // <privateKey>` and `cert: <serverCert>`. For mutual TLS,
   // `cacert: <CACertificate>` can be provided in the same secret or
   // a separate secret named `<secret>-cacert`.
-  // Secret of type tls for server certificates along with
-  // ca.crt key for CA certificates is also supported.
+  // A secret of type `kubernetes.io/tls` for server certificates along
+  // with `ca.crt` key for CA certificates is also supported.
   // Only one of server certificates and CA certificate
   // or credentialName can be specified.
   string credential_name = 10;

--- a/networking/v1alpha3/sidecar.gen.json
+++ b/networking/v1alpha3/sidecar.gen.json
@@ -153,7 +153,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. The secret (of type `generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for server certificates along with `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1alpha3/sidecar.gen.json
+++ b/networking/v1alpha3/sidecar.gen.json
@@ -153,7 +153,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for server certificates along with `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. An Opaque secret should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A TLS secret for server certificates with an additional `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -26,7 +26,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. This secret must exist in the namespace of the proxy using the certificates. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for client certificates along with `ca.crt` key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. This secret must exist in the namespace of the proxy using the certificates. An Opaque secret should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A TLS secret for client certificates with an additional `ca.crt` key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1beta1/destination_rule.gen.json
+++ b/networking/v1beta1/destination_rule.gen.json
@@ -26,7 +26,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. Secret must exist in the same namespace with the proxy using the certificates. The secret (of type `generic`)should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for client certificates along with ca.crt key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
+            "description": "The name of the secret that holds the TLS certs for the client including the CA certificates. This secret must exist in the namespace of the proxy using the certificates. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e`, `cert: \u003cclientCert\u003e`, `cacert: \u003cCACertificate\u003e`. Here CACertificate is used to verify the server certificate. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for client certificates along with `ca.crt` key for CA certificates is also supported. Only one of client certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1484,14 +1484,13 @@ type ClientTLSSettings struct {
 	// The name of the secret that holds the TLS certs for the
 	// client including the CA certificates. This secret must exist in
 	// the namespace of the proxy using the certificates.
-	// A secret of type `Opaque` should contain the
-	// following keys and values: `key: <privateKey>`,
-	// `cert: <clientCert>`, `cacert: <CACertificate>`.
+	// An Opaque secret should contain the following keys and values:
+	// `key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`.
 	// Here CACertificate is used to verify the server certificate.
 	// For mutual TLS, `cacert: <CACertificate>` can be provided in the
 	// same secret or a separate secret named `<secret>-cacert`.
-	// A secret of type `kubernetes.io/tls` for client certificates along
-	// with `ca.crt` key for CA certificates is also supported.
+	// A TLS secret for client certificates with an additional
+	// `ca.crt` key for CA certificates is also supported.
 	// Only one of client certificates and CA certificate
 	// or credentialName can be specified.
 	//

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -1482,16 +1482,16 @@ type ClientTLSSettings struct {
 	// Should be empty if mode is `ISTIO_MUTUAL`.
 	CaCertificates string `protobuf:"bytes,4,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// The name of the secret that holds the TLS certs for the
-	// client including the CA certificates. Secret must exist in the
-	// same namespace with the proxy using the certificates.
-	// The secret (of type `generic`)should contain the
+	// client including the CA certificates. This secret must exist in
+	// the namespace of the proxy using the certificates.
+	// A secret of type `Opaque` should contain the
 	// following keys and values: `key: <privateKey>`,
 	// `cert: <clientCert>`, `cacert: <CACertificate>`.
 	// Here CACertificate is used to verify the server certificate.
 	// For mutual TLS, `cacert: <CACertificate>` can be provided in the
 	// same secret or a separate secret named `<secret>-cacert`.
-	// Secret of type tls for client certificates along with
-	// ca.crt key for CA certificates is also supported.
+	// A secret of type `kubernetes.io/tls` for client certificates along
+	// with `ca.crt` key for CA certificates is also supported.
 	// Only one of client certificates and CA certificate
 	// or credentialName can be specified.
 	//

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -1044,14 +1044,13 @@ message ClientTLSSettings {
   // The name of the secret that holds the TLS certs for the
   // client including the CA certificates. This secret must exist in
   // the namespace of the proxy using the certificates.
-  // A secret of type `Opaque` should contain the
-  // following keys and values: `key: <privateKey>`,
-  // `cert: <clientCert>`, `cacert: <CACertificate>`.
+  // An Opaque secret should contain the following keys and values:
+  // `key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`.
   // Here CACertificate is used to verify the server certificate.
   // For mutual TLS, `cacert: <CACertificate>` can be provided in the
   // same secret or a separate secret named `<secret>-cacert`.
-  // A secret of type `kubernetes.io/tls` for client certificates along
-  // with `ca.crt` key for CA certificates is also supported.
+  // A TLS secret for client certificates with an additional
+  // `ca.crt` key for CA certificates is also supported.
   // Only one of client certificates and CA certificate
   // or credentialName can be specified.
   //

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -1042,16 +1042,16 @@ message ClientTLSSettings {
   string ca_certificates = 4;
 
   // The name of the secret that holds the TLS certs for the
-  // client including the CA certificates. Secret must exist in the
-  // same namespace with the proxy using the certificates.
-  // The secret (of type `generic`)should contain the
+  // client including the CA certificates. This secret must exist in
+  // the namespace of the proxy using the certificates.
+  // A secret of type `Opaque` should contain the
   // following keys and values: `key: <privateKey>`,
   // `cert: <clientCert>`, `cacert: <CACertificate>`.
   // Here CACertificate is used to verify the server certificate.
   // For mutual TLS, `cacert: <CACertificate>` can be provided in the
   // same secret or a separate secret named `<secret>-cacert`.
-  // Secret of type tls for client certificates along with
-  // ca.crt key for CA certificates is also supported.
+  // A secret of type `kubernetes.io/tls` for client certificates along
+  // with `ca.crt` key for CA certificates is also supported.
   // Only one of client certificates and CA certificate
   // or credentialName can be specified.
   //

--- a/networking/v1beta1/gateway.gen.json
+++ b/networking/v1beta1/gateway.gen.json
@@ -103,7 +103,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for server certificates along with `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. An Opaque secret should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A TLS secret for server certificates with an additional `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1beta1/gateway.gen.json
+++ b/networking/v1beta1/gateway.gen.json
@@ -103,7 +103,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. The secret (of type `generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for server certificates along with `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1beta1/gateway.pb.go
+++ b/networking/v1beta1/gateway.pb.go
@@ -1000,13 +1000,13 @@ type ServerTLSSettings struct {
 	CaCertificates string `protobuf:"bytes,5,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// For gateways running on Kubernetes, the name of the secret that
 	// holds the TLS certs including the CA certificates. Applicable
-	// only on Kubernetes. The secret (of type `generic`) should
+	// only on Kubernetes. A secret of type `Opaque` should
 	// contain the following keys and values: `key:
 	// <privateKey>` and `cert: <serverCert>`. For mutual TLS,
 	// `cacert: <CACertificate>` can be provided in the same secret or
 	// a separate secret named `<secret>-cacert`.
-	// Secret of type tls for server certificates along with
-	// ca.crt key for CA certificates is also supported.
+	// A secret of type `kubernetes.io/tls` for server certificates along
+	// with `ca.crt` key for CA certificates is also supported.
 	// Only one of server certificates and CA certificate
 	// or credentialName can be specified.
 	CredentialName string `protobuf:"bytes,10,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`

--- a/networking/v1beta1/gateway.pb.go
+++ b/networking/v1beta1/gateway.pb.go
@@ -1000,13 +1000,12 @@ type ServerTLSSettings struct {
 	CaCertificates string `protobuf:"bytes,5,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	// For gateways running on Kubernetes, the name of the secret that
 	// holds the TLS certs including the CA certificates. Applicable
-	// only on Kubernetes. A secret of type `Opaque` should
-	// contain the following keys and values: `key:
-	// <privateKey>` and `cert: <serverCert>`. For mutual TLS,
-	// `cacert: <CACertificate>` can be provided in the same secret or
-	// a separate secret named `<secret>-cacert`.
-	// A secret of type `kubernetes.io/tls` for server certificates along
-	// with `ca.crt` key for CA certificates is also supported.
+	// only on Kubernetes. An Opaque secret should contain the following
+	// keys and values: `key: <privateKey>` and `cert: <serverCert>`.
+	// For mutual TLS, `cacert: <CACertificate>` can be provided in the
+	// same secret or a separate secret named `<secret>-cacert`.
+	// A TLS secret for server certificates with an additional `ca.crt`
+	// key for CA certificates is also supported.
 	// Only one of server certificates and CA certificate
 	// or credentialName can be specified.
 	CredentialName string `protobuf:"bytes,10,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`

--- a/networking/v1beta1/gateway.proto
+++ b/networking/v1beta1/gateway.proto
@@ -672,13 +672,12 @@ message ServerTLSSettings {
 
   // For gateways running on Kubernetes, the name of the secret that
   // holds the TLS certs including the CA certificates. Applicable
-  // only on Kubernetes. A secret of type `Opaque` should
-  // contain the following keys and values: `key:
-  // <privateKey>` and `cert: <serverCert>`. For mutual TLS,
-  // `cacert: <CACertificate>` can be provided in the same secret or
-  // a separate secret named `<secret>-cacert`.
-  // A secret of type `kubernetes.io/tls` for server certificates along
-  // with `ca.crt` key for CA certificates is also supported.
+  // only on Kubernetes. An Opaque secret should contain the following
+  // keys and values: `key: <privateKey>` and `cert: <serverCert>`.
+  // For mutual TLS, `cacert: <CACertificate>` can be provided in the 
+  // same secret or a separate secret named `<secret>-cacert`.
+  // A TLS secret for server certificates with an additional `ca.crt`
+  // key for CA certificates is also supported.
   // Only one of server certificates and CA certificate
   // or credentialName can be specified.
   string credential_name = 10;

--- a/networking/v1beta1/gateway.proto
+++ b/networking/v1beta1/gateway.proto
@@ -672,13 +672,13 @@ message ServerTLSSettings {
 
   // For gateways running on Kubernetes, the name of the secret that
   // holds the TLS certs including the CA certificates. Applicable
-  // only on Kubernetes. The secret (of type `generic`) should
+  // only on Kubernetes. A secret of type `Opaque` should
   // contain the following keys and values: `key:
   // <privateKey>` and `cert: <serverCert>`. For mutual TLS,
   // `cacert: <CACertificate>` can be provided in the same secret or
   // a separate secret named `<secret>-cacert`.
-  // Secret of type tls for server certificates along with
-  // ca.crt key for CA certificates is also supported.
+  // A secret of type `kubernetes.io/tls` for server certificates along
+  // with `ca.crt` key for CA certificates is also supported.
   // Only one of server certificates and CA certificate
   // or credentialName can be specified.
   string credential_name = 10;

--- a/networking/v1beta1/sidecar.gen.json
+++ b/networking/v1beta1/sidecar.gen.json
@@ -153,7 +153,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. The secret (of type `generic`) should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. Secret of type tls for server certificates along with ca.crt key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for server certificates along with `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {

--- a/networking/v1beta1/sidecar.gen.json
+++ b/networking/v1beta1/sidecar.gen.json
@@ -153,7 +153,7 @@
             "type": "string"
           },
           "credentialName": {
-            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. A secret of type `Opaque` should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A secret of type `kubernetes.io/tls` for server certificates along with `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
+            "description": "For gateways running on Kubernetes, the name of the secret that holds the TLS certs including the CA certificates. Applicable only on Kubernetes. An Opaque secret should contain the following keys and values: `key: \u003cprivateKey\u003e` and `cert: \u003cserverCert\u003e`. For mutual TLS, `cacert: \u003cCACertificate\u003e` can be provided in the same secret or a separate secret named `\u003csecret\u003e-cacert`. A TLS secret for server certificates with an additional `ca.crt` key for CA certificates is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
             "type": "string"
           },
           "subjectAltNames": {


### PR DESCRIPTION
small update to the docs for the `credentialName` field. Main change is referring to the secret as Opaque instead of `generic` (the kubectl subcommand).