### PR TITLE
Fix doc link for istio.operator.v1alpha1 helm options pointing at v1.5 docs

### DIFF
--- a/operator/v1alpha1/istio.operator.v1alpha1.pb.html
+++ b/operator/v1alpha1/istio.operator.v1alpha1.pb.html
@@ -163,7 +163,7 @@ No
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#struct">Struct</a></code></td>
 <td>
 <p>Overrides for default <code>values.yaml</code>. This is a validated pass-through to Helm templates.
-See the <a href="https://istio.io/v1.5/docs/reference/config/installation-options/">Helm installation options</a> for schema details.
+See the <a href="https://istio.io/docs/reference/config/installation-options/">Helm installation options</a> for schema details.
 Anything that is available in <code>IstioOperatorSpec</code> should be set above rather than using the passthrough. This
 includes Kubernetes resource settings for components in <code>KubernetesResourcesSpec</code>.</p>
 

--- a/operator/v1alpha1/operator.pb.go
+++ b/operator/v1alpha1/operator.pb.go
@@ -196,7 +196,7 @@ type IstioOperatorSpec struct {
 	// Deprecated: Marked as deprecated in operator/v1alpha1/operator.proto.
 	AddonComponents map[string]*ExternalComponentSpec `protobuf:"bytes,51,rep,name=addonComponents,proto3" json:"addonComponents,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Overrides for default `values.yaml`. This is a validated pass-through to Helm templates.
-	// See the [Helm installation options](https://istio.io/v1.5/docs/reference/config/installation-options/) for schema details.
+	// See the [Helm installation options](https://istio.io/docs/reference/config/installation-options/) for schema details.
 	// Anything that is available in `IstioOperatorSpec` should be set above rather than using the passthrough. This
 	// includes Kubernetes resource settings for components in `KubernetesResourcesSpec`.
 	Values *_struct.Struct `protobuf:"bytes,100,opt,name=values,proto3" json:"values,omitempty"`

--- a/operator/v1alpha1/operator.proto
+++ b/operator/v1alpha1/operator.proto
@@ -112,7 +112,7 @@ message IstioOperatorSpec {
     map<string, ExternalComponentSpec> addonComponents = 51 [deprecated = true];
 
     // Overrides for default `values.yaml`. This is a validated pass-through to Helm templates.
-    // See the [Helm installation options](https://istio.io/v1.5/docs/reference/config/installation-options/) for schema details.
+    // See the [Helm installation options](https://istio.io/docs/reference/config/installation-options/) for schema details.
     // Anything that is available in `IstioOperatorSpec` should be set above rather than using the passthrough. This
     // includes Kubernetes resource settings for components in `KubernetesResourcesSpec`.
     google.protobuf.Struct values = 100;


### PR DESCRIPTION
Fixes the link for `Helm installation options` link that appears https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/ linking to v1.5 instead of latest docs.