### PR TITLE
Add gateway.istio.io/controller-version annotation

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -132,6 +132,18 @@ var (
 		},
 	}
 
+	GatewayControllerVersion = Instance {
+		Name:          "gateway.istio.io/controller-version",
+		Description:   "A version added to the Gateway by the controller "+
+                        "specifying the `controller version`.",
+		FeatureStatus: Alpha,
+		Hidden:        true,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Any,
+		},
+	}
+
 	InjectTemplates = Instance {
 		Name:          "inject.istio.io/templates",
 		Description:   "The name of the inject template(s) to use, as a comma "+
@@ -787,6 +799,7 @@ func AllResourceAnnotations() []*Instance {
 		&AlphaIdentity,
 		&AlphaKubernetesServiceAccounts,
 		&GalleyAnalyzeSuppress,
+		&GatewayControllerVersion,
 		&InjectTemplates,
 		&OperatorInstallChartOwner,
 		&OperatorInstallOwnerGeneration,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -40,6 +40,8 @@ Istio supports to control its behavior.
 			
 		
 			
+		
+			
 				
 					<tr>
 				

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -507,7 +507,7 @@ annotations:
 
   - name: gateway.istio.io/controller-version
     featureStatus: Alpha
-    description:  A version added to the Gateway by the controller specifying the "controller version".
+    description: A version added to the Gateway by the controller specifying the "controller version".
     deprecated: false
     hidden: true
     resources:

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -347,7 +347,7 @@ annotations:
     hidden: false
     resources:
       - Pod
-  
+
   - name: traffic.sidecar.istio.io/includeOutboundPorts
     featureStatus: Alpha
     description: A comma separated list of outbound ports for which traffic is to be
@@ -504,3 +504,11 @@ annotations:
     hidden: false
     resources:
       - Namespace
+
+  - name: gateway.istio.io/controller-version
+    featureStatus: Alpha
+    description:  A version added to the Gateway by the controller specifying the "controller version".
+    deprecated: false
+    hidden: true
+    resources:
+      - Any


### PR DESCRIPTION
Introduced in https://github.com/istio/istio/pull/44174 and causes a `istioctl analyze` `Unknown Annotation` errors:
```
"Warning [IST0108] (Deployment default/bookinfo-gateway-istio) Unknown annotation: gateway.istio.io/controller-version
Warning [IST0108] (Pod default/bookinfo-gateway-istio-7f4d8dd7f6-cvg9d) Unknown annotation: gateway.istio.io/controller-version
Warning [IST0108] (Service default/bookinfo-gateway-istio) Unknown annotation: gateway.istio.io/controller-version"
```

I believe this should fix the issue, but this is my first time working with annotations. I believe we would keep this hidden and it seems most annotations are Alpha.