### PR TITLE
Add authz dry-run example

### DIFF
--- a/security/v1/authorization_policy.pb.go
+++ b/security/v1/authorization_policy.pb.go
@@ -220,7 +220,8 @@
 //      version: v1
 // ```
 //
-// The following example set up an authorization policy using annotation `istio.io/dry-run` to dry-run the policy without actually enforcing it.
+// The following example shows you how to set up an authorization policy using an [experimental annotation](https://istio.io/latest/docs/reference/config/annotations/)
+// `istio.io/dry-run` to dry-run the policy without actually enforcing it.
 //
 // The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
 // This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
@@ -230,7 +231,7 @@
 // apiVersion: security.istio.io/v1
 // kind: AuthorizationPolicy
 // metadata:
-//   name: deny-path-headers
+//   name: dry-run-example
 //   annotations:
 //     "istio.io/dry-run": "true"
 // spec:

--- a/security/v1/authorization_policy.pb.go
+++ b/security/v1/authorization_policy.pb.go
@@ -219,6 +219,30 @@
 //    matchLabels:
 //      version: v1
 // ```
+//
+// The following example set up an authorization policy using annotation `istio.io/dry-run` to dry-run the policy without actually enforcing it.
+//
+// The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
+// This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
+// For more information, see [dry-run tasks](https://istio.io/latest/docs/tasks/security/authorization/authz-dry-run/).
+//
+// ```yaml
+// apiVersion: security.istio.io/v1
+// kind: AuthorizationPolicy
+// metadata:
+//   name: deny-path-headers
+//   annotations:
+//     "istio.io/dry-run": "true"
+// spec:
+//   selector:
+//     matchLabels:
+//       app: httpbin
+//   action: DENY
+//   rules:
+//   - to:
+//     - operation:
+//         paths: ["/headers"]
+// ```
 
 package v1
 

--- a/security/v1/authorization_policy.pb.html
+++ b/security/v1/authorization_policy.pb.html
@@ -173,14 +173,15 @@ spec:
    matchLabels:
      version: v1
 </code></pre>
-<p>The following example set up an authorization policy using annotation <code>istio.io/dry-run</code> to dry-run the policy without actually enforcing it.</p>
+<p>The following example shows you how to set up an authorization policy using an <a href="https://istio.io/latest/docs/reference/config/annotations/">experimental annotation</a>
+<code>istio.io/dry-run</code> to dry-run the policy without actually enforcing it.</p>
 <p>The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
 This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
 For more information, see <a href="https://istio.io/latest/docs/tasks/security/authorization/authz-dry-run/">dry-run tasks</a>.</p>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: deny-path-headers
+  name: dry-run-example
   annotations:
     &quot;istio.io/dry-run&quot;: &quot;true&quot;
 spec:

--- a/security/v1/authorization_policy.pb.html
+++ b/security/v1/authorization_policy.pb.html
@@ -173,6 +173,26 @@ spec:
    matchLabels:
      version: v1
 </code></pre>
+<p>The following example set up an authorization policy using annotation <code>istio.io/dry-run</code> to dry-run the policy without actually enforcing it.</p>
+<p>The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
+This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
+For more information, see <a href="https://istio.io/latest/docs/tasks/security/authorization/authz-dry-run/">dry-run tasks</a>.</p>
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-path-headers
+  annotations:
+    &quot;istio.io/dry-run&quot;: &quot;true&quot;
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: [&quot;/headers&quot;]
+</code></pre>
 
 <h2 id="AuthorizationPolicy">AuthorizationPolicy</h2>
 <section>

--- a/security/v1/authorization_policy.proto
+++ b/security/v1/authorization_policy.proto
@@ -217,6 +217,30 @@ import "type/v1beta1/selector.proto";
 //    matchLabels:
 //      version: v1
 // ```
+//
+// The following example set up an authorization policy using annotation `istio.io/dry-run` to dry-run the policy without actually enforcing it.
+//
+// The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
+// This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
+// For more information, see [dry-run tasks](https://istio.io/latest/docs/tasks/security/authorization/authz-dry-run/).
+//
+// ```yaml
+// apiVersion: security.istio.io/v1
+// kind: AuthorizationPolicy
+// metadata:
+//   name: deny-path-headers
+//   annotations:
+//     "istio.io/dry-run": "true"
+// spec:
+//   selector:
+//     matchLabels:
+//       app: httpbin
+//   action: DENY
+//   rules:
+//   - to:
+//     - operation:
+//         paths: ["/headers"]
+// ```
 package istio.security.v1;
 
 option go_package="istio.io/api/security/v1";

--- a/security/v1/authorization_policy.proto
+++ b/security/v1/authorization_policy.proto
@@ -218,7 +218,8 @@ import "type/v1beta1/selector.proto";
 //      version: v1
 // ```
 //
-// The following example set up an authorization policy using annotation `istio.io/dry-run` to dry-run the policy without actually enforcing it.
+// The following example shows you how to set up an authorization policy using an [experimental annotation](https://istio.io/latest/docs/reference/config/annotations/)
+// `istio.io/dry-run` to dry-run the policy without actually enforcing it.
 //
 // The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
 // This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
