### PR TITLE
Update virtualservice HTTPRetry docs for the `attempt` field

### DIFF
--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -3216,7 +3216,8 @@ type HTTPRetry struct {
 	// between retries will be determined automatically (25ms+). When request
 	// `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
 	// or `per_try_timeout` is configured, the actual number of retries attempted also depends on
-	// the specified request `timeout` and `per_try_timeout` values.
+	// the specified request `timeout` and `per_try_timeout` values. MUST BE >= 0. If `0`, retries will be disabled.
+	// The maximum possible number of requests made will be 1 + `attempts`.
 	Attempts int32 `protobuf:"varint,1,opt,name=attempts,proto3" json:"attempts,omitempty"`
 	// Timeout per attempt for a given request, including the initial call and any retries. Format: 1h/1m/1s/1ms. MUST BE >=1ms.
 	// Default is same value as request

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -2509,7 +2509,8 @@ spec:
 between retries will be determined automatically (25ms+). When request
 <code>timeout</code> of the <a href="https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute">HTTP route</a>
 or <code>per_try_timeout</code> is configured, the actual number of retries attempted also depends on
-the specified request <code>timeout</code> and <code>per_try_timeout</code> values.</p>
+the specified request <code>timeout</code> and <code>per_try_timeout</code> values. MUST BE &gt;= 0. If <code>0</code>, retries will be disabled.
+The maximum possible number of requests made will be 1 + <code>attempts</code>.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -1793,7 +1793,8 @@ message HTTPRetry {
   // between retries will be determined automatically (25ms+). When request
   // `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
   // or `per_try_timeout` is configured, the actual number of retries attempted also depends on
-  // the specified request `timeout` and `per_try_timeout` values.
+  // the specified request `timeout` and `per_try_timeout` values. MUST BE >= 0. If `0`, retries will be disabled.
+  // The maximum possible number of requests made will be 1 + `attempts`.
   int32 attempts = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Timeout per attempt for a given request, including the initial call and any retries. Format: 1h/1m/1s/1ms. MUST BE >=1ms.

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -3216,7 +3216,8 @@ type HTTPRetry struct {
 	// between retries will be determined automatically (25ms+). When request
 	// `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
 	// or `per_try_timeout` is configured, the actual number of retries attempted also depends on
-	// the specified request `timeout` and `per_try_timeout` values.
+	// the specified request `timeout` and `per_try_timeout` values. MUST BE >= 0. If `0`, retries will be disabled.
+	// The maximum possible number of requests made will be 1 + `attempts`.
 	Attempts int32 `protobuf:"varint,1,opt,name=attempts,proto3" json:"attempts,omitempty"`
 	// Timeout per attempt for a given request, including the initial call and any retries. Format: 1h/1m/1s/1ms. MUST BE >=1ms.
 	// Default is same value as request

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -1793,7 +1793,8 @@ message HTTPRetry {
   // between retries will be determined automatically (25ms+). When request
   // `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)
   // or `per_try_timeout` is configured, the actual number of retries attempted also depends on
-  // the specified request `timeout` and `per_try_timeout` values.
+  // the specified request `timeout` and `per_try_timeout` values. MUST BE >= 0. If `0`, retries will be disabled.
+  // The maximum possible number of requests made will be 1 + `attempts`.
   int32 attempts = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Timeout per attempt for a given request, including the initial call and any retries. Format: 1h/1m/1s/1ms. MUST BE >=1ms.


### PR DESCRIPTION
Some folks communicated that they were confused about how `attempts` could impact the maximum number of requests made.