### PR TITLE
Remove mention of REPLACE operation for EXTENSION_CONFIG EnvoyFilter

### DIFF
--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -335,7 +335,7 @@
 //   #   to avoid accidental name collisions.
 //   - applyTo: EXTENSION_CONFIG
 //     patch:
-//       operation: ADD # REPLACE is also supported, and would override a cluster level resource with the same name.
+//       operation: ADD
 //       value:
 //         name: my-wasm-extension
 //         typed_config:

--- a/networking/v1alpha3/envoy_filter.pb.html
+++ b/networking/v1alpha3/envoy_filter.pb.html
@@ -294,7 +294,7 @@ spec:
   #   to avoid accidental name collisions.
   - applyTo: EXTENSION_CONFIG
     patch:
-      operation: ADD # REPLACE is also supported, and would override a cluster level resource with the same name.
+      operation: ADD
       value:
         name: my-wasm-extension
         typed_config:

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -334,7 +334,7 @@ import "networking/v1alpha3/sidecar.proto";
 //   #   to avoid accidental name collisions.
 //   - applyTo: EXTENSION_CONFIG
 //     patch:
-//       operation: ADD # REPLACE is also supported, and would override a cluster level resource with the same name.
+//       operation: ADD
 //       value:
 //         name: my-wasm-extension
 //         typed_config:


### PR DESCRIPTION
Fixes #3034

EnvoyFilter patching extenion_config only supports ADD operation as shown here
https://github.com/istio/istio/blob/master/pilot/pkg/networking/core/v1alpha3/envoyfilter/extension_configuration_patch.go#L35

REPLACE operation is only valid for HTTP_FILTER and NETWORK_FILTER. If the named filter is not found, this operation has no effect.