### PR TITLE
Migrate to protoc-gen-crd

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -25,7 +25,6 @@ repo_dir := .
 protolock = protolock
 annotations_prep = annotations_prep
 htmlproofer = htmlproofer
-cue = cue-gen -paths=common-protos
 
 #####################
 # Generation Rules

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -12,6 +12,9 @@ plugins:
 - name: golang-deepcopy
   out: .
   opt: paths=source_relative
+- name: crd
+  out: .
+  strategy: all
 - name: golang-jsonshim
   out: .
   opt: paths=source_relative

--- a/cue.yaml
+++ b/cue.yaml
@@ -1,7 +1,0 @@
-# Cuelang configuration to generate OpenAPI schema for Istio configs.
-
-module: istio.io/api
-
-openapi:
-  selfContained: true
-  fieldFilter: "min.*|max.*"

--- a/gen.sh
+++ b/gen.sh
@@ -40,6 +40,3 @@ buf generate --template buf.gen-noncrd.yaml \
 # These plugins are sent to Envoy, which uses golang/protobuf, so do not use gogo
 buf generate --template buf.gen-golang.yaml \
   --path envoy
-
-# Generate CRDs
-cue-gen -paths=common-protos -f=./cue.yaml --crd=true -snake=jwksUri,apiKeys,apiSpecs,includedPaths,jwtHeaders,triggerRules,excludedPaths,mirrorPercent

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -173,7 +173,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -334,84 +333,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -425,6 +385,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -654,84 +616,45 @@ spec:
                                     anyOf:
                                     - required:
                                       - simple
-                                    - properties:
-                                        consistentHash:
-                                          allOf:
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - httpHeaderName
-                                                - required:
-                                                  - httpCookie
-                                                - required:
-                                                  - useSourceIp
-                                                - required:
-                                                  - httpQueryParameterName
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - ringHash
-                                                - required:
-                                                  - maglev
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                          properties:
-                                            minimumRingSize: {}
-                                      required:
+                                    - required:
                                       - consistentHash
                                 - required:
                                   - simple
-                                - properties:
-                                    consistentHash:
-                                      allOf:
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                        - required:
-                                          - ringHash
-                                        - required:
-                                          - maglev
-                                      properties:
-                                        minimumRingSize: {}
-                                  required:
+                                - required:
                                   - consistentHash
                                 properties:
                                   consistentHash:
+                                    allOf:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
                                     properties:
                                       httpCookie:
                                         description: Hash based on HTTP cookie.
@@ -745,6 +668,8 @@ spec:
                                           ttl:
                                             description: Lifetime of the cookie.
                                             type: string
+                                        required:
+                                        - name
                                         type: object
                                       httpHeaderName:
                                         description: Hash based on a specific HTTP
@@ -1004,8 +929,13 @@ spec:
                               description: Specifies a port to which the downstream
                                 connection is tunneled.
                               type: integer
+                          required:
+                          - targetHost
+                          - targetPort
                           type: object
                       type: object
+                  required:
+                  - name
                   type: object
                 type: array
               trafficPolicy:
@@ -1096,84 +1026,45 @@ spec:
                         anyOf:
                         - required:
                           - simple
-                        - properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                minimumRingSize: {}
-                          required:
+                        - required:
                           - consistentHash
                     - required:
                       - simple
-                    - properties:
-                        consistentHash:
-                          allOf:
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            - required:
-                              - httpHeaderName
-                            - required:
-                              - httpCookie
-                            - required:
-                              - useSourceIp
-                            - required:
-                              - httpQueryParameterName
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                            - required:
-                              - ringHash
-                            - required:
-                              - maglev
-                          properties:
-                            minimumRingSize: {}
-                      required:
+                    - required:
                       - consistentHash
                     properties:
                       consistentHash:
+                        allOf:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
                         properties:
                           httpCookie:
                             description: Hash based on HTTP cookie.
@@ -1187,6 +1078,8 @@ spec:
                               ttl:
                                 description: Lifetime of the cookie.
                                 type: string
+                            required:
+                            - name
                             type: object
                           httpHeaderName:
                             description: Hash based on a specific HTTP header.
@@ -1410,84 +1303,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -1501,6 +1355,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -1751,6 +1607,9 @@ spec:
                         description: Specifies a port to which the downstream connection
                           is tunneled.
                         type: integer
