### PR TITLE
docs: use Kubernetes instead of k8s in the proto field comments

### DIFF
--- a/operator/v1alpha1/istio.operator.v1alpha1.pb.html
+++ b/operator/v1alpha1/istio.operator.v1alpha1.pb.html
@@ -641,7 +641,7 @@ No
 </section>
 <h2 id="KubernetesResourcesSpec">KubernetesResourcesSpec</h2>
 <section>
-<p>KubernetesResourcesConfig is a common set of k8s resource configs for components.</p>
+<p>KubernetesResourcesConfig is a common set of Kubernetes resource configs for components.</p>
 
 <table class="message-fields">
 <thead>
@@ -657,7 +657,7 @@ No
 <td><code>affinity</code></td>
 <td><code><a href="#Affinity">Affinity</a></code></td>
 <td>
-<p>k8s affinity.
+<p>Kubernetes affinity.
 <a href="https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity">https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity</a></p>
 
 </td>
@@ -681,7 +681,7 @@ No
 <td><code>hpaSpec</code></td>
 <td><code><a href="#HorizontalPodAutoscalerSpec">HorizontalPodAutoscalerSpec</a></code></td>
 <td>
-<p>k8s HorizontalPodAutoscaler settings.
+<p>Kubernetes HorizontalPodAutoscaler settings.
 <a href="https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/">https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/</a></p>
 
 </td>
@@ -693,7 +693,7 @@ No
 <td><code>imagePullPolicy</code></td>
 <td><code>string</code></td>
 <td>
-<p>k8s imagePullPolicy.
+<p>Kubernetes imagePullPolicy.
 <a href="https://kubernetes.io/docs/concepts/containers/images/">https://kubernetes.io/docs/concepts/containers/images/</a></p>
 
 </td>
@@ -705,7 +705,7 @@ No
 <td><code>nodeSelector</code></td>
 <td><code>map&lt;string,&nbsp;string&gt;</code></td>
 <td>
-<p>k8s nodeSelector.
+<p>Kubernetes nodeSelector.
 <a href="https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector">https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector</a></p>
 
 </td>
@@ -717,7 +717,7 @@ No
 <td><code>podDisruptionBudget</code></td>
 <td><code><a href="#PodDisruptionBudgetSpec">PodDisruptionBudgetSpec</a></code></td>
 <td>
-<p>k8s PodDisruptionBudget settings.
+<p>Kubernetes PodDisruptionBudget settings.
 <a href="https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#how-disruption-budgets-work">https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#how-disruption-budgets-work</a></p>
 
 </td>
@@ -729,7 +729,7 @@ No
 <td><code>podAnnotations</code></td>
 <td><code>map&lt;string,&nbsp;string&gt;</code></td>
 <td>
-<p>k8s pod annotations.
+<p>Kubernetes pod annotations.
 <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/">https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/</a></p>
 
 </td>
@@ -741,7 +741,7 @@ No
 <td><code>priorityClassName</code></td>
 <td><code>string</code></td>
 <td>
-<p>k8s priority_class_name. Default for all resources unless overridden.
+<p>Kubernetes priorityClassName. Default for all resources unless overridden.
 <a href="https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass">https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass</a></p>
 
 </td>
@@ -753,7 +753,7 @@ No
 <td><code>readinessProbe</code></td>
 <td><code><a href="#ReadinessProbe">ReadinessProbe</a></code></td>
 <td>
-<p>k8s readinessProbe settings.
+<p>Kubernetes readinessProbe settings.
 <a href="https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/">https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/</a>
 k8s.io.api.core.v1.Probe readiness_probe = 9;</p>
 
@@ -766,7 +766,7 @@ No
 <td><code>replicaCount</code></td>
 <td><code>uint32</code></td>
 <td>
-<p>k8s Deployment replicas setting.
+<p>Kubernetes Deployment replicas setting.
 <a href="https://kubernetes.io/docs/concepts/workloads/controllers/deployment/">https://kubernetes.io/docs/concepts/workloads/controllers/deployment/</a></p>
 
 </td>
@@ -778,7 +778,7 @@ No
 <td><code>resources</code></td>
 <td><code><a href="#Resources">Resources</a></code></td>
 <td>
-<p>k8s resources settings.
+<p>Kubernetes resources settings.
 <a href="https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container">https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container</a></p>
 
 </td>
@@ -790,7 +790,7 @@ No
 <td><code>service</code></td>
 <td><code><a href="#ServiceSpec">ServiceSpec</a></code></td>
 <td>
