### PR TITLE
fix JWT claim based routing doc

### DIFF
--- a/security/v1/request_authentication.pb.go
+++ b/security/v1/request_authentication.pb.go
@@ -366,8 +366,10 @@ const (
 // is now supported. A prefix '@' is used to denote a match against internal metadata instead of the headers in the request.
 // Currently this feature is only supported for the following metadata:
 //
-// - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
-// currently does not support the `.` character. Examples: `request.auth.claims.sub` and `request.auth.claims.name.givenName`.
+// - `request.auth.claims.{claim-name}[.{nested-claim}]*` which are extracted from validated JWT tokens.
+// Use the `.` or `[]` as a separator for nested claim names.
+// Examples: `request.auth.claims.sub`, `request.auth.claims.name.givenName` and `request.auth.claims[foo.com/name]`.
+// For more information, see [JWT claim based routing](https://istio.io/latest/docs/tasks/security/authentication/jwt-route/).
 //
 // The use of matches against JWT claim metadata is only supported in Gateways. The following example shows:
 //

--- a/security/v1/request_authentication.proto
+++ b/security/v1/request_authentication.proto
@@ -295,8 +295,10 @@ option go_package="istio.io/api/security/v1";
 // is now supported. A prefix '@' is used to denote a match against internal metadata instead of the headers in the request.
 // Currently this feature is only supported for the following metadata:
 //
-// - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
-// currently does not support the `.` character. Examples: `request.auth.claims.sub` and `request.auth.claims.name.givenName`.
+// - `request.auth.claims.{claim-name}[.{nested-claim}]*` which are extracted from validated JWT tokens.
+// Use the `.` or `[]` as a separator for nested claim names.
+// Examples: `request.auth.claims.sub`, `request.auth.claims.name.givenName` and `request.auth.claims[foo.com/name]`.
+// For more information, see [JWT claim based routing](https://istio.io/latest/docs/tasks/security/authentication/jwt-route/).
 //
 // The use of matches against JWT claim metadata is only supported in Gateways. The following example shows:
 //

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -364,8 +364,10 @@ const (
 // is now supported. A prefix '@' is used to denote a match against internal metadata instead of the headers in the request.
 // Currently this feature is only supported for the following metadata:
 //
-// - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
-// currently does not support the `.` character. Examples: `request.auth.claims.sub` and `request.auth.claims.name.givenName`.
+// - `request.auth.claims.{claim-name}[.{nested-claim}]*` which are extracted from validated JWT tokens.
+// Use the `.` or `[]` as a separator for nested claim names.
+// Examples: `request.auth.claims.sub`, `request.auth.claims.name.givenName` and `request.auth.claims[foo.com/name]`.
+// For more information, see [JWT claim based routing](https://istio.io/latest/docs/tasks/security/authentication/jwt-route/).
 //
 // The use of matches against JWT claim metadata is only supported in Gateways. The following example shows:
 //

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -264,8 +264,10 @@ spec:
 is now supported. A prefix &lsquo;@&rsquo; is used to denote a match against internal metadata instead of the headers in the request.
 Currently this feature is only supported for the following metadata:</p>
 <ul>
-<li><code>request.auth.claims.{claim-name}[.{sub-claim}]*</code> which are extracted from validated JWT tokens. The claim name
-currently does not support the <code>.</code> character. Examples: <code>request.auth.claims.sub</code> and <code>request.auth.claims.name.givenName</code>.</li>
+<li><code>request.auth.claims.{claim-name}[.{nested-claim}]*</code> which are extracted from validated JWT tokens.
+Use the <code>.</code> or <code>[]</code> as a separator for nested claim names.
+Examples: <code>request.auth.claims.sub</code>, <code>request.auth.claims.name.givenName</code> and <code>request.auth.claims[foo.com/name]</code>.
+For more information, see <a href="https://istio.io/latest/docs/tasks/security/authentication/jwt-route/">JWT claim based routing</a>.</li>
 </ul>
 <p>The use of matches against JWT claim metadata is only supported in Gateways. The following example shows:</p>
 <ul>

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -293,8 +293,10 @@ option go_package="istio.io/api/security/v1beta1";
 // is now supported. A prefix '@' is used to denote a match against internal metadata instead of the headers in the request.
 // Currently this feature is only supported for the following metadata:
 //
-// - `request.auth.claims.{claim-name}[.{sub-claim}]*` which are extracted from validated JWT tokens. The claim name
-// currently does not support the `.` character. Examples: `request.auth.claims.sub` and `request.auth.claims.name.givenName`.
+// - `request.auth.claims.{claim-name}[.{nested-claim}]*` which are extracted from validated JWT tokens.
+// Use the `.` or `[]` as a separator for nested claim names.
+// Examples: `request.auth.claims.sub`, `request.auth.claims.name.givenName` and `request.auth.claims[foo.com/name]`.
+// For more information, see [JWT claim based routing](https://istio.io/latest/docs/tasks/security/authentication/jwt-route/).
 //
 // The use of matches against JWT claim metadata is only supported in Gateways. The following example shows:
 //


### PR DESCRIPTION
from v1.19, support using `[]` as a separator for nested claim names. see https://github.com/istio/istio/pull/44355