+                    required:
+                    - targetHost
+                    - targetPort
                     type: object
                 type: object
               workloadSelector:
@@ -1764,6 +1623,8 @@ spec:
                       pods/VMs on which a policy should be applied.
                     type: object
                 type: object
+            required:
+            - host
             type: object
           status:
             type: object
@@ -1907,84 +1768,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -1998,6 +1820,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -2227,84 +2051,45 @@ spec:
                                     anyOf:
                                     - required:
                                       - simple
-                                    - properties:
-                                        consistentHash:
-                                          allOf:
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - httpHeaderName
-                                                - required:
-                                                  - httpCookie
-                                                - required:
-                                                  - useSourceIp
-                                                - required:
-                                                  - httpQueryParameterName
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - ringHash
-                                                - required:
-                                                  - maglev
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                          properties:
-                                            minimumRingSize: {}
-                                      required:
+                                    - required:
                                       - consistentHash
                                 - required:
                                   - simple
-                                - properties:
-                                    consistentHash:
-                                      allOf:
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                        - required:
-                                          - ringHash
-                                        - required:
-                                          - maglev
-                                      properties:
-                                        minimumRingSize: {}
-                                  required:
+                                - required:
                                   - consistentHash
                                 properties:
                                   consistentHash:
+                                    allOf:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
                                     properties:
                                       httpCookie:
                                         description: Hash based on HTTP cookie.
@@ -2318,6 +2103,8 @@ spec:
                                           ttl:
                                             description: Lifetime of the cookie.
                                             type: string
+                                        required:
+                                        - name
                                         type: object
                                       httpHeaderName:
                                         description: Hash based on a specific HTTP
@@ -2577,8 +2364,13 @@ spec:
                               description: Specifies a port to which the downstream
                                 connection is tunneled.
                               type: integer
+                          required:
+                          - targetHost
+                          - targetPort
                           type: object
                       type: object
+                  required:
+                  - name
                   type: object
                 type: array
               trafficPolicy:
@@ -2669,84 +2461,45 @@ spec:
                         anyOf:
                         - required:
                           - simple
-                        - properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                minimumRingSize: {}
-                          required:
+                        - required:
                           - consistentHash
                     - required:
                       - simple
-                    - properties:
-                        consistentHash:
-                          allOf:
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            - required:
-                              - httpHeaderName
-                            - required:
-                              - httpCookie
-                            - required:
-                              - useSourceIp
-                            - required:
-                              - httpQueryParameterName
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                            - required:
-                              - ringHash
-                            - required:
-                              - maglev
-                          properties:
-                            minimumRingSize: {}
-                      required:
+                    - required:
                       - consistentHash
                     properties:
                       consistentHash:
+                        allOf:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
                         properties:
                           httpCookie:
                             description: Hash based on HTTP cookie.
@@ -2760,6 +2513,8 @@ spec:
                               ttl:
                                 description: Lifetime of the cookie.
                                 type: string
+                            required:
+                            - name
                             type: object
                           httpHeaderName:
                             description: Hash based on a specific HTTP header.
@@ -2983,84 +2738,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -3074,6 +2790,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -3324,6 +3042,9 @@ spec:
                         description: Specifies a port to which the downstream connection
                           is tunneled.
                         type: integer
+                    required:
+                    - targetHost
+                    - targetPort
                     type: object
                 type: object
               workloadSelector:
@@ -3337,6 +3058,8 @@ spec:
                       pods/VMs on which a policy should be applied.
                     type: object
                 type: object
+            required:
+            - host
             type: object
           status:
             type: object
@@ -3346,7 +3069,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3618,7 +3340,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3693,6 +3414,10 @@ spec:
                           type: string
                         targetPort:
                           type: integer
+                      required:
+                      - number
+                      - protocol
+                      - name
                       type: object
                     tls:
                       description: Set of TLS related options that govern the server's
@@ -3771,8 +3496,13 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
+                  - hosts
                   type: object
                 type: array
+            required:
+            - servers
             type: object
           status:
             type: object
@@ -3830,6 +3560,10 @@ spec:
                           type: string
                         targetPort:
                           type: integer
+                      required:
+                      - number
+                      - protocol
+                      - name
                       type: object
                     tls:
                       description: Set of TLS related options that govern the server's
@@ -3908,8 +3642,13 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
+                  - hosts
                   type: object
                 type: array
