### PR TITLE
docs: field name and minor formatting fixes

### DIFF
--- a/security/v1/authorization_policy.pb.go
+++ b/security/v1/authorization_policy.pb.go
@@ -477,7 +477,7 @@ const (
 	// the authorization decision to it.
 	//
 	// The following authorization policy applies to an ingress gateway and delegates the authorization check to a named extension
-	// "my-custom-authz" if the request path has prefix "/admin/".
+	// `my-custom-authz` if the request path has prefix `/admin/`.
 	//
 	// ```yaml
 	// apiVersion: security.istio.io/v1beta1
@@ -699,24 +699,24 @@ func (*AuthorizationPolicy_Provider) isAuthorizationPolicy_ActionDetail() {}
 //
 // Any string field in the rule supports Exact, Prefix, Suffix and Presence match:
 //
-// - Exact match: "abc" will match on value "abc".
-// - Prefix match: "abc*" will match on value "abc" and "abcd".
-// - Suffix match: "*abc" will match on value "abc" and "xabc".
-// - Presence match: "*" will match when value is not empty.
+// - Exact match: `abc` will match on value `abc`.
+// - Prefix match: `abc*` will match on value `abc` and `abcd`.
+// - Suffix match: `*abc` will match on value `abc` and `xabc`.
+// - Presence match: `*` will match when value is not empty.
 type Rule struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Optional. from specifies the source of a request.
+	// Optional. `from` specifies the source of a request.
 	//
 	// If not set, any source is allowed.
 	From []*Rule_From `protobuf:"bytes,1,rep,name=from,proto3" json:"from,omitempty"`
-	// Optional. to specifies the operation of a request.
+	// Optional. `to` specifies the operation of a request.
 	//
 	// If not set, any operation is allowed.
 	To []*Rule_To `protobuf:"bytes,2,rep,name=to,proto3" json:"to,omitempty"`
-	// Optional. when specifies a list of additional conditions of a request.
+	// Optional. `when` specifies a list of additional conditions of a request.
 	//
 	// If not set, any condition is allowed.
 	When []*Condition `protobuf:"bytes,3,rep,name=when,proto3" json:"when,omitempty"`
@@ -778,8 +778,8 @@ func (x *Rule) GetWhen() []*Condition {
 // Source specifies the source identities of a request. Fields in the source are
 // ANDed together.
 //
-// For example, the following source matches if the principal is "admin" or "dev"
-// and the namespace is "prod" or "test" and the ip is not "203.0.113.4".
+// For example, the following source matches if the principal is `admin` or `dev`
+// and the namespace is `prod` or `test` and the ip is not `203.0.113.4`.
 //
 // ```yaml
 // principals: ["admin", "dev"]
@@ -814,18 +814,18 @@ type Source struct {
 	Namespaces []string `protobuf:"bytes,3,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
 	// Optional. A list of negative match of namespaces.
 	NotNamespaces []string `protobuf:"bytes,7,rep,name=not_namespaces,json=notNamespaces,proto3" json:"not_namespaces,omitempty"`
-	// Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "203.0.113.4") and
-	// CIDR (e.g. "203.0.113.0/24") are supported. This is the same as the `source.ip` attribute.
+	// Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. `203.0.113.4`) and
+	// CIDR (e.g. `203.0.113.0/24`) are supported. This is the same as the `source.ip` attribute.
 	//
 	// If not set, any IP is allowed.
 	IpBlocks []string `protobuf:"bytes,4,rep,name=ip_blocks,json=ipBlocks,proto3" json:"ip_blocks,omitempty"`
 	// Optional. A list of negative match of IP blocks.
 	NotIpBlocks []string `protobuf:"bytes,8,rep,name=not_ip_blocks,json=notIpBlocks,proto3" json:"not_ip_blocks,omitempty"`
-	// Optional. A list of IP blocks, populated from X-Forwarded-For header or proxy protocol.
-	// To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig
+	// Optional. A list of IP blocks, populated from `X-Forwarded-For` header or proxy protocol.
+	// To make use of this field, you must configure the `numTrustedProxies` field of the `gatewayTopology` under the `meshConfig`
 	// when you install Istio or using an annotation on the ingress gateway.  See the documentation here:
 	// [Configuring Gateway Network Topology](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/).
-	// Single IP (e.g. "203.0.113.4") and CIDR (e.g. "203.0.113.0/24") are supported.
+	// Single IP (e.g. `203.0.113.4`) and CIDR (e.g. `203.0.113.0/24`) are supported.
 	// This is the same as the `remote.ip` attribute.
 	//
 	// If not set, any IP is allowed.
@@ -939,8 +939,8 @@ func (x *Source) GetNotRemoteIpBlocks() []string {
 // Operation specifies the operations of a request. Fields in the operation are
 // ANDed together.
 //
-// For example, the following operation matches if the host has suffix ".example.com"
-// and the method is "GET" or "HEAD" and the path doesn't have prefix "/admin".
+// For example, the following operation matches if the host has suffix `.example.com`
+// and the method is `GET` or `HEAD` and the path doesn't have prefix `/admin`.
 //
 // ```yaml
 // hosts: ["*.example.com"]
@@ -967,7 +967,7 @@ type Operation struct {
 	// Optional. A list of negative match of ports as specified in the connection.
 	NotPorts []string `protobuf:"bytes,6,rep,name=not_ports,json=notPorts,proto3" json:"not_ports,omitempty"`
 	// Optional. A list of methods as specified in the HTTP request.
-	// For gRPC service, this will always be "POST".
+	// For gRPC service, this will always be `POST`.
 	//
 	// If not set, any method is allowed. Must be used only with HTTP.
 	Methods []string `protobuf:"bytes,3,rep,name=methods,proto3" json:"methods,omitempty"`
@@ -975,7 +975,7 @@ type Operation struct {
 	NotMethods []string `protobuf:"bytes,7,rep,name=not_methods,json=notMethods,proto3" json:"not_methods,omitempty"`
 	// Optional. A list of paths as specified in the HTTP request. See the [Authorization Policy Normalization](https://istio.io/latest/docs/reference/config/security/normalization/)
 	// for details of the path normalization.
-	// For gRPC service, this will be the fully-qualified name in the form of "/package.service/method".
+	// For gRPC service, this will be the fully-qualified name in the form of `/package.service/method`.
 	//
 	// If not set, any path is allowed. Must be used only with HTTP.
 	Paths []string `protobuf:"bytes,4,rep,name=paths,proto3" json:"paths,omitempty"`
@@ -1081,10 +1081,10 @@ type Condition struct {
 	// See the [full list of supported attributes](https://istio.io/docs/reference/config/security/conditions/).
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// Optional. A list of allowed values for the attribute.
-	// Note: at least one of values or not_values must be set.
+	// Note: at least one of `values` or `notValues` must be set.
 	Values []string `protobuf:"bytes,2,rep,name=values,proto3" json:"values,omitempty"`
 	// Optional. A list of negative match of values for the attribute.
-	// Note: at least one of values or not_values must be set.
+	// Note: at least one of `values` or `notValues` must be set.
 	NotValues []string `protobuf:"bytes,3,rep,name=not_values,json=notValues,proto3" json:"not_values,omitempty"`
 }
 

--- a/security/v1/authorization_policy.proto
+++ b/security/v1/authorization_policy.proto
@@ -517,7 +517,7 @@ message AuthorizationPolicy {
     // the authorization decision to it.
     //
     // The following authorization policy applies to an ingress gateway and delegates the authorization check to a named extension
-    // "my-custom-authz" if the request path has prefix "/admin/".
+    // `my-custom-authz` if the request path has prefix `/admin/`.
     //
     // ```yaml
     // apiVersion: security.istio.io/v1beta1
@@ -561,10 +561,10 @@ message AuthorizationPolicy {
 //
 // Any string field in the rule supports Exact, Prefix, Suffix and Presence match:
 //
-// - Exact match: "abc" will match on value "abc".
-// - Prefix match: "abc*" will match on value "abc" and "abcd".
-// - Suffix match: "*abc" will match on value "abc" and "xabc".
-// - Presence match: "*" will match when value is not empty.
+// - Exact match: `abc` will match on value `abc`.
+// - Prefix match: `abc*` will match on value `abc` and `abcd`.
+// - Suffix match: `*abc` will match on value `abc` and `xabc`.
+// - Presence match: `*` will match when value is not empty.
 message Rule {
   // From includes a list of sources.
   message From {
@@ -572,7 +572,7 @@ message Rule {
     Source source = 1;
   }
 
-  // Optional. from specifies the source of a request.
+  // Optional. `from` specifies the source of a request.
   //
   // If not set, any source is allowed.
   repeated From from = 1;
@@ -583,12 +583,12 @@ message Rule {
     Operation operation = 1;
   }
 
-  // Optional. to specifies the operation of a request.
+  // Optional. `to` specifies the operation of a request.
   //
   // If not set, any operation is allowed.
   repeated To to = 2;
 
-  // Optional. when specifies a list of additional conditions of a request.
+  // Optional. `when` specifies a list of additional conditions of a request.
   //
   // If not set, any condition is allowed.
   repeated Condition when = 3;
@@ -597,8 +597,8 @@ message Rule {
 // Source specifies the source identities of a request. Fields in the source are
 // ANDed together.
 //
-// For example, the following source matches if the principal is "admin" or "dev"
-// and the namespace is "prod" or "test" and the ip is not "203.0.113.4".
+// For example, the following source matches if the principal is `admin` or `dev`
+// and the namespace is `prod` or `test` and the ip is not `203.0.113.4`.
 //
 // ```yaml
 // principals: ["admin", "dev"]
@@ -635,8 +635,8 @@ message Source {
   // Optional. A list of negative match of namespaces.
   repeated string not_namespaces = 7;
 
-  // Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "203.0.113.4") and
-  // CIDR (e.g. "203.0.113.0/24") are supported. This is the same as the `source.ip` attribute.
+  // Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. `203.0.113.4`) and
+  // CIDR (e.g. `203.0.113.0/24`) are supported. This is the same as the `source.ip` attribute.
   //
   // If not set, any IP is allowed.
   repeated string ip_blocks = 4;
@@ -644,11 +644,11 @@ message Source {
   // Optional. A list of negative match of IP blocks.
   repeated string not_ip_blocks = 8;
 
-  // Optional. A list of IP blocks, populated from X-Forwarded-For header or proxy protocol.
-  // To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig
+  // Optional. A list of IP blocks, populated from `X-Forwarded-For` header or proxy protocol.
+  // To make use of this field, you must configure the `numTrustedProxies` field of the `gatewayTopology` under the `meshConfig`
   // when you install Istio or using an annotation on the ingress gateway.  See the documentation here:
   // [Configuring Gateway Network Topology](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/).
-  // Single IP (e.g. "203.0.113.4") and CIDR (e.g. "203.0.113.0/24") are supported.
+  // Single IP (e.g. `203.0.113.4`) and CIDR (e.g. `203.0.113.0/24`) are supported.
   // This is the same as the `remote.ip` attribute.
   //
   // If not set, any IP is allowed.
@@ -661,8 +661,8 @@ message Source {
 // Operation specifies the operations of a request. Fields in the operation are
 // ANDed together.
 //
-// For example, the following operation matches if the host has suffix ".example.com"
-// and the method is "GET" or "HEAD" and the path doesn't have prefix "/admin".
+// For example, the following operation matches if the host has suffix `.example.com`
+// and the method is `GET` or `HEAD` and the path doesn't have prefix `/admin`.
 //
 // ```yaml
 // hosts: ["*.example.com"]
@@ -689,7 +689,7 @@ message Operation {
   repeated string not_ports = 6;
 
   // Optional. A list of methods as specified in the HTTP request.
-  // For gRPC service, this will always be "POST".
+  // For gRPC service, this will always be `POST`.
   //
   // If not set, any method is allowed. Must be used only with HTTP.
   repeated string methods = 3;
@@ -699,7 +699,7 @@ message Operation {
 
   // Optional. A list of paths as specified in the HTTP request. See the [Authorization Policy Normalization](https://istio.io/latest/docs/reference/config/security/normalization/)
   // for details of the path normalization.
-  // For gRPC service, this will be the fully-qualified name in the form of "/package.service/method".
+  // For gRPC service, this will be the fully-qualified name in the form of `/package.service/method`.
   //
   // If not set, any path is allowed. Must be used only with HTTP.
   repeated string paths = 4;
@@ -715,10 +715,10 @@ message Condition {
   string key = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. A list of allowed values for the attribute.
-  // Note: at least one of values or not_values must be set.
+  // Note: at least one of `values` or `notValues` must be set.
   repeated string values = 2;
 
   // Optional. A list of negative match of values for the attribute.
-  // Note: at least one of values or not_values must be set.
+  // Note: at least one of `values` or `notValues` must be set.
   repeated string not_values = 3;
 }

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -476,7 +476,7 @@ const (
 	// the authorization decision to it.
 	//
 	// The following authorization policy applies to an ingress gateway and delegates the authorization check to a named extension
-	// "my-custom-authz" if the request path has prefix "/admin/".
+	// `my-custom-authz` if the request path has prefix `/admin/`.
 	//
 	// ```yaml
 	// apiVersion: security.istio.io/v1beta1
@@ -699,24 +699,24 @@ func (*AuthorizationPolicy_Provider) isAuthorizationPolicy_ActionDetail() {}
 //
 // Any string field in the rule supports Exact, Prefix, Suffix and Presence match:
 //
-// - Exact match: "abc" will match on value "abc".
-// - Prefix match: "abc*" will match on value "abc" and "abcd".
-// - Suffix match: "*abc" will match on value "abc" and "xabc".
-// - Presence match: "*" will match when value is not empty.
+// - Exact match: `abc` will match on value `abc`.
+// - Prefix match: `abc*` will match on value `abc` and `abcd`.
+// - Suffix match: `*abc` will match on value `abc` and `xabc`.
+// - Presence match: `*` will match when value is not empty.
 type Rule struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Optional. from specifies the source of a request.
+	// Optional. `from` specifies the source of a request.
 	//
 	// If not set, any source is allowed.
 	From []*Rule_From `protobuf:"bytes,1,rep,name=from,proto3" json:"from,omitempty"`
-	// Optional. to specifies the operation of a request.
+	// Optional. `to` specifies the operation of a request.
 	//
 	// If not set, any operation is allowed.
 	To []*Rule_To `protobuf:"bytes,2,rep,name=to,proto3" json:"to,omitempty"`
-	// Optional. when specifies a list of additional conditions of a request.
+	// Optional. `when` specifies a list of additional conditions of a request.
 	//
 	// If not set, any condition is allowed.
 	When []*Condition `protobuf:"bytes,3,rep,name=when,proto3" json:"when,omitempty"`
@@ -778,8 +778,8 @@ func (x *Rule) GetWhen() []*Condition {
 // Source specifies the source identities of a request. Fields in the source are
 // ANDed together.
 //
-// For example, the following source matches if the principal is "admin" or "dev"
-// and the namespace is "prod" or "test" and the ip is not "203.0.113.4".
+// For example, the following source matches if the principal is `admin` or `dev`
+// and the namespace is `prod` or `test` and the ip is not `203.0.113.4`.
 //
 // ```yaml
 // principals: ["admin", "dev"]
@@ -814,18 +814,18 @@ type Source struct {
 	Namespaces []string `protobuf:"bytes,3,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
 	// Optional. A list of negative match of namespaces.
 	NotNamespaces []string `protobuf:"bytes,7,rep,name=not_namespaces,json=notNamespaces,proto3" json:"not_namespaces,omitempty"`
-	// Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "203.0.113.4") and
-	// CIDR (e.g. "203.0.113.0/24") are supported. This is the same as the `source.ip` attribute.
+	// Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. `203.0.113.4`) and
+	// CIDR (e.g. `203.0.113.0/24`) are supported. This is the same as the `source.ip` attribute.
 	//
 	// If not set, any IP is allowed.
 	IpBlocks []string `protobuf:"bytes,4,rep,name=ip_blocks,json=ipBlocks,proto3" json:"ip_blocks,omitempty"`
 	// Optional. A list of negative match of IP blocks.
 	NotIpBlocks []string `protobuf:"bytes,8,rep,name=not_ip_blocks,json=notIpBlocks,proto3" json:"not_ip_blocks,omitempty"`
-	// Optional. A list of IP blocks, populated from X-Forwarded-For header or proxy protocol.
-	// To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig
+	// Optional. A list of IP blocks, populated from `X-Forwarded-For` header or proxy protocol.
+	// To make use of this field, you must configure the `numTrustedProxies` field of the `gatewayTopology` under the `meshConfig`
 	// when you install Istio or using an annotation on the ingress gateway.  See the documentation here:
 	// [Configuring Gateway Network Topology](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/).
-	// Single IP (e.g. "203.0.113.4") and CIDR (e.g. "203.0.113.0/24") are supported.
+	// Single IP (e.g. `203.0.113.4`) and CIDR (e.g. `203.0.113.0/24`) are supported.
 	// This is the same as the `remote.ip` attribute.
 	//
 	// If not set, any IP is allowed.
@@ -939,8 +939,8 @@ func (x *Source) GetNotRemoteIpBlocks() []string {
 // Operation specifies the operations of a request. Fields in the operation are
 // ANDed together.
 //
-// For example, the following operation matches if the host has suffix ".example.com"
-// and the method is "GET" or "HEAD" and the path doesn't have prefix "/admin".
+// For example, the following operation matches if the host has suffix `.example.com`
+// and the method is `GET` or `HEAD` and the path doesn't have prefix `/admin`.
 //
 // ```yaml
 // hosts: ["*.example.com"]
@@ -967,7 +967,7 @@ type Operation struct {
 	// Optional. A list of negative match of ports as specified in the connection.
 	NotPorts []string `protobuf:"bytes,6,rep,name=not_ports,json=notPorts,proto3" json:"not_ports,omitempty"`
 	// Optional. A list of methods as specified in the HTTP request.
-	// For gRPC service, this will always be "POST".
+	// For gRPC service, this will always be `POST`.
 	//
 	// If not set, any method is allowed. Must be used only with HTTP.
 	Methods []string `protobuf:"bytes,3,rep,name=methods,proto3" json:"methods,omitempty"`
@@ -975,7 +975,7 @@ type Operation struct {
 	NotMethods []string `protobuf:"bytes,7,rep,name=not_methods,json=notMethods,proto3" json:"not_methods,omitempty"`
 	// Optional. A list of paths as specified in the HTTP request. See the [Authorization Policy Normalization](https://istio.io/latest/docs/reference/config/security/normalization/)
 	// for details of the path normalization.
-	// For gRPC service, this will be the fully-qualified name in the form of "/package.service/method".
+	// For gRPC service, this will be the fully-qualified name in the form of `/package.service/method`.
 	//
 	// If not set, any path is allowed. Must be used only with HTTP.
 	Paths []string `protobuf:"bytes,4,rep,name=paths,proto3" json:"paths,omitempty"`
@@ -1081,10 +1081,10 @@ type Condition struct {
 	// See the [full list of supported attributes](https://istio.io/docs/reference/config/security/conditions/).
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// Optional. A list of allowed values for the attribute.
-	// Note: at least one of values or not_values must be set.
+	// Note: at least one of `values` or `notValues` must be set.
 	Values []string `protobuf:"bytes,2,rep,name=values,proto3" json:"values,omitempty"`
 	// Optional. A list of negative match of values for the attribute.
-	// Note: at least one of values or not_values must be set.
+	// Note: at least one of `values` or `notValues` must be set.
 	NotValues []string `protobuf:"bytes,3,rep,name=not_values,json=notValues,proto3" json:"not_values,omitempty"`
 }
 

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -465,10 +465,10 @@ list of conditions. A match occurs when at least one source, one operation and a
 matches the request. An empty rule is always matched.</p>
 <p>Any string field in the rule supports Exact, Prefix, Suffix and Presence match:</p>
 <ul>
-<li>Exact match: &ldquo;abc&rdquo; will match on value &ldquo;abc&rdquo;.</li>
-<li>Prefix match: &ldquo;abc*&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;abcd&rdquo;.</li>
-<li>Suffix match: &ldquo;*abc&rdquo; will match on value &ldquo;abc&rdquo; and &ldquo;xabc&rdquo;.</li>
-<li>Presence match: &ldquo;*&rdquo; will match when value is not empty.</li>
+<li>Exact match: <code>abc</code> will match on value <code>abc</code>.</li>
+<li>Prefix match: <code>abc*</code> will match on value <code>abc</code> and <code>abcd</code>.</li>
+<li>Suffix match: <code>*abc</code> will match on value <code>abc</code> and <code>xabc</code>.</li>
+<li>Presence match: <code>*</code> will match when value is not empty.</li>
 </ul>
 
 <table class="message-fields">
@@ -485,7 +485,7 @@ matches the request. An empty rule is always matched.</p>
 <td><code>from</code></td>
 <td><code><a href="#Rule-From">From[]</a></code></td>
 <td>
-<p>Optional. from specifies the source of a request.</p>
+<p>Optional. <code>from</code> specifies the source of a request.</p>
 <p>If not set, any source is allowed.</p>
 
 </td>
@@ -497,7 +497,7 @@ No
 <td><code>to</code></td>
 <td><code><a href="#Rule-To">To[]</a></code></td>
 <td>
-<p>Optional. to specifies the operation of a request.</p>
+<p>Optional. <code>to</code> specifies the operation of a request.</p>
 <p>If not set, any operation is allowed.</p>
 
 </td>
@@ -509,7 +509,7 @@ No
 <td><code>when</code></td>
 <td><code><a href="#Condition">Condition[]</a></code></td>
 <td>
-<p>Optional. when specifies a list of additional conditions of a request.</p>
+<p>Optional. <code>when</code> specifies a list of additional conditions of a request.</p>
 <p>If not set, any condition is allowed.</p>
 
 </td>
@@ -524,8 +524,8 @@ No
 <section>
 <p>Source specifies the source identities of a request. Fields in the source are
 ANDed together.</p>
-<p>For example, the following source matches if the principal is &ldquo;admin&rdquo; or &ldquo;dev&rdquo;
-and the namespace is &ldquo;prod&rdquo; or &ldquo;test&rdquo; and the ip is not &ldquo;203.0.113.4&rdquo;.</p>
+<p>For example, the following source matches if the principal is <code>admin</code> or <code>dev</code>
+and the namespace is <code>prod</code> or <code>test</code> and the ip is not <code>203.0.113.4</code>.</p>
 <pre><code class="language-yaml">principals: [&quot;admin&quot;, &quot;dev&quot;]
 namespaces: [&quot;prod&quot;, &quot;test&quot;]
 notIpBlocks: [&quot;203.0.113.4&quot;]
@@ -619,8 +619,8 @@ No
 <td><code>ipBlocks</code></td>
 <td><code>string[]</code></td>
 <td>
-<p>Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. &ldquo;203.0.113.4&rdquo;) and
-CIDR (e.g. &ldquo;203.0.113.0/24&rdquo;) are supported. This is the same as the <code>source.ip</code> attribute.</p>
+<p>Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. <code>203.0.113.4</code>) and
+CIDR (e.g. <code>203.0.113.0/24</code>) are supported. This is the same as the <code>source.ip</code> attribute.</p>
 <p>If not set, any IP is allowed.</p>
 
 </td>
@@ -643,11 +643,11 @@ No
 <td><code>remoteIpBlocks</code></td>
 <td><code>string[]</code></td>
 <td>
-<p>Optional. A list of IP blocks, populated from X-Forwarded-For header or proxy protocol.
-To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig
+<p>Optional. A list of IP blocks, populated from <code>X-Forwarded-For</code> header or proxy protocol.
+To make use of this field, you must configure the <code>numTrustedProxies</code> field of the <code>gatewayTopology</code> under the <code>meshConfig</code>
 when you install Istio or using an annotation on the ingress gateway.  See the documentation here:
 <a href="https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/">Configuring Gateway Network Topology</a>.
-Single IP (e.g. &ldquo;203.0.113.4&rdquo;) and CIDR (e.g. &ldquo;203.0.113.0/24&rdquo;) are supported.
+Single IP (e.g. <code>203.0.113.4</code>) and CIDR (e.g. <code>203.0.113.0/24</code>) are supported.
 This is the same as the <code>remote.ip</code> attribute.</p>
 <p>If not set, any IP is allowed.</p>
 
@@ -674,8 +674,8 @@ No
 <section>
 <p>Operation specifies the operations of a request. Fields in the operation are
 ANDed together.</p>
-<p>For example, the following operation matches if the host has suffix &ldquo;.example.com&rdquo;
-and the method is &ldquo;GET&rdquo; or &ldquo;HEAD&rdquo; and the path doesn&rsquo;t have prefix &ldquo;/admin&rdquo;.</p>
+<p>For example, the following operation matches if the host has suffix <code>.example.com</code>
+and the method is <code>GET</code> or <code>HEAD</code> and the path doesn&rsquo;t have prefix <code>/admin</code>.</p>
 <pre><code class="language-yaml">hosts: [&quot;*.example.com&quot;]
 methods: [&quot;GET&quot;, &quot;HEAD&quot;]
 notPaths: [&quot;/admin*&quot;]
@@ -744,7 +744,7 @@ No
 <td><code>string[]</code></td>
 <td>
 <p>Optional. A list of methods as specified in the HTTP request.
-For gRPC service, this will always be &ldquo;POST&rdquo;.</p>
+For gRPC service, this will always be <code>POST</code>.</p>
 <p>If not set, any method is allowed. Must be used only with HTTP.</p>
 
 </td>
@@ -769,7 +769,7 @@ No
 <td>
 <p>Optional. A list of paths as specified in the HTTP request. See the <a href="https://istio.io/latest/docs/reference/config/security/normalization/">Authorization Policy Normalization</a>
 for details of the path normalization.
-For gRPC service, this will be the fully-qualified name in the form of &ldquo;/package.service/method&rdquo;.</p>
+For gRPC service, this will be the fully-qualified name in the form of <code>/package.service/method</code>.</p>
 <p>If not set, any path is allowed. Must be used only with HTTP.</p>
 
 </td>
@@ -822,7 +822,7 @@ Yes
 <td><code>string[]</code></td>
 <td>
 <p>Optional. A list of allowed values for the attribute.
-Note: at least one of values or not_values must be set.</p>
+Note: at least one of <code>values</code> or <code>notValues</code> must be set.</p>
 
 </td>
 <td>
@@ -834,7 +834,7 @@ No
 <td><code>string[]</code></td>
 <td>
 <p>Optional. A list of negative match of values for the attribute.
-Note: at least one of values or not_values must be set.</p>
+Note: at least one of <code>values</code> or <code>notValues</code> must be set.</p>
 
 </td>
 <td>
@@ -972,7 +972,7 @@ the extension by specifying the name of the provider.
 One example use case of the extension is to integrate with a custom external authorization system to delegate
 the authorization decision to it.</p>
 <p>The following authorization policy applies to an ingress gateway and delegates the authorization check to a named extension
-&ldquo;my-custom-authz&rdquo; if the request path has prefix &ldquo;/admin/&rdquo;.</p>
+<code>my-custom-authz</code> if the request path has prefix <code>/admin/</code>.</p>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -517,7 +517,7 @@ message AuthorizationPolicy {
     // the authorization decision to it.
     //
     // The following authorization policy applies to an ingress gateway and delegates the authorization check to a named extension
-    // "my-custom-authz" if the request path has prefix "/admin/".
+    // `my-custom-authz` if the request path has prefix `/admin/`.
     //
     // ```yaml
     // apiVersion: security.istio.io/v1beta1
@@ -561,10 +561,10 @@ message AuthorizationPolicy {
 //
 // Any string field in the rule supports Exact, Prefix, Suffix and Presence match:
 //
-// - Exact match: "abc" will match on value "abc".
-// - Prefix match: "abc*" will match on value "abc" and "abcd".
-// - Suffix match: "*abc" will match on value "abc" and "xabc".
-// - Presence match: "*" will match when value is not empty.
+// - Exact match: `abc` will match on value `abc`.
+// - Prefix match: `abc*` will match on value `abc` and `abcd`.
+// - Suffix match: `*abc` will match on value `abc` and `xabc`.
+// - Presence match: `*` will match when value is not empty.
 message Rule {
   // From includes a list of sources.
   message From {
@@ -572,7 +572,7 @@ message Rule {
     Source source = 1;
   }
 
-  // Optional. from specifies the source of a request.
+  // Optional. `from` specifies the source of a request.
   //
   // If not set, any source is allowed.
   repeated From from = 1;
@@ -583,12 +583,12 @@ message Rule {
     Operation operation = 1;
   }
 
-  // Optional. to specifies the operation of a request.
+  // Optional. `to` specifies the operation of a request.
   //
   // If not set, any operation is allowed.
   repeated To to = 2;
 
-  // Optional. when specifies a list of additional conditions of a request.
+  // Optional. `when` specifies a list of additional conditions of a request.
   //
   // If not set, any condition is allowed.
   repeated Condition when = 3;
@@ -597,8 +597,8 @@ message Rule {
 // Source specifies the source identities of a request. Fields in the source are
 // ANDed together.
 //
-// For example, the following source matches if the principal is "admin" or "dev"
-// and the namespace is "prod" or "test" and the ip is not "203.0.113.4".
+// For example, the following source matches if the principal is `admin` or `dev`
+// and the namespace is `prod` or `test` and the ip is not `203.0.113.4`.
 //
 // ```yaml
 // principals: ["admin", "dev"]
@@ -635,8 +635,8 @@ message Source {
   // Optional. A list of negative match of namespaces.
   repeated string not_namespaces = 7;
 
-  // Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. "203.0.113.4") and
-  // CIDR (e.g. "203.0.113.0/24") are supported. This is the same as the `source.ip` attribute.
+  // Optional. A list of IP blocks, populated from the source address of the IP packet. Single IP (e.g. `203.0.113.4`) and
+  // CIDR (e.g. `203.0.113.0/24`) are supported. This is the same as the `source.ip` attribute.
   //
   // If not set, any IP is allowed.
   repeated string ip_blocks = 4;
@@ -644,11 +644,11 @@ message Source {
   // Optional. A list of negative match of IP blocks.
   repeated string not_ip_blocks = 8;
 
-  // Optional. A list of IP blocks, populated from X-Forwarded-For header or proxy protocol.
-  // To make use of this field, you must configure the numTrustedProxies field of the gatewayTopology under the meshConfig
+  // Optional. A list of IP blocks, populated from `X-Forwarded-For` header or proxy protocol.
+  // To make use of this field, you must configure the `numTrustedProxies` field of the `gatewayTopology` under the `meshConfig`
   // when you install Istio or using an annotation on the ingress gateway.  See the documentation here:
   // [Configuring Gateway Network Topology](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/).
-  // Single IP (e.g. "203.0.113.4") and CIDR (e.g. "203.0.113.0/24") are supported.
+  // Single IP (e.g. `203.0.113.4`) and CIDR (e.g. `203.0.113.0/24`) are supported.
   // This is the same as the `remote.ip` attribute.
   //
   // If not set, any IP is allowed.
@@ -661,8 +661,8 @@ message Source {
 // Operation specifies the operations of a request. Fields in the operation are
 // ANDed together.
 //
-// For example, the following operation matches if the host has suffix ".example.com"
-// and the method is "GET" or "HEAD" and the path doesn't have prefix "/admin".
+// For example, the following operation matches if the host has suffix `.example.com`
+// and the method is `GET` or `HEAD` and the path doesn't have prefix `/admin`.
 //
 // ```yaml
 // hosts: ["*.example.com"]
@@ -689,7 +689,7 @@ message Operation {
   repeated string not_ports = 6;
 
   // Optional. A list of methods as specified in the HTTP request.
-  // For gRPC service, this will always be "POST".
+  // For gRPC service, this will always be `POST`.
   //
   // If not set, any method is allowed. Must be used only with HTTP.
   repeated string methods = 3;
@@ -699,7 +699,7 @@ message Operation {
 
   // Optional. A list of paths as specified in the HTTP request. See the [Authorization Policy Normalization](https://istio.io/latest/docs/reference/config/security/normalization/)
   // for details of the path normalization.
-  // For gRPC service, this will be the fully-qualified name in the form of "/package.service/method".
+  // For gRPC service, this will be the fully-qualified name in the form of `/package.service/method`.
   //
   // If not set, any path is allowed. Must be used only with HTTP.
   repeated string paths = 4;
@@ -715,10 +715,10 @@ message Condition {
   string key = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. A list of allowed values for the attribute.
-  // Note: at least one of values or not_values must be set.
+  // Note: at least one of `values` or `notValues` must be set.
   repeated string values = 2;
 
   // Optional. A list of negative match of values for the attribute.
-  // Note: at least one of values or not_values must be set.
+  // Note: at least one of `values` or `notValues` must be set.
   repeated string not_values = 3;
 }


### PR DESCRIPTION
Minor formatting fixes (i.e. `backticks`) and fixing the field name in the doc.