@@ -228,7 +229,7 @@ import "type/v1beta1/selector.proto";
 // apiVersion: security.istio.io/v1
 // kind: AuthorizationPolicy
 // metadata:
-//   name: deny-path-headers
+//   name: dry-run-example
 //   annotations:
 //     "istio.io/dry-run": "true"
 // spec:

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -220,7 +220,8 @@
 //      version: v1
 // ```
 //
-// The following example set up an authorization policy using annotation `istio.io/dry-run` to dry-run the policy without actually enforcing it.
+// The following example shows you how to set up an authorization policy using an [experimental annotation](https://istio.io/latest/docs/reference/config/annotations/)
+// `istio.io/dry-run` to dry-run the policy without actually enforcing it.
 //
 // The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
 // This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
@@ -230,7 +231,7 @@
 // apiVersion: security.istio.io/v1beta1
 // kind: AuthorizationPolicy
 // metadata:
-//   name: deny-path-headers
+//   name: dry-run-example
 //   annotations:
 //     "istio.io/dry-run": "true"
 // spec:

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -219,6 +219,30 @@
 //    matchLabels:
 //      version: v1
 // ```
+//
+// The following example set up an authorization policy using annotation `istio.io/dry-run` to dry-run the policy without actually enforcing it.
+//
+// The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
+// This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
+// For more information, see [dry-run tasks](https://istio.io/latest/docs/tasks/security/authorization/authz-dry-run/).
+//
+// ```yaml
+// apiVersion: security.istio.io/v1beta1
+// kind: AuthorizationPolicy
+// metadata:
+//   name: deny-path-headers
+//   annotations:
+//     "istio.io/dry-run": "true"
+// spec:
+//   selector:
+//     matchLabels:
+//       app: httpbin
+//   action: DENY
+//   rules:
+//   - to:
+//     - operation:
+//         paths: ["/headers"]
+// ```
 
 package v1beta1
 

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -173,14 +173,15 @@ spec:
    matchLabels:
      version: v1
 </code></pre>
-<p>The following example set up an authorization policy using annotation <code>istio.io/dry-run</code> to dry-run the policy without actually enforcing it.</p>
+<p>The following example shows you how to set up an authorization policy using an <a href="https://istio.io/latest/docs/reference/config/annotations/">experimental annotation</a>
+<code>istio.io/dry-run</code> to dry-run the policy without actually enforcing it.</p>
 <p>The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
 This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
 For more information, see <a href="https://istio.io/latest/docs/tasks/security/authorization/authz-dry-run/">dry-run tasks</a>.</p>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: deny-path-headers
+  name: dry-run-example
   annotations:
     &quot;istio.io/dry-run&quot;: &quot;true&quot;
 spec:

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -173,6 +173,26 @@ spec:
    matchLabels:
      version: v1
 </code></pre>
+<p>The following example set up an authorization policy using annotation <code>istio.io/dry-run</code> to dry-run the policy without actually enforcing it.</p>
+<p>The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
+This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
+For more information, see <a href="https://istio.io/latest/docs/tasks/security/authorization/authz-dry-run/">dry-run tasks</a>.</p>
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-path-headers
+  annotations:
+    &quot;istio.io/dry-run&quot;: &quot;true&quot;
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: [&quot;/headers&quot;]
+</code></pre>
 
 <h2 id="AuthorizationPolicy">AuthorizationPolicy</h2>
 <section>

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -218,7 +218,8 @@ import "type/v1beta1/selector.proto";
 //      version: v1
 // ```
 //
-// The following example set up an authorization policy using annotation `istio.io/dry-run` to dry-run the policy without actually enforcing it.
+// The following example shows you how to set up an authorization policy using an [experimental annotation](https://istio.io/latest/docs/reference/config/annotations/)
+// `istio.io/dry-run` to dry-run the policy without actually enforcing it.
 //
 // The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
 // This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
@@ -228,7 +229,7 @@ import "type/v1beta1/selector.proto";
 // apiVersion: security.istio.io/v1beta1
 // kind: AuthorizationPolicy
 // metadata:
-//   name: deny-path-headers
+//   name: dry-run-example
 //   annotations:
 //     "istio.io/dry-run": "true"
 // spec:

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -217,6 +217,30 @@ import "type/v1beta1/selector.proto";
 //    matchLabels:
 //      version: v1
 // ```
+//
+// The following example set up an authorization policy using annotation `istio.io/dry-run` to dry-run the policy without actually enforcing it.
+//
+// The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to the production traffic.
+// This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
+// For more information, see [dry-run tasks](https://istio.io/latest/docs/tasks/security/authorization/authz-dry-run/).
+//
+// ```yaml
+// apiVersion: security.istio.io/v1beta1
+// kind: AuthorizationPolicy
+// metadata:
+//   name: deny-path-headers
+//   annotations:
+//     "istio.io/dry-run": "true"
+// spec:
+//   selector:
+//     matchLabels:
+//       app: httpbin
+//   action: DENY
+//   rules:
+//   - to:
+//     - operation:
+//         paths: ["/headers"]
+// ```
 package istio.security.v1beta1;
 
 option go_package="istio.io/api/security/v1beta1";


### PR DESCRIPTION
dry-run is a very useful feature, but there is no mention in the authz reference document, so add an example.