+            required:
+            - servers
             type: object
           status:
             type: object
@@ -3919,7 +3658,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3987,7 +3725,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4117,6 +3854,9 @@ spec:
                       description: The port number on the endpoint where the traffic
                         will be received.
                       type: integer
+                  required:
+                  - number
+                  - name
                   type: object
                 type: array
               resolution:
@@ -4143,6 +3883,8 @@ spec:
                       pods/VMs on which the configuration should be applied.
                     type: object
                 type: object
+            required:
+            - hosts
             type: object
           status:
             type: object
@@ -4255,6 +3997,9 @@ spec:
                       description: The port number on the endpoint where the traffic
                         will be received.
                       type: integer
+                  required:
+                  - number
+                  - name
                   type: object
                 type: array
               resolution:
@@ -4281,6 +4026,8 @@ spec:
                       pods/VMs on which the configuration should be applied.
                     type: object
                 type: object
+            required:
+            - hosts
             type: object
           status:
             type: object
@@ -4290,7 +4037,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4363,6 +4109,8 @@ spec:
                         targetPort:
                           type: integer
                       type: object
+                  required:
+                  - hosts
                   type: object
                 type: array
               ingress:
@@ -4479,6 +4227,8 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
                   type: object
                 type: array
               outboundTrafficPolicy:
@@ -4499,6 +4249,8 @@ spec:
                       subset:
                         description: The name of a subset within the service.
                         type: string
+                    required:
+                    - host
                     type: object
                   mode:
                     enum:
@@ -4574,6 +4326,8 @@ spec:
                         targetPort:
                           type: integer
                       type: object
+                  required:
+                  - hosts
                   type: object
                 type: array
               ingress:
@@ -4690,6 +4444,8 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
                   type: object
                 type: array
               outboundTrafficPolicy:
@@ -4710,6 +4466,8 @@ spec:
                       subset:
                         description: The name of a subset within the service.
                         type: string
+                    required:
+                    - host
                     type: object
                   mode:
                     enum:
@@ -4737,7 +4495,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4913,6 +4670,8 @@ spec:
                         status:
                           description: Specifies the HTTP response status to be returned.
                           type: integer
+                      required:
+                      - status
                       type: object
                     fault:
                       description: Fault injection policy to apply on HTTP traffic
@@ -5285,6 +5044,8 @@ spec:
                         subset:
                           description: The name of a subset within the service.
                           type: string
+                      required:
+                      - host
                       type: object
                     mirror_percent:
                       nullable: true
@@ -5323,6 +5084,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           percentage:
                             description: Percentage of the traffic to be mirrored
@@ -5332,6 +5095,8 @@ spec:
                                 format: double
                                 type: number
                             type: object
+                        required:
+                        - destination
                         type: object
                       type: array
                     name:
@@ -5451,6 +5216,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           headers:
                             properties:
@@ -5490,6 +5257,8 @@ spec:
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                     timeout:
@@ -5560,12 +5329,16 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                   type: object
@@ -5611,6 +5384,8 @@ spec:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
                             type: string
+                        required:
+                        - sniHosts
                         type: object
                       type: array
                     route:
@@ -5637,14 +5412,20 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
+                  required:
+                  - match
                   type: object
                 type: array
             type: object
@@ -5805,6 +5586,8 @@ spec:
                         status:
                           description: Specifies the HTTP response status to be returned.
                           type: integer
+                      required:
+                      - status
                       type: object
                     fault:
                       description: Fault injection policy to apply on HTTP traffic
@@ -6177,6 +5960,8 @@ spec:
                         subset:
                           description: The name of a subset within the service.
                           type: string
+                      required:
+                      - host
                       type: object
                     mirror_percent:
                       nullable: true
@@ -6215,6 +6000,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           percentage:
                             description: Percentage of the traffic to be mirrored
@@ -6224,6 +6011,8 @@ spec:
                                 format: double
                                 type: number
                             type: object
+                        required:
+                        - destination
                         type: object
                       type: array
                     name:
@@ -6343,6 +6132,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           headers:
                             properties:
@@ -6382,6 +6173,8 @@ spec:
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                     timeout:
@@ -6452,12 +6245,16 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                   type: object
@@ -6503,6 +6300,8 @@ spec:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
                             type: string
+                        required:
+                        - sniHosts
                         type: object
                       type: array
                     route:
