### PR TITLE
support HTTP/1.1 case preserve

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -506,8 +506,8 @@ var (
 
 	SidecarPreserveHeaderCase = Instance {
 		Name:          "sidecar.istio.io/preserveHeaderCase",
-		Description:   "If set to `true`, Envoy preserve the header case for "+
-                        "proxied HTTP/1.1 requests.",
+		Description:   "If set to `true`, Envoy preserves the header case for "+
+                        "proxied HTTP/1.1 requests instead of normalizing them.",
 		FeatureStatus: Alpha,
 		Hidden:        false,
 		Deprecated:    false,

--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -504,6 +504,18 @@ var (
 		},
 	}
 
+	SidecarPreserveHeaderCase = Instance {
+		Name:          "sidecar.istio.io/preserveHeaderCase",
+		Description:   "If set to `true`, Envoy preserve the header case for "+
+                        "proxied HTTP/1.1 requests.",
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Pod,
+		},
+	}
+
 	SidecarProxyCPU = Instance {
 		Name:          "sidecar.istio.io/proxyCPU",
 		Description:   "Specifies the requested CPU setting for the Envoy "+
@@ -860,6 +872,7 @@ func AllResourceAnnotations() []*Instance {
 		&SidecarInject,
 		&SidecarInterceptionMode,
 		&SidecarLogLevel,
+		&SidecarPreserveHeaderCase,
 		&SidecarProxyCPU,
 		&SidecarProxyCPULimit,
 		&SidecarProxyImage,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -367,6 +367,19 @@ Istio supports to control its behavior.
 				
 					<tr>
 				
+					<td><code>sidecar.istio.io/preserveHeaderCase</code></td>
+				
+					<td>Alpha</td>
+				
+					<td>[Pod]</td>
+					<td>If set to "true", Envoy preserve the header case for proxied HTTP/1.1 requests.</td>
+				</tr>
+			
+		
+			
+				
+					<tr>
+				
 					<td><code>sidecar.istio.io/proxyCPU</code></td>
 				
 					<td>Alpha</td>

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -372,7 +372,7 @@ Istio supports to control its behavior.
 					<td>Alpha</td>
 				
 					<td>[Pod]</td>
-					<td>If set to "true", Envoy preserve the header case for proxied HTTP/1.1 requests.</td>
+					<td>If set to "true", Envoy preserves the header case for proxied HTTP/1.1 requests instead of normalizing them.</td>
 				</tr>
 			
 		

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -209,7 +209,7 @@ annotations:
 
   - name: sidecar.istio.io/preserveHeaderCase
     featureStatus: Alpha
-    description: If set to "true", Envoy preserve the header case for proxied HTTP/1.1 requests.
+    description: If set to "true", Envoy preserves the header case for proxied HTTP/1.1 requests instead of normalizing them.
     deprecated: false
     hidden: false
     resources:

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -207,6 +207,14 @@ annotations:
     resources:
       - Pod
 
+  - name: sidecar.istio.io/preserveHeaderCase
+    featureStatus: Alpha
+    description: If set to "true", Envoy preserve the header case for proxied HTTP/1.1 requests.
+    deprecated: false
+    hidden: false
+    resources:
+      - Pod
+
   - name: sidecar.istio.io/userVolume
     featureStatus: Alpha
     description: Specifies one or more user volumes (as a JSON array) to be added to


### PR DESCRIPTION
Enables stateful HTTP header case formatter per https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/header_casing on a per-proxy basis.

This has to be opt-in for backwards compatibility.