### PR TITLE
Subject: update doc for ignoreUriCase

### DIFF
--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -1620,7 +1620,7 @@ type HTTPMatchRequest struct {
 	// - `regex: "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
 	//
 	// **Note:** Case-insensitive matching could be enabled via the
-	// `ignore_uri_case` flag.
+	// `ignoreUriCase` flag.
 	Uri *StringMatch `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
 	// URI Scheme
 	// values are case-sensitive and formatted as follows:

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -1268,7 +1268,7 @@ values are case-sensitive and formatted as follows:</p>
 </li>
 </ul>
 <p><strong>Note:</strong> Case-insensitive matching could be enabled via the
-<code>ignore_uri_case</code> flag.</p>
+<code>ignoreUriCase</code> flag.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -1032,7 +1032,7 @@ message HTTPMatchRequest {
   // - `regex: "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
   //
   // **Note:** Case-insensitive matching could be enabled via the
-  // `ignore_uri_case` flag.
+  // `ignoreUriCase` flag.
   StringMatch uri = 1;
 
   // URI Scheme

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -1620,7 +1620,7 @@ type HTTPMatchRequest struct {
 	// - `regex: "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
 	//
 	// **Note:** Case-insensitive matching could be enabled via the
-	// `ignore_uri_case` flag.
+	// `ignoreUriCase` flag.
 	Uri *StringMatch `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
 	// URI Scheme
 	// values are case-sensitive and formatted as follows:

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -1032,7 +1032,7 @@ message HTTPMatchRequest {
   // - `regex: "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
   //
   // **Note:** Case-insensitive matching could be enabled via the
-  // `ignore_uri_case` flag.
+  // `ignoreUriCase` flag.
   StringMatch uri = 1;
 
   // URI Scheme


### PR DESCRIPTION
The property name that users should use is `ignoreUriCase`.

closes istio/istio.io#14072