-<p>k8s Service settings.
+<p>Kubernetes Service settings.
 <a href="https://kubernetes.io/docs/concepts/services-networking/service/">https://kubernetes.io/docs/concepts/services-networking/service/</a></p>
 
 </td>
@@ -802,7 +802,7 @@ No
 <td><code>strategy</code></td>
 <td><code><a href="#DeploymentStrategy">DeploymentStrategy</a></code></td>
 <td>
-<p>k8s deployment strategy.
+<p>Kubernetes deployment strategy.
 <a href="https://kubernetes.io/docs/concepts/workloads/controllers/deployment/">https://kubernetes.io/docs/concepts/workloads/controllers/deployment/</a></p>
 
 </td>
@@ -814,7 +814,7 @@ No
 <td><code>tolerations</code></td>
 <td><code><a href="#Toleration">Toleration[]</a></code></td>
 <td>
-<p>k8s toleration
+<p>Kubernetes toleration
 <a href="https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/">https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/</a></p>
 
 </td>
@@ -826,7 +826,7 @@ No
 <td><code>serviceAnnotations</code></td>
 <td><code>map&lt;string,&nbsp;string&gt;</code></td>
 <td>
-<p>k8s service annotations.
+<p>Kubernetes service annotations.
 <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/">https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/</a></p>
 
 </td>
@@ -838,7 +838,7 @@ No
 <td><code>securityContext</code></td>
 <td><code><a href="#PodSecurityContext">PodSecurityContext</a></code></td>
 <td>
-<p>k8s pod security context
+<p>Kubernetes pod security context
 <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod</a></p>
 
 </td>
@@ -850,7 +850,7 @@ No
 <td><code>volumes</code></td>
 <td><code><a href="#k8s-io-api-core-v1-Volume">Volume[]</a></code></td>
 <td>
-<p>k8s volume
+<p>Kubernetes volumes
 <a href="https://kubernetes.io/docs/concepts/storage/volumes/">https://kubernetes.io/docs/concepts/storage/volumes/</a>
 Volumes defines the collection of Volume to inject into the pod.</p>
 
@@ -863,7 +863,7 @@ No
 <td><code>volumeMounts</code></td>
 <td><code><a href="#k8s-io-api-core-v1-VolumeMount">VolumeMount[]</a></code></td>
 <td>
-<p>k8s volumeMounts
+<p>Kubernetes volumeMounts
 VolumeMounts defines the collection of VolumeMount to inject into containers.</p>
 
 </td>
@@ -875,7 +875,7 @@ No
 <td><code>overlays</code></td>
 <td><code><a href="#K8sObjectOverlay">K8sObjectOverlay[]</a></code></td>
 <td>
-<p>Overlays for k8s resources in rendered manifests.</p>
+<p>Overlays for Kubernetes resources in rendered manifests.</p>
 
 </td>
 <td>
@@ -887,7 +887,7 @@ No
 </section>
 <h2 id="K8sObjectOverlay">K8sObjectOverlay</h2>
 <section>
-<p>Patch for an existing k8s resource.</p>
+<p>Patch for an existing Kubernetes resource.</p>
 
 <table class="message-fields">
 <thead>

--- a/operator/v1alpha1/operator.pb.go
+++ b/operator/v1alpha1/operator.pb.go
@@ -850,69 +850,69 @@ func (x *GatewaySpec) GetK8S() *KubernetesResourcesSpec {
 	return nil
 }
 
-// KubernetesResourcesConfig is a common set of k8s resource configs for components.
+// KubernetesResourcesConfig is a common set of Kubernetes resource configs for components.
 type KubernetesResourcesSpec struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// k8s affinity.
+	// Kubernetes affinity.
 	// [https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
 	Affinity *Affinity `protobuf:"bytes,1,opt,name=affinity,proto3" json:"affinity,omitempty"`
 	// Deployment environment variables.
 	// [https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
 	Env []*EnvVar `protobuf:"bytes,2,rep,name=env,proto3" json:"env,omitempty"`
-	// k8s HorizontalPodAutoscaler settings.
+	// Kubernetes HorizontalPodAutoscaler settings.
 	// [https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
 	HpaSpec *HorizontalPodAutoscalerSpec `protobuf:"bytes,3,opt,name=hpaSpec,proto3" json:"hpaSpec,omitempty"`
-	// k8s imagePullPolicy.
+	// Kubernetes imagePullPolicy.
 	// [https://kubernetes.io/docs/concepts/containers/images/](https://kubernetes.io/docs/concepts/containers/images/)
 	ImagePullPolicy string `protobuf:"bytes,4,opt,name=imagePullPolicy,proto3" json:"imagePullPolicy,omitempty"`
-	// k8s nodeSelector.
+	// Kubernetes nodeSelector.
 	// [https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
 	NodeSelector map[string]string `protobuf:"bytes,5,rep,name=nodeSelector,proto3" json:"nodeSelector,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	// k8s PodDisruptionBudget settings.
+	// Kubernetes PodDisruptionBudget settings.
 	// [https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#how-disruption-budgets-work](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#how-disruption-budgets-work)
 	PodDisruptionBudget *PodDisruptionBudgetSpec `protobuf:"bytes,6,opt,name=podDisruptionBudget,proto3" json:"podDisruptionBudget,omitempty"`
-	// k8s pod annotations.
+	// Kubernetes pod annotations.
 	// [https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 	PodAnnotations map[string]string `protobuf:"bytes,7,rep,name=podAnnotations,proto3" json:"podAnnotations,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	// k8s priority_class_name. Default for all resources unless overridden.
+	// Kubernetes priorityClassName. Default for all resources unless overridden.
 	// [https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass)
 	PriorityClassName string `protobuf:"bytes,8,opt,name=priorityClassName,proto3" json:"priorityClassName,omitempty"`
-	// k8s readinessProbe settings.
+	// Kubernetes readinessProbe settings.
 	// [https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
 	// k8s.io.api.core.v1.Probe readiness_probe = 9;
 	ReadinessProbe *ReadinessProbe `protobuf:"bytes,9,opt,name=readinessProbe,proto3" json:"readinessProbe,omitempty"`
-	// k8s Deployment replicas setting.
+	// Kubernetes Deployment replicas setting.
 	// [https://kubernetes.io/docs/concepts/workloads/controllers/deployment/](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
 	ReplicaCount uint32 `protobuf:"varint,10,opt,name=replicaCount,proto3" json:"replicaCount,omitempty"`
-	// k8s resources settings.
+	// Kubernetes resources settings.
 	// [https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container)
 	Resources *Resources `protobuf:"bytes,11,opt,name=resources,proto3" json:"resources,omitempty"`
-	// k8s Service settings.
+	// Kubernetes Service settings.
 	// [https://kubernetes.io/docs/concepts/services-networking/service/](https://kubernetes.io/docs/concepts/services-networking/service/)
 	Service *ServiceSpec `protobuf:"bytes,12,opt,name=service,proto3" json:"service,omitempty"`
-	// k8s deployment strategy.
+	// Kubernetes deployment strategy.
 	// [https://kubernetes.io/docs/concepts/workloads/controllers/deployment/](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
 	Strategy *DeploymentStrategy `protobuf:"bytes,13,opt,name=strategy,proto3" json:"strategy,omitempty"`
-	// k8s toleration
+	// Kubernetes toleration
 	// [https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
 	Tolerations []*Toleration `protobuf:"bytes,14,rep,name=tolerations,proto3" json:"tolerations,omitempty"`
-	// k8s service annotations.
+	// Kubernetes service annotations.
 	// [https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 	ServiceAnnotations map[string]string `protobuf:"bytes,15,rep,name=serviceAnnotations,proto3" json:"serviceAnnotations,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	// k8s pod security context
+	// Kubernetes pod security context
 	// [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
 	SecurityContext *PodSecurityContext `protobuf:"bytes,16,opt,name=securityContext,proto3" json:"securityContext,omitempty"`
-	// k8s volume
+	// Kubernetes volumes
 	// [https://kubernetes.io/docs/concepts/storage/volumes/](https://kubernetes.io/docs/concepts/storage/volumes/)
 	// Volumes defines the collection of Volume to inject into the pod.
 	Volumes []*v1.Volume `protobuf:"bytes,17,rep,name=volumes,proto3" json:"volumes,omitempty"`
-	// k8s volumeMounts
+	// Kubernetes volumeMounts
 	// VolumeMounts defines the collection of VolumeMount to inject into containers.
 	VolumeMounts []*v1.VolumeMount `protobuf:"bytes,18,rep,name=volumeMounts,proto3" json:"volumeMounts,omitempty"`
-	// Overlays for k8s resources in rendered manifests.
+	// Overlays for Kubernetes resources in rendered manifests.
 	Overlays []*K8SObjectOverlay `protobuf:"bytes,100,rep,name=overlays,proto3" json:"overlays,omitempty"`
 }
 
@@ -1081,7 +1081,7 @@ func (x *KubernetesResourcesSpec) GetOverlays() []*K8SObjectOverlay {
 	return nil
 }
 
-// Patch for an existing k8s resource.
+// Patch for an existing Kubernetes resource.
 type K8SObjectOverlay struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/operator/v1alpha1/operator.proto
+++ b/operator/v1alpha1/operator.proto
@@ -245,70 +245,70 @@ message GatewaySpec {
     KubernetesResourcesSpec k8s = 50;
 }
 
-// KubernetesResourcesConfig is a common set of k8s resource configs for components.
+// KubernetesResourcesConfig is a common set of Kubernetes resource configs for components.
 message KubernetesResourcesSpec {
-    // k8s affinity.
+    // Kubernetes affinity.
     // [https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     Affinity affinity = 1;
     // Deployment environment variables.
     // [https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
     repeated EnvVar env = 2;
-    // k8s HorizontalPodAutoscaler settings.
+    // Kubernetes HorizontalPodAutoscaler settings.
     // [https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
     HorizontalPodAutoscalerSpec hpaSpec = 3;
-    // k8s imagePullPolicy.
+    // Kubernetes imagePullPolicy.
     // [https://kubernetes.io/docs/concepts/containers/images/](https://kubernetes.io/docs/concepts/containers/images/)
     string imagePullPolicy = 4;
-    // k8s nodeSelector.
+    // Kubernetes nodeSelector.
     // [https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
     map<string, string> nodeSelector = 5;
-    // k8s PodDisruptionBudget settings.
+    // Kubernetes PodDisruptionBudget settings.
     // [https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#how-disruption-budgets-work](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#how-disruption-budgets-work)
     PodDisruptionBudgetSpec podDisruptionBudget = 6;
-    // k8s pod annotations.
+    // Kubernetes pod annotations.
     // [https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
     map<string, string> podAnnotations = 7;
-    // k8s priority_class_name. Default for all resources unless overridden.
+    // Kubernetes priorityClassName. Default for all resources unless overridden.
     // [https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass)
     string priorityClassName = 8;
-    // k8s readinessProbe settings.
+    // Kubernetes readinessProbe settings.
     // [https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
     // k8s.io.api.core.v1.Probe readiness_probe = 9;
     ReadinessProbe readinessProbe = 9;
-    // k8s Deployment replicas setting.
+    // Kubernetes Deployment replicas setting.
     // [https://kubernetes.io/docs/concepts/workloads/controllers/deployment/](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
     uint32 replicaCount = 10;
-    // k8s resources settings.
+    // Kubernetes resources settings.
     // [https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container)
     Resources resources = 11;
-    // k8s Service settings.
+    // Kubernetes Service settings.
     // [https://kubernetes.io/docs/concepts/services-networking/service/](https://kubernetes.io/docs/concepts/services-networking/service/)
     ServiceSpec service = 12;
-    // k8s deployment strategy.
+    // Kubernetes deployment strategy.
     // [https://kubernetes.io/docs/concepts/workloads/controllers/deployment/](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
     DeploymentStrategy strategy = 13;
-    // k8s toleration
+    // Kubernetes toleration
     // [https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
     repeated Toleration tolerations = 14;
-    // k8s service annotations.
+    // Kubernetes service annotations.
     // [https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
     map<string, string> serviceAnnotations = 15;
-    // k8s pod security context
+    // Kubernetes pod security context
     // [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
     PodSecurityContext securityContext = 16;
-    // k8s volume
+    // Kubernetes volumes
     // [https://kubernetes.io/docs/concepts/storage/volumes/](https://kubernetes.io/docs/concepts/storage/volumes/)
     // Volumes defines the collection of Volume to inject into the pod.
     repeated k8s.io.api.core.v1.Volume volumes = 17;
-    // k8s volumeMounts
+    // Kubernetes volumeMounts
     // VolumeMounts defines the collection of VolumeMount to inject into containers.
     repeated k8s.io.api.core.v1.VolumeMount volumeMounts = 18;
 
-    // Overlays for k8s resources in rendered manifests.
+    // Overlays for Kubernetes resources in rendered manifests.
     repeated K8sObjectOverlay overlays = 100;
 }
 
-// Patch for an existing k8s resource.
+// Patch for an existing Kubernetes resource.
 message K8sObjectOverlay {
     message PathValue {
         // Path of the form a.[key1:value1].b.[:value2]


### PR DESCRIPTION
For the consistency/readability sake, updating all instances of "k8s" in the comments to "Kubernetes".