### PR TITLE
align `selector` comments of PeerAuthentication with `RequestAuthentication` and `AuthorizationPolicy`

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -7817,7 +7817,7 @@ spec:
                 description: Port specific mutual TLS settings.
                 type: object
               selector:
-                description: The selector determines the workloads to apply the ChannelAuthentication
+                description: The selector determines the workloads to apply the PeerAuthentication
                   on.
                 properties:
                   matchLabels:

--- a/security/v1beta1/peer_authentication.pb.go
+++ b/security/v1beta1/peer_authentication.pb.go
@@ -223,8 +223,11 @@ type PeerAuthentication struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The selector determines the workloads to apply the ChannelAuthentication on.
-	// If not set, the policy will be applied to all workloads in the same namespace as the policy.
+	// The selector determines the workloads to apply the PeerAuthentication on. The selector will match with workloads in the
+	// same namespace as the policy. If the policy is in the root namespace, the selector will additionally match with workloads in all namespace.
+	//
+	// If not set, the policy will be applied to all workloads in the same namespace as the policy. If it is in the root namespace, it would be applied
+	// to all workloads in the mesh.
 	Selector *v1beta1.WorkloadSelector `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
 	// Mutual TLS settings for workload. If not defined, inherit from parent.
 	Mtls *PeerAuthentication_MutualTLS `protobuf:"bytes,2,opt,name=mtls,proto3" json:"mtls,omitempty"`

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -95,8 +95,10 @@ spec:
 <td><code>selector</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
-<p>The selector determines the workloads to apply the ChannelAuthentication on.
-If not set, the policy will be applied to all workloads in the same namespace as the policy.</p>
+<p>The selector determines the workloads to apply the PeerAuthentication on. The selector will match with workloads in the
+same namespace as the policy. If the policy is in the root namespace, the selector will additionally match with workloads in all namespace.</p>
+<p>If not set, the policy will be applied to all workloads in the same namespace as the policy. If it is in the root namespace, it would be applied
+to all workloads in the mesh.</p>
 
 </td>
 <td>

--- a/security/v1beta1/peer_authentication.proto
+++ b/security/v1beta1/peer_authentication.proto
@@ -127,8 +127,11 @@ option go_package="istio.io/api/security/v1beta1";
 // +k8s:deepcopy-gen=true
 // -->
 message PeerAuthentication {
-  // The selector determines the workloads to apply the ChannelAuthentication on.
-  // If not set, the policy will be applied to all workloads in the same namespace as the policy.
+  // The selector determines the workloads to apply the ChannelAuthentication on. The selector will match with workloads in the
+  // same namespace as the policy. If the policy is in the root namespace, the selector will additionally match with workloads in all namespace.
+  //
+  // If not set, the policy will be applied to all workloads in the same namespace as the policy. If it is in the root namespace, it would be applied
+  // to all workloads in the mesh.
   istio.type.v1beta1.WorkloadSelector selector = 1;
 
   // Mutual TLS settings.

--- a/security/v1beta1/peer_authentication.proto
+++ b/security/v1beta1/peer_authentication.proto
@@ -127,7 +127,7 @@ option go_package="istio.io/api/security/v1beta1";
 // +k8s:deepcopy-gen=true
 // -->
 message PeerAuthentication {
-  // The selector determines the workloads to apply the ChannelAuthentication on. The selector will match with workloads in the
+  // The selector determines the workloads to apply the PeerAuthentication on. The selector will match with workloads in the
   // same namespace as the policy. If the policy is in the root namespace, the selector will additionally match with workloads in all namespace.
   //
   // If not set, the policy will be applied to all workloads in the same namespace as the policy. If it is in the root namespace, it would be applied


### PR DESCRIPTION
The current `selector` comments of PeerAuthentication doesn't explain whether the selector in root namespace will select all workloads in all namespaces like  `RequestAuthentication` and `AuthorizationPolicy`. So make it clear.