@@ -6529,14 +6328,20 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
+                  required:
+                  - match
                   type: object
                 type: array
             type: object
@@ -6548,7 +6353,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -6691,7 +6495,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -6805,6 +6608,8 @@ spec:
                         type: integer
                       scheme:
                         type: string
+                    required:
+                    - port
                     type: object
                   initialDelaySeconds:
                     description: Number of seconds after the container has started
@@ -6827,6 +6632,8 @@ spec:
                         type: string
                       port:
                         type: integer
+                    required:
+                    - port
                     type: object
                   timeoutSeconds:
                     description: Number of seconds after which the probe times out.
@@ -6866,6 +6673,8 @@ spec:
                     description: The load balancing weight associated with the endpoint.
                     type: integer
                 type: object
+            required:
+            - template
             type: object
           status:
             type: object
@@ -6966,6 +6775,8 @@ spec:
                         type: integer
                       scheme:
                         type: string
+                    required:
+                    - port
                     type: object
                   initialDelaySeconds:
                     description: Number of seconds after the container has started
@@ -6988,6 +6799,8 @@ spec:
                         type: string
                       port:
                         type: integer
+                    required:
+                    - port
                     type: object
                   timeoutSeconds:
                     description: Number of seconds after which the probe times out.
@@ -7027,6 +6840,8 @@ spec:
                     description: The load balancing weight associated with the endpoint.
                     type: integer
                 type: object
+            required:
+            - template
             type: object
           status:
             type: object
@@ -7036,7 +6851,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7223,6 +7037,8 @@ spec:
                             items:
                               type: string
                             type: array
+                        required:
+                        - key
                         type: object
                       type: array
                   type: object
@@ -7418,6 +7234,8 @@ spec:
                             items:
                               type: string
                             type: array
+                        required:
+                        - key
                         type: object
                       type: array
                   type: object
@@ -7452,7 +7270,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7498,8 +7315,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: PeerAuthentication defines how traffic will be tunneled (or
-              not) to the sidecar.
+            description: 'Peer authentication configuration for workloads. See more
+              details at: https://istio.io/docs/reference/config/security/peer_authentication.html'
             properties:
               mtls:
                 description: Mutual TLS settings for workload.
@@ -7547,7 +7364,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7580,8 +7396,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: RequestAuthentication defines what request authentication
-              methods are supported by a workload.
+            description: 'Request authentication configuration for workloads. See
+              more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
             properties:
               jwtRules:
                 description: Define the list of JWTs that can be validated at the
@@ -7609,6 +7425,8 @@ spec:
                             description: The prefix that should be stripped before
                               decoding the token.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     fromParams:
@@ -7648,6 +7466,8 @@ spec:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
                       type: string
+                  required:
+                  - issuer
                   type: object
                 type: array
               selector:
@@ -7685,8 +7505,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: RequestAuthentication defines what request authentication
-              methods are supported by a workload.
+            description: 'Request authentication configuration for workloads. See
+              more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
             properties:
               jwtRules:
                 description: Define the list of JWTs that can be validated at the
@@ -7714,6 +7534,8 @@ spec:
                             description: The prefix that should be stripped before
                               decoding the token.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     fromParams:
@@ -7753,6 +7575,8 @@ spec:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
                       type: string
+                  required:
+                  - issuer
                   type: object
                 type: array
               selector:
@@ -7785,7 +7609,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7867,6 +7690,8 @@ spec:
                           name:
                             description: Required.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                   type: object
@@ -7951,6 +7776,8 @@ spec:
                           name:
                             description: Required.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     reportingInterval:
@@ -8060,6 +7887,8 @@ spec:
                           name:
                             description: Required.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     randomSamplingPercentage:
@@ -8081,5 +7910,3 @@ spec:
     storage: true
     subresources:
       status: {}
