### PR TITLE
docs: fix a typo and incorrect rendering of URLs

### DIFF
--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -225,15 +225,20 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// PluginType indicates the type of Wasm Extension to be used.
-// There are two types of Extensions: `HTTP` and `NETWORK`.
-// HTTP Extension work at "Layer 7"(for example as an HTTP filters in Envoy).
-// The detailed HTTP interface for can be found at [C++] (https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L199)
-// and [Rust] (https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L309).
-// NETWORK Extension work at "Layer 4"(for example, as a network filter in Envoy).
-// The detailed NETWORK interface for can be found at [C++] (https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L257)
-// and [Rust] (https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L257).
-// The NETWORK Extension can be applied to HTTP traffic as well.
+// PluginType indicates the type of Wasm extension to be used.
+// There are two types of extensions: `HTTP` and `NETWORK`.
+//
+// The `HTTP` extension works at Layer 7 (for example, as an HTTP filter in Envoy).
+// The detailed HTTP interface can be found here:
+// - [C++](https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L199)
+// - [Rust](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L309)
+//
+// The `NETWORK` extension works at Layer 4 (for example, as a network filter in Envoy).
+// The detailed `NETWORK` interface can be found here:
+// - [C++](https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L257)
+// - [Rust](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L257)
+//
+// The `NETWORK` extension can be applied to HTTP traffic as well.
 type PluginType int32
 
 const (
@@ -628,7 +633,7 @@ type WasmPlugin struct {
 	// Specifies the failure behavior for the plugin due to fatal errors.
 	FailStrategy FailStrategy `protobuf:"varint,13,opt,name=fail_strategy,json=failStrategy,proto3,enum=istio.extensions.v1alpha1.FailStrategy" json:"fail_strategy,omitempty"`
 	// Configuration for a Wasm VM.
-	// more details can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-vmconfig).
+	// More details can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-vmconfig).
 	VmConfig *VmConfig `protobuf:"bytes,11,opt,name=vm_config,json=vmConfig,proto3" json:"vm_config,omitempty"`
 	// Specifies the criteria to determine which traffic is passed to WasmPlugin.
 	// If a traffic satisfies any of TrafficSelectors,

--- a/extensions/v1alpha1/wasm.pb.html
+++ b/extensions/v1alpha1/wasm.pb.html
@@ -326,7 +326,7 @@ No
 <td><code><a href="#VmConfig">VmConfig</a></code></td>
 <td>
 <p>Configuration for a Wasm VM.
-more details can be found <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-vmconfig">here</a>.</p>
+More details can be found <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-vmconfig">here</a>.</p>
 
 </td>
 <td>
@@ -495,15 +495,21 @@ No
 </section>
 <h2 id="PluginType">PluginType</h2>
 <section>
-<p>PluginType indicates the type of Wasm Extension to be used.
-There are two types of Extensions: <code>HTTP</code> and <code>NETWORK</code>.
-HTTP Extension work at &ldquo;Layer 7&rdquo;(for example as an HTTP filters in Envoy).
-The detailed HTTP interface for can be found at [C++] (<a href="https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L199">https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L199</a>)
-and [Rust] (<a href="https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L309)">https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L309)</a>.
-NETWORK Extension work at &ldquo;Layer 4&rdquo;(for example, as a network filter in Envoy).
-The detailed NETWORK interface for can be found at [C++] (<a href="https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L257">https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L257</a>)
-and [Rust] (<a href="https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L257)">https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L257)</a>.
-The NETWORK Extension can be applied to HTTP traffic as well.</p>
+<p>PluginType indicates the type of Wasm extension to be used.
+There are two types of extensions: <code>HTTP</code> and <code>NETWORK</code>.</p>
+<p>The <code>HTTP</code> extension works at Layer 7 (for example, as an HTTP filter in Envoy).
+The detailed HTTP interface can be found here:</p>
+<ul>
+<li><a href="https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L199">C++</a></li>
+<li><a href="https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L309">Rust</a></li>
+</ul>
+<p>The <code>NETWORK</code> extension works at Layer 4 (for example, as a network filter in Envoy).
+The detailed <code>NETWORK</code> interface can be found here:</p>
+<ul>
+<li><a href="https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L257">C++</a></li>
+<li><a href="https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L257">Rust</a></li>
+</ul>
+<p>The <code>NETWORK</code> extension can be applied to HTTP traffic as well.</p>
 
 <table class="enum-values">
 <thead>

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -338,7 +338,7 @@ message WasmPlugin {
   FailStrategy fail_strategy = 13;
 
   // Configuration for a Wasm VM.
-  // more details can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-vmconfig).
+  // More details can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-vmconfig).
   VmConfig vm_config = 11;
 
   // TrafficSelector provides a mechanism to select a specific traffic flow
@@ -375,15 +375,20 @@ message WasmPlugin {
 }
 
 
-// PluginType indicates the type of Wasm Extension to be used. 
-// There are two types of Extensions: `HTTP` and `NETWORK`.
-// HTTP Extension work at "Layer 7"(for example as an HTTP filters in Envoy). 
-// The detailed HTTP interface for can be found at [C++] (https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L199)
-// and [Rust] (https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L309).
-// NETWORK Extension work at "Layer 4"(for example, as a network filter in Envoy).
-// The detailed NETWORK interface for can be found at [C++] (https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L257)
-// and [Rust] (https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L257).
-// The NETWORK Extension can be applied to HTTP traffic as well.
+// PluginType indicates the type of Wasm extension to be used.
+// There are two types of extensions: `HTTP` and `NETWORK`.
+//
+// The `HTTP` extension works at Layer 7 (for example, as an HTTP filter in Envoy).
+// The detailed HTTP interface can be found here:
+// - [C++](https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L199)
+// - [Rust](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L309)
+//
+// The `NETWORK` extension works at Layer 4 (for example, as a network filter in Envoy).
+// The detailed `NETWORK` interface can be found here:
+// - [C++](https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/b7e690703c7f26707438a2f1ebd7c197bc8f0296/include/proxy-wasm/context_interface.h#L257)
+// - [Rust](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/6b47aec926bc29971c727471d6f4c972ec407c7f/src/traits.rs#L257)
+//
+// The `NETWORK` extension can be applied to HTTP traffic as well.
 enum PluginType {
   // Defaults to HTTP.
   UNSPECIFIED_PLUGIN_TYPE = 0;


### PR DESCRIPTION
The URLs weren't rendered correctly in the docs. 