### PR TITLE
Clarify that MeshConfig.localityLbSetting is enabled by default

### DIFF
--- a/mesh/v1alpha1/config.pb.go
+++ b/mesh/v1alpha1/config.pb.go
@@ -707,6 +707,7 @@ type MeshConfig struct {
 	// type.
 	RootNamespace string `protobuf:"bytes,34,opt,name=root_namespace,json=rootNamespace,proto3" json:"root_namespace,omitempty"`
 	// Locality based load balancing distribution or failover settings.
+	// If unspecified, locality based load balancing will be enabled by default.
 	LocalityLbSetting *v1alpha3.LocalityLoadBalancerSetting `protobuf:"bytes,35,opt,name=locality_lb_setting,json=localityLbSetting,proto3" json:"locality_lb_setting,omitempty"`
 	// Configures DNS refresh rate for Envoy clusters of type `STRICT_DNS`
 	// Default refresh rate is `60s`.

--- a/mesh/v1alpha1/config.pb.go
+++ b/mesh/v1alpha1/config.pb.go
@@ -708,6 +708,8 @@ type MeshConfig struct {
 	RootNamespace string `protobuf:"bytes,34,opt,name=root_namespace,json=rootNamespace,proto3" json:"root_namespace,omitempty"`
 	// Locality based load balancing distribution or failover settings.
 	// If unspecified, locality based load balancing will be enabled by default.
+	// However, this requires outlierDetection to actually take effect for a particular
+	// service, see https://istio.io/latest/docs/tasks/traffic-management/locality-load-balancing/failover/
 	LocalityLbSetting *v1alpha3.LocalityLoadBalancerSetting `protobuf:"bytes,35,opt,name=locality_lb_setting,json=localityLbSetting,proto3" json:"locality_lb_setting,omitempty"`
 	// Configures DNS refresh rate for Envoy clusters of type `STRICT_DNS`
 	// Default refresh rate is `60s`.

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -303,6 +303,8 @@ message MeshConfig {
 
   // Locality based load balancing distribution or failover settings.
   // If unspecified, locality based load balancing will be enabled by default.
+  // However, this requires outlierDetection to actually take effect for a particular
+  // service, see https://istio.io/latest/docs/tasks/traffic-management/locality-load-balancing/failover/
   istio.networking.v1alpha3.LocalityLoadBalancerSetting locality_lb_setting = 35;
 
   // Configures DNS refresh rate for Envoy clusters of type `STRICT_DNS`

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -302,6 +302,7 @@ message MeshConfig {
   string root_namespace = 34;
 
   // Locality based load balancing distribution or failover settings.
+  // If unspecified, locality based load balancing will be enabled by default.
   istio.networking.v1alpha3.LocalityLoadBalancerSetting locality_lb_setting = 35;
 
   // Configures DNS refresh rate for Envoy clusters of type `STRICT_DNS`

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -424,7 +424,9 @@ No
 <td><code><a href="https://istio.io/docs/reference/config/networking/destination-rule.html#LocalityLoadBalancerSetting">LocalityLoadBalancerSetting</a></code></td>
 <td>
 <p>Locality based load balancing distribution or failover settings.
-If unspecified, locality based load balancing will be enabled by default.</p>
+If unspecified, locality based load balancing will be enabled by default.
+However, this requires outlierDetection to actually take effect for a particular
+service, see <a href="https://istio.io/latest/docs/tasks/traffic-management/locality-load-balancing/failover/">https://istio.io/latest/docs/tasks/traffic-management/locality-load-balancing/failover/</a></p>
 
 </td>
 <td>

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -423,7 +423,8 @@ No
 <td><code>localityLbSetting</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/networking/destination-rule.html#LocalityLoadBalancerSetting">LocalityLoadBalancerSetting</a></code></td>
 <td>
-<p>Locality based load balancing distribution or failover settings.</p>
+<p>Locality based load balancing distribution or failover settings.
+If unspecified, locality based load balancing will be enabled by default.</p>
 
 </td>
 <td>


### PR DESCRIPTION
As per : https://github.com/istio/istio/blob/master/pkg/config/mesh/mesh.go#L92 this is enabled by default.
Better to clarify this in docs, because k8s has this disabled by default, and caused us come confusions while we started using this. Ideally this should have been disabled by default.