-
----

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -863,6 +863,7 @@ type HTTPRoute struct {
 	// Use of integer `mirror_percent` value is deprecated. Use the
 	// double `mirror_percentage` field instead
 	// $hide_from_docs
+	// +kubebuilder:altName=mirror_percent
 	//
 	// Deprecated: Marked as deprecated in networking/v1alpha3/virtual_service.proto.
 	MirrorPercent *wrappers.UInt32Value `protobuf:"bytes,18,opt,name=mirror_percent,json=mirrorPercent,proto3" json:"mirror_percent,omitempty"`

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -645,6 +645,7 @@ message HTTPRoute {
   // Use of integer `mirror_percent` value is deprecated. Use the
   // double `mirror_percentage` field instead
   // $hide_from_docs
+  // +kubebuilder:altName=mirror_percent
   google.protobuf.UInt32Value mirror_percent = 18 [deprecated=true];
 
   // Percentage of the traffic to be mirrored by the `mirror` field.

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -863,6 +863,7 @@ type HTTPRoute struct {
 	// Use of integer `mirror_percent` value is deprecated. Use the
 	// double `mirror_percentage` field instead
 	// $hide_from_docs
+	// +kubebuilder:altName=mirror_percent
 	//
 	// Deprecated: Marked as deprecated in networking/v1beta1/virtual_service.proto.
 	MirrorPercent *wrappers.UInt32Value `protobuf:"bytes,18,opt,name=mirror_percent,json=mirrorPercent,proto3" json:"mirror_percent,omitempty"`

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -645,6 +645,7 @@ message HTTPRoute {
   // Use of integer `mirror_percent` value is deprecated. Use the
   // double `mirror_percentage` field instead
   // $hide_from_docs
+  // +kubebuilder:altName=mirror_percent
   google.protobuf.UInt32Value mirror_percent = 18 [deprecated=true];
 
   // Percentage of the traffic to be mirrored by the `mirror` field.

--- a/security/v1/jwt.pb.go
+++ b/security/v1/jwt.pb.go
@@ -114,6 +114,7 @@ type JWTRule struct {
 	// Example: `https://www.googleapis.com/oauth2/v1/certs`
 	//
 	// Note: Only one of `jwksUri` and `jwks` should be used.
+	// +kubebuilder:altName=jwks_uri
 	JwksUri string `protobuf:"bytes,3,opt,name=jwks_uri,json=jwksUri,proto3" json:"jwks_uri,omitempty"`
 	// JSON Web Key Set of public keys to validate signature of the JWT.
 	// See https://auth0.com/docs/jwks.

--- a/security/v1/jwt.proto
+++ b/security/v1/jwt.proto
@@ -94,6 +94,7 @@ message JWTRule {
   // Example: `https://www.googleapis.com/oauth2/v1/certs`
   //
   // Note: Only one of `jwksUri` and `jwks` should be used.
+  // +kubebuilder:altName=jwks_uri
   string jwks_uri = 3;
 
   // JSON Web Key Set of public keys to validate signature of the JWT.

--- a/security/v1beta1/jwt.pb.go
+++ b/security/v1beta1/jwt.pb.go
@@ -113,6 +113,7 @@ type JWTRule struct {
 	// Example: `https://www.googleapis.com/oauth2/v1/certs`
 	//
 	// Note: Only one of `jwksUri` and `jwks` should be used.
+	// +kubebuilder:altName=jwks_uri
 	JwksUri string `protobuf:"bytes,3,opt,name=jwks_uri,json=jwksUri,proto3" json:"jwks_uri,omitempty"`
 	// JSON Web Key Set of public keys to validate signature of the JWT.
 	// See https://auth0.com/docs/jwks.

--- a/security/v1beta1/jwt.proto
+++ b/security/v1beta1/jwt.proto
@@ -93,6 +93,7 @@ message JWTRule {
   // Example: `https://www.googleapis.com/oauth2/v1/certs`
   //
   // Note: Only one of `jwksUri` and `jwks` should be used.
+  // +kubebuilder:altName=jwks_uri
   string jwks_uri = 3;
 
   // JSON Web Key Set of public keys to validate signature of the JWT.


### PR DESCRIPTION
For https://github.com/istio/istio/issues/46151
Based on https://github.com/istio/api/pull/2946, will rebase once that merges

This PR moves our CRD generator from cue-gen to protoc-gen-crd. The details of these don't matter too much; the final generated CRD.yaml does. The migration value is not really exposed in this PR, as I tried to keep it minimal; a followup PR will be used where we implement https://github.com/istio/istio/issues/46151 (likely multiple PRs, to keep it small). For now, the following changes are present:

* REQUIRED fields are actually required. I validated each field that is currently set as REQUIRED is marked as required in the webhook, so this is not a breaking change
* The `oneOf` representation is simplified. In my testing, I have found these to be equivalent in functionality.

Overall this should have no user facing changes