### PR TITLE
remove hide_from_docs for http route mirrors

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -4739,6 +4739,8 @@ spec:
                       items:
                         properties:
                           destination:
+                            description: Destination specifies the target of the mirror
+                              operation.
                             properties:
                               host:
                                 description: The name of a service from the service
@@ -4756,6 +4758,8 @@ spec:
                                 type: string
                             type: object
                           percentage:
+                            description: Percentage of the traffic to be mirrored
+                              by the `destination` field.
                             properties:
                               value:
                                 format: double
@@ -5562,6 +5566,8 @@ spec:
                       items:
                         properties:
                           destination:
+                            description: Destination specifies the target of the mirror
+                              operation.
                             properties:
                               host:
                                 description: The name of a service from the service
@@ -5579,6 +5585,8 @@ spec:
                                 type: string
                             type: object
                           percentage:
+                            description: Percentage of the traffic to be mirrored
+                              by the `destination` field.
                             properties:
                               value:
                                 format: double

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -852,9 +852,6 @@ type HTTPRoute struct {
 	// original destination.  Statistics will be generated for the mirrored
 	// destination.
 	Mirror *Destination `protobuf:"bytes,9,opt,name=mirror,proto3" json:"mirror,omitempty"`
-	// $hide_from_docs
-	// Hide this from doc until implemented.
-	//
 	// Specifies the destinations to mirror HTTP traffic in addition
 	// to the original destination. Mirrored traffic is on a
 	// best effort basis where the sidecar/gateway will not wait for the
@@ -3551,9 +3548,6 @@ func (x *HTTPFaultInjection) GetAbort() *HTTPFaultInjection_Abort {
 	return nil
 }
 
-// $hide_from_docs
-// Hide this from doc until implemented.
-//
 // HTTPMirrorPolicy can be used to specify the destinations to mirror HTTP traffic in addition
 // to the original destination. Mirrored traffic is on a
 // best effort basis where the sidecar/gateway will not wait for the
@@ -3565,14 +3559,8 @@ type HTTPMirrorPolicy struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// $hide_from_docs
-	// Hide this from doc until implemented.
-	//
 	// Destination specifies the target of the mirror operation.
 	Destination *Destination `protobuf:"bytes,1,opt,name=destination,proto3" json:"destination,omitempty"`
-	// $hide_from_docs
-	// Hide this from doc until implemented.
-	//
 	// Percentage of the traffic to be mirrored by the `destination` field.
 	// If this field is absent, all the traffic (100%) will be mirrored.
 	// Max value is 100.

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -6,7 +6,7 @@ layout: protoc-gen-docs
 generator: protoc-gen-docs
 schema: istio.networking.v1alpha3.VirtualService
 aliases: [/docs/reference/config/networking/v1alpha3/virtual-service]
-number_of_entries: 28
+number_of_entries: 29
 ---
 <p>Configuration affecting traffic routing. Here are a few terms useful to define
 in the context of traffic routing.</p>
@@ -725,6 +725,22 @@ the requests to the intended destination. Mirrored traffic is on a
 best effort basis where the sidecar/gateway will not wait for the
 mirrored cluster to respond before returning the response from the
 original destination.  Statistics will be generated for the mirrored
+destination.</p>
+
+</td>
+<td>
+No
+</td>
+</tr>
+<tr id="HTTPRoute-mirrors">
+<td><code>mirrors</code></td>
+<td><code><a href="#HTTPMirrorPolicy">HTTPMirrorPolicy[]</a></code></td>
+<td>
+<p>Specifies the destinations to mirror HTTP traffic in addition
+to the original destination. Mirrored traffic is on a
+best effort basis where the sidecar/gateway will not wait for the
+mirrored destinations to respond before returning the response from the
+original destination. Statistics will be generated for the mirrored
 destination.</p>
 
 </td>
@@ -2731,6 +2747,52 @@ No
 <td>
 <p>Abort Http request attempts and return error codes back to downstream
 service, giving the impression that the upstream service is faulty.</p>
+
+</td>
+<td>
+No
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="HTTPMirrorPolicy">HTTPMirrorPolicy</h2>
+<section>
+<p>HTTPMirrorPolicy can be used to specify the destinations to mirror HTTP traffic in addition
+to the original destination. Mirrored traffic is on a
+best effort basis where the sidecar/gateway will not wait for the
+mirrored destinations to respond before returning the response from the
+original destination. Statistics will be generated for the mirrored
+destination.</p>
+
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+<th>Required</th>
+</tr>
+</thead>
+<tbody>
+<tr id="HTTPMirrorPolicy-destination">
+<td><code>destination</code></td>
+<td><code><a href="#Destination">Destination</a></code></td>
+<td>
+<p>Destination specifies the target of the mirror operation.</p>
+
+</td>
+<td>
+Yes
+</td>
+</tr>
+<tr id="HTTPMirrorPolicy-percentage">
+<td><code>percentage</code></td>
+<td><code><a href="#Percent">Percent</a></code></td>
+<td>
+<p>Percentage of the traffic to be mirrored by the <code>destination</code> field.
+If this field is absent, all the traffic (100%) will be mirrored.
+Max value is 100.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -633,9 +633,6 @@ message HTTPRoute {
   // destination.
   Destination mirror = 9;
 
-  // $hide_from_docs
-  // Hide this from doc until implemented.
-  //
   // Specifies the destinations to mirror HTTP traffic in addition
   // to the original destination. Mirrored traffic is on a
   // best effort basis where the sidecar/gateway will not wait for the
@@ -2090,9 +2087,6 @@ message HTTPFaultInjection {
   }
 }
 
-// $hide_from_docs
-// Hide this from doc until implemented.
-//
 // HTTPMirrorPolicy can be used to specify the destinations to mirror HTTP traffic in addition
 // to the original destination. Mirrored traffic is on a
 // best effort basis where the sidecar/gateway will not wait for the
@@ -2100,15 +2094,9 @@ message HTTPFaultInjection {
 // original destination. Statistics will be generated for the mirrored
 // destination.
 message HTTPMirrorPolicy {
-  // $hide_from_docs
-  // Hide this from doc until implemented.
-  //
   // Destination specifies the target of the mirror operation.
   Destination destination = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // $hide_from_docs
-  // Hide this from doc until implemented.
-  //
   // Percentage of the traffic to be mirrored by the `destination` field.
   // If this field is absent, all the traffic (100%) will be mirrored.
   // Max value is 100.

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -852,9 +852,6 @@ type HTTPRoute struct {
 	// original destination.  Statistics will be generated for the mirrored
 	// destination.
 	Mirror *Destination `protobuf:"bytes,9,opt,name=mirror,proto3" json:"mirror,omitempty"`
-	// $hide_from_docs
-	// Hide this from doc until implemented.
-	//
 	// Specifies the destinations to mirror HTTP traffic in addition
 	// to the original destination. Mirrored traffic is on a
 	// best effort basis where the sidecar/gateway will not wait for the
@@ -3551,9 +3548,6 @@ func (x *HTTPFaultInjection) GetAbort() *HTTPFaultInjection_Abort {
 	return nil
 }
 
-// $hide_from_docs
-// Hide this from doc until implemented.
-//
 // HTTPMirrorPolicy can be used to specify the destinations to mirror HTTP traffic in addition
 // to the original destination. Mirrored traffic is on a
 // best effort basis where the sidecar/gateway will not wait for the
@@ -3565,14 +3559,8 @@ type HTTPMirrorPolicy struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// $hide_from_docs
-	// Hide this from doc until implemented.
-	//
 	// Destination specifies the target of the mirror operation.
 	Destination *Destination `protobuf:"bytes,1,opt,name=destination,proto3" json:"destination,omitempty"`
-	// $hide_from_docs
-	// Hide this from doc until implemented.
-	//
 	// Percentage of the traffic to be mirrored by the `destination` field.
 	// If this field is absent, all the traffic (100%) will be mirrored.
 	// Max value is 100.

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -633,9 +633,6 @@ message HTTPRoute {
   // destination.
   Destination mirror = 9;
 
-  // $hide_from_docs
-  // Hide this from doc until implemented.
-  //
   // Specifies the destinations to mirror HTTP traffic in addition
   // to the original destination. Mirrored traffic is on a
   // best effort basis where the sidecar/gateway will not wait for the
@@ -2090,9 +2087,6 @@ message HTTPFaultInjection {
   }
 }
 
-// $hide_from_docs
-// Hide this from doc until implemented.
-//
 // HTTPMirrorPolicy can be used to specify the destinations to mirror HTTP traffic in addition
 // to the original destination. Mirrored traffic is on a
 // best effort basis where the sidecar/gateway will not wait for the
@@ -2100,15 +2094,9 @@ message HTTPFaultInjection {
 // original destination. Statistics will be generated for the mirrored
 // destination.
 message HTTPMirrorPolicy {
-  // $hide_from_docs
-  // Hide this from doc until implemented.
-  //
   // Destination specifies the target of the mirror operation.
   Destination destination = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // $hide_from_docs
-  // Hide this from doc until implemented.
-  //
   // Percentage of the traffic to be mirrored by the `destination` field.
   // If this field is absent, all the traffic (100%) will be mirrored.
   // Max value is 100.


### PR DESCRIPTION
Added in https://github.com/istio/api/pull/2805
Implemented by https://github.com/istio/istio/pull/45944