### PR TITLE
docs: fix wasm plugin traffic selector docs

### DIFF
--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -746,7 +746,7 @@ type WasmPlugin_TrafficSelector struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Criteria for selecting traffic by their direction.
-	// Note that CLIENT and SERVER are analogous to INBOUND and OUTBOUND,
+	// Note that CLIENT and SERVER are analogous to OUTBOUND and INBOUND,
 	// respectively.
 	// For the gateway, the field should be CLIENT or CLIENT_AND_SERVER.
 	// If not specified, the default value is CLIENT_AND_SERVER.

--- a/extensions/v1alpha1/wasm.pb.html
+++ b/extensions/v1alpha1/wasm.pb.html
@@ -441,7 +441,7 @@ traffic will be selected.</p>
 <td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#WorkloadMode">WorkloadMode</a></code></td>
 <td>
 <p>Criteria for selecting traffic by their direction.
-Note that CLIENT and SERVER are analogous to INBOUND and OUTBOUND,
+Note that CLIENT and SERVER are analogous to OUTBOUND and INBOUND,
 respectively.
 For the gateway, the field should be CLIENT or CLIENT_AND_SERVER.
 If not specified, the default value is CLIENT_AND_SERVER.</p>

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -321,7 +321,7 @@ message WasmPlugin {
   // traffic will be selected.
   message TrafficSelector {
     // Criteria for selecting traffic by their direction.
-    // Note that CLIENT and SERVER are analogous to INBOUND and OUTBOUND,
+    // Note that CLIENT and SERVER are analogous to OUTBOUND and INBOUND,
     // respectively.
     // For the gateway, the field should be CLIENT or CLIENT_AND_SERVER.
     // If not specified, the default value is CLIENT_AND_SERVER.


### PR DESCRIPTION
The docs incorrectly mentioned CLIENT as INBOUND and SERVER as OUTBOUND in the traffic selector field docs in WASM Plugin. This PR changes the order of OUTBOUND and INBOUND terms to fix this confusion. 

The `WorkloadMode` docs correctly mention the CLIENT as OUTBOUND and SERVER as INBOUND: https://istio.io/latest/docs/reference/config/type/workload-selector/#WorkloadMode