### PR TITLE
Replace 1.2.3.4 with RFC5737 address (#2774)

### DIFF
--- a/security/v1/authorization_policy.pb.go
+++ b/security/v1/authorization_policy.pb.go
@@ -540,12 +540,12 @@ func (x *Rule) GetWhen() []*Condition {
 // ANDed together.
 //
 // For example, the following source matches if the principal is "admin" or "dev"
-// and the namespace is "prod" or "test" and the ip is not "1.2.3.4".
+// and the namespace is "prod" or "test" and the ip is not "203.0.113.4".
 //
 // ```yaml
 // principals: ["admin", "dev"]
 // namespaces: ["prod", "test"]
-// notIpBlocks: ["1.2.3.4"]
+// notIpBlocks: ["203.0.113.4"]
 // ```
 type Source struct {
 	state         protoimpl.MessageState
@@ -575,8 +575,8 @@ type Source struct {
 	Namespaces []string `protobuf:"bytes,3,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
 	// Optional. A list of negative match of namespaces.
 	NotNamespaces []string `protobuf:"bytes,7,rep,name=not_namespaces,json=notNamespaces,proto3" json:"not_namespaces,omitempty"`
-	// Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "1.2.3.4") and
-	// CIDR (e.g. "1.2.3.0/24") are supported. This is the same as the `source.ip` attribute.
+	// Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "203.0.113.4") and
+	// CIDR (e.g. "203.0.113.0/24") are supported. This is the same as the `source.ip` attribute.
 	//
 	// If not set, any IP is allowed.
 	IpBlocks []string `protobuf:"bytes,4,rep,name=ip_blocks,json=ipBlocks,proto3" json:"ip_blocks,omitempty"`
@@ -586,7 +586,7 @@ type Source struct {
 	// To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig
 	// when you install Istio or using an annotation on the ingress gateway.  See the documentation here:
 	// [Configuring Gateway Network Topology](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/).
-	// Single IP (e.g. "1.2.3.4") and CIDR (e.g. "1.2.3.0/24") are supported.
+	// Single IP (e.g. "203.0.113.4") and CIDR (e.g. "203.0.113.0/24") are supported.
 	// This is the same as the `remote.ip` attribute.
 	//
 	// If not set, any IP is allowed.

--- a/security/v1/authorization_policy.pb.html
+++ b/security/v1/authorization_policy.pb.html
@@ -307,10 +307,10 @@ No
 <p>Source specifies the source identities of a request. Fields in the source are
 ANDed together.</p>
 <p>For example, the following source matches if the principal is &ldquo;admin&rdquo; or &ldquo;dev&rdquo;
-and the namespace is &ldquo;prod&rdquo; or &ldquo;test&rdquo; and the ip is not &ldquo;1.2.3.4&rdquo;.</p>
+and the namespace is &ldquo;prod&rdquo; or &ldquo;test&rdquo; and the ip is not &ldquo;203.0.113.4&rdquo;.</p>
 <pre><code class="language-yaml">principals: [&quot;admin&quot;, &quot;dev&quot;]
 namespaces: [&quot;prod&quot;, &quot;test&quot;]
-notIpBlocks: [&quot;1.2.3.4&quot;]
+notIpBlocks: [&quot;203.0.113.4&quot;]
 </code></pre>
 
 <table class="message-fields">
@@ -401,8 +401,8 @@ No
 <td><code>ipBlocks</code></td>
 <td><code>string[]</code></td>
 <td>
-<p>Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. &ldquo;1.2.3.4&rdquo;) and
-CIDR (e.g. &ldquo;1.2.3.0/24&rdquo;) are supported. This is the same as the <code>source.ip</code> attribute.</p>
+<p>Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. &ldquo;203.0.113.4&rdquo;) and
+CIDR (e.g. &ldquo;203.0.113.0/24&rdquo;) are supported. This is the same as the <code>source.ip</code> attribute.</p>
 <p>If not set, any IP is allowed.</p>
 
 </td>
@@ -429,7 +429,7 @@ No
 To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig
 when you install Istio or using an annotation on the ingress gateway.  See the documentation here:
 <a href="https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/">Configuring Gateway Network Topology</a>.
-Single IP (e.g. &ldquo;1.2.3.4&rdquo;) and CIDR (e.g. &ldquo;1.2.3.0/24&rdquo;) are supported.
+Single IP (e.g. &ldquo;203.0.113.4&rdquo;) and CIDR (e.g. &ldquo;203.0.113.0/24&rdquo;) are supported.
 This is the same as the <code>remote.ip</code> attribute.</p>
 <p>If not set, any IP is allowed.</p>
 

--- a/security/v1/authorization_policy.proto
+++ b/security/v1/authorization_policy.proto
@@ -365,12 +365,12 @@ message Rule {
 // ANDed together.
 //
 // For example, the following source matches if the principal is "admin" or "dev"
-// and the namespace is "prod" or "test" and the ip is not "1.2.3.4".
+// and the namespace is "prod" or "test" and the ip is not "203.0.113.4".
 //
 // ```yaml
 // principals: ["admin", "dev"]
 // namespaces: ["prod", "test"]
-// notIpBlocks: ["1.2.3.4"]
+// notIpBlocks: ["203.0.113.4"]
 // ```
 message Source {
   // Optional. A list of peer identities derived from the peer certificate. The peer identity is in the format of
@@ -402,8 +402,8 @@ message Source {
   // Optional. A list of negative match of namespaces.
   repeated string not_namespaces = 7;
 
-  // Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "1.2.3.4") and
-  // CIDR (e.g. "1.2.3.0/24") are supported. This is the same as the `source.ip` attribute.
+  // Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "203.0.113.4") and
+  // CIDR (e.g. "203.0.113.0/24") are supported. This is the same as the `source.ip` attribute.
   //
   // If not set, any IP is allowed.
   repeated string ip_blocks = 4;
@@ -415,7 +415,7 @@ message Source {
   // To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig
   // when you install Istio or using an annotation on the ingress gateway.  See the documentation here:
   // [Configuring Gateway Network Topology](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/).
-  // Single IP (e.g. "1.2.3.4") and CIDR (e.g. "1.2.3.0/24") are supported.
+  // Single IP (e.g. "203.0.113.4") and CIDR (e.g. "203.0.113.0/24") are supported.
   // This is the same as the `remote.ip` attribute.
   //
   // If not set, any IP is allowed.

--- a/security/v1beta1/authorization_policy.gen.json
+++ b/security/v1beta1/authorization_policy.gen.json
@@ -250,7 +250,7 @@
             }
           },
           "ipBlocks": {
-            "description": "Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. \"1.2.3.4\") and CIDR (e.g. \"1.2.3.0/24\") are supported. This is the same as the `source.ip` attribute.",
+            "description": "Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. \"203.0.113.4\") and CIDR (e.g. \"203.0.113.0/24\") are supported. This is the same as the `source.ip` attribute.",
             "type": "array",
             "items": {
               "type": "string"
@@ -264,7 +264,7 @@
             }
           },
           "remoteIpBlocks": {
-            "description": "Optional. A list of IP blocks, populated from X-Forwarded-For header or proxy protocol. To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig when you install Istio or using an annotation on the ingress gateway. See the documentation here: [Configuring Gateway Network Topology](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/). Single IP (e.g. \"1.2.3.4\") and CIDR (e.g. \"1.2.3.0/24\") are supported. This is the same as the `remote.ip` attribute.",
+            "description": "Optional. A list of IP blocks, populated from X-Forwarded-For header or proxy protocol. To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig when you install Istio or using an annotation on the ingress gateway. See the documentation here: [Configuring Gateway Network Topology](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/). Single IP (e.g. \"203.0.113.4\") and CIDR (e.g. \"203.0.113.0/24\") are supported. This is the same as the `remote.ip` attribute.",
             "type": "array",
             "items": {
               "type": "string"

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -541,12 +541,12 @@ func (x *Rule) GetWhen() []*Condition {
 // ANDed together.
 //
 // For example, the following source matches if the principal is "admin" or "dev"
-// and the namespace is "prod" or "test" and the ip is not "1.2.3.4".
+// and the namespace is "prod" or "test" and the ip is not "203.0.113.4".
 //
 // ```yaml
 // principals: ["admin", "dev"]
 // namespaces: ["prod", "test"]
-// notIpBlocks: ["1.2.3.4"]
+// notIpBlocks: ["203.0.113.4"]
 // ```
 type Source struct {
 	state         protoimpl.MessageState
@@ -576,8 +576,8 @@ type Source struct {
 	Namespaces []string `protobuf:"bytes,3,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
 	// Optional. A list of negative match of namespaces.
 	NotNamespaces []string `protobuf:"bytes,7,rep,name=not_namespaces,json=notNamespaces,proto3" json:"not_namespaces,omitempty"`
-	// Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "1.2.3.4") and
-	// CIDR (e.g. "1.2.3.0/24") are supported. This is the same as the `source.ip` attribute.
+	// Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "203.0.113.4") and
+	// CIDR (e.g. "203.0.113.0/24") are supported. This is the same as the `source.ip` attribute.
 	//
 	// If not set, any IP is allowed.
 	IpBlocks []string `protobuf:"bytes,4,rep,name=ip_blocks,json=ipBlocks,proto3" json:"ip_blocks,omitempty"`
@@ -587,7 +587,7 @@ type Source struct {
 	// To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig
 	// when you install Istio or using an annotation on the ingress gateway.  See the documentation here:
 	// [Configuring Gateway Network Topology](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/).
-	// Single IP (e.g. "1.2.3.4") and CIDR (e.g. "1.2.3.0/24") are supported.
+	// Single IP (e.g. "203.0.113.4") and CIDR (e.g. "203.0.113.0/24") are supported.
 	// This is the same as the `remote.ip` attribute.
 	//
 	// If not set, any IP is allowed.

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -307,10 +307,10 @@ No
 <p>Source specifies the source identities of a request. Fields in the source are
 ANDed together.</p>
 <p>For example, the following source matches if the principal is &ldquo;admin&rdquo; or &ldquo;dev&rdquo;
-and the namespace is &ldquo;prod&rdquo; or &ldquo;test&rdquo; and the ip is not &ldquo;1.2.3.4&rdquo;.</p>
+and the namespace is &ldquo;prod&rdquo; or &ldquo;test&rdquo; and the ip is not &ldquo;203.0.113.4&rdquo;.</p>
 <pre><code class="language-yaml">principals: [&quot;admin&quot;, &quot;dev&quot;]
 namespaces: [&quot;prod&quot;, &quot;test&quot;]
-notIpBlocks: [&quot;1.2.3.4&quot;]
+notIpBlocks: [&quot;203.0.113.4&quot;]
 </code></pre>
 
 <table class="message-fields">
@@ -401,8 +401,8 @@ No
 <td><code>ipBlocks</code></td>
 <td><code>string[]</code></td>
 <td>
-<p>Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. &ldquo;1.2.3.4&rdquo;) and
-CIDR (e.g. &ldquo;1.2.3.0/24&rdquo;) are supported. This is the same as the <code>source.ip</code> attribute.</p>
+<p>Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. &ldquo;203.0.113.4&rdquo;) and
+CIDR (e.g. &ldquo;203.0.113.0/24&rdquo;) are supported. This is the same as the <code>source.ip</code> attribute.</p>
 <p>If not set, any IP is allowed.</p>
 
 </td>
@@ -429,7 +429,7 @@ No
 To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig
 when you install Istio or using an annotation on the ingress gateway.  See the documentation here:
 <a href="https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/">Configuring Gateway Network Topology</a>.
-Single IP (e.g. &ldquo;1.2.3.4&rdquo;) and CIDR (e.g. &ldquo;1.2.3.0/24&rdquo;) are supported.
+Single IP (e.g. &ldquo;203.0.113.4&rdquo;) and CIDR (e.g. &ldquo;203.0.113.0/24&rdquo;) are supported.
 This is the same as the <code>remote.ip</code> attribute.</p>
 <p>If not set, any IP is allowed.</p>
 

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -366,12 +366,12 @@ message Rule {
 // ANDed together.
 //
 // For example, the following source matches if the principal is "admin" or "dev"
-// and the namespace is "prod" or "test" and the ip is not "1.2.3.4".
+// and the namespace is "prod" or "test" and the ip is not "203.0.113.4".
 //
 // ```yaml
 // principals: ["admin", "dev"]
 // namespaces: ["prod", "test"]
-// notIpBlocks: ["1.2.3.4"]
+// notIpBlocks: ["203.0.113.4"]
 // ```
 message Source {
   // Optional. A list of peer identities derived from the peer certificate. The peer identity is in the format of
@@ -403,8 +403,8 @@ message Source {
   // Optional. A list of negative match of namespaces.
   repeated string not_namespaces = 7;
 
-  // Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "1.2.3.4") and
-  // CIDR (e.g. "1.2.3.0/24") are supported. This is the same as the `source.ip` attribute.
+  // Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "203.0.113.4") and
+  // CIDR (e.g. "203.0.113.0/24") are supported. This is the same as the `source.ip` attribute.
   //
   // If not set, any IP is allowed.
   repeated string ip_blocks = 4;
@@ -416,7 +416,7 @@ message Source {
   // To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig
   // when you install Istio or using an annotation on the ingress gateway.  See the documentation here:
   // [Configuring Gateway Network Topology](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/).
-  // Single IP (e.g. "1.2.3.4") and CIDR (e.g. "1.2.3.0/24") are supported.
+  // Single IP (e.g. "203.0.113.4") and CIDR (e.g. "203.0.113.0/24") are supported.
   // This is the same as the `remote.ip` attribute.
   //
   // If not set, any IP is allowed.


### PR DESCRIPTION
This fixes #2774.

1.2.3.4 currently belongs to APNIC Debogon Project, which means that it is currently unallocated but may be allocated in the future. For documentation purposes RFC5737 allocates 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2), and 203.0.113.0/24 (TEST-NET-3). Documentation in proto files should use one of these addresses instead.
