### PR TITLE
docs: fix formatting issues, typo, add links

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -8228,7 +8228,7 @@ spec:
                             nullable: true
                             type: boolean
                           match:
-                            description: Match allows provides the scope of the override.
+                            description: Match allows providing the scope of the override.
                             oneOf:
                             - not:
                                 anyOf:
@@ -8246,8 +8246,8 @@ spec:
                                 minLength: 1
                                 type: string
                               metric:
-                                description: One of the well-known Istio Standard
-                                  Metrics.
+                                description: One of the well-known [Istio Standard
+                                  Metrics](https://istio.io/latest/docs/reference/config/metrics/).
                                 enum:
                                 - ALL_METRICS
                                 - REQUEST_COUNT
@@ -8263,7 +8263,7 @@ spec:
                                 type: string
                               mode:
                                 description: 'Controls which mode of metrics generation
-                                  is selected: CLIENT and/or SERVER.'
+                                  is selected: `CLIENT`, `SERVER`, or `CLIENT_AND_SERVER`.'
                                 enum:
                                 - CLIENT_AND_SERVER
                                 - CLIENT

--- a/telemetry/v1alpha1/telemetry.pb.go
+++ b/telemetry/v1alpha1/telemetry.pb.go
@@ -41,7 +41,7 @@
 // 2. Namespace-specific configuration
 // 3. Root namespace configuration
 //
-// Examples:
+// ## Examples
 //
 // Policy to enable random sampling for 10% of traffic:
 // ```yaml
@@ -56,7 +56,7 @@
 //   - randomSamplingPercentage: 10.00
 // ```
 //
-// Policy to disable trace reporting for the "foo" workload (note: tracing
+// Policy to disable trace reporting for the `foo` workload (note: tracing
 // context will still be propagated):
 // ```yaml
 // apiVersion: telemetry.istio.io/v1alpha1
@@ -146,7 +146,7 @@
 //           value: "request.host"
 // ```
 //
-// Policy to remove the response_code dimension on some Prometheus metrics for
+// Policy to remove the `response_code` dimension on some Prometheus metrics for
 // the `bar.foo` workload:
 // ```yaml
 // apiVersion: telemetry.istio.io/v1alpha1
@@ -237,10 +237,10 @@ const (
 )
 
 // WorkloadMode allows selection of the role of the underlying workload in
-// network traffic. A workload is considered as acting as a SERVER if it is
+// network traffic. A workload is considered as acting as a `SERVER` if it is
 // the destination of the traffic (that is, traffic direction, from the
 // perspective of the workload is *inbound*). If the workload is the source of
-// the network traffic, it is considered to be in CLIENT mode (traffic is
+// the network traffic, it is considered to be in `CLIENT` mode (traffic is
 // *outbound* from the workload).
 type WorkloadMode int32
 
@@ -460,7 +460,7 @@ type MetricsOverrides_TagOverride_Operation int32
 
 const (
 	// Insert or Update the tag with the provided value expression. The
-	// `value` field MUST be specified if UPSERT is used as the operation.
+	// `value` field MUST be specified if `UPSERT` is used as the operation.
 	MetricsOverrides_TagOverride_UPSERT MetricsOverrides_TagOverride_Operation = 0
 	// Specifies that the tag should not be included in the metric when
 	// generated.
@@ -541,23 +541,23 @@ type Telemetry struct {
 	//
 	// At most, only one of the selector or targetRef can be set for a given policy.
 	Selector *v1beta1.WorkloadSelector `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
-	// Optional. The targetRef specifies the gateway the policy should be
+	// Optional. The `targetRef` specifies the gateway the policy should be
 	// applied to. The targeted resource specified will determine which
 	// workloads the telemetry policy applies to. The targeted resource
-	// must be a k8s gateway. The resource must be in the same namespace as
+	// must be a Kubernetes gateway. The resource must be in the same namespace as
 	// the Telemetry policy.
 	//
 	// If not set, the policy is applied as defined by the selector.
-	// At most, only one of the selector or targetRef can be set for a given policy.
+	// At most, only one of the selector or `targetRef` can be set for a given policy.
 	// Waypoint proxies will not respect selectors even if they match.
 	TargetRef *v1beta1.PolicyTargetReference `protobuf:"bytes,5,opt,name=targetRef,proto3" json:"targetRef,omitempty"`
 	// Optional. Tracing configures the tracing behavior for all
 	// selected workloads.
 	Tracing []*Tracing `protobuf:"bytes,2,rep,name=tracing,proto3" json:"tracing,omitempty"`
-	// Optional. Metrics configure the metrics behavior for all
+	// Optional. Metrics configures the metrics behavior for all
 	// selected workloads.
 	Metrics []*Metrics `protobuf:"bytes,3,rep,name=metrics,proto3" json:"metrics,omitempty"`
-	// Optional. AccessLogging configures the access logging behavior for all
+	// Optional. Access logging configures the access logging behavior for all
 	// selected workloads.
 	AccessLogging []*AccessLogging `protobuf:"bytes,4,rep,name=access_logging,json=accessLogging,proto3" json:"access_logging,omitempty"`
 }
@@ -764,7 +764,7 @@ type ProviderRef struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Required. Name of Telemetry provider in MeshConfig.
+	// Required. Name of Telemetry provider in [MeshConfig](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider).
 	// +kubebuilder:validation:MinLength=1
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 }
@@ -908,8 +908,8 @@ type MetricSelector struct {
 	//	*MetricSelector_Metric
 	//	*MetricSelector_CustomMetric
 	MetricMatch isMetricSelector_MetricMatch `protobuf_oneof:"metric_match"`
-	// Controls which mode of metrics generation is selected: CLIENT and/or
-	// SERVER.
+	// Controls which mode of metrics generation is selected: `CLIENT`, `SERVER`,
+	// or `CLIENT_AND_SERVER`.
 	Mode WorkloadMode `protobuf:"varint,3,opt,name=mode,proto3,enum=istio.telemetry.v1alpha1.WorkloadMode" json:"mode,omitempty"`
 }
 
@@ -978,7 +978,7 @@ type isMetricSelector_MetricMatch interface {
 }
 
 type MetricSelector_Metric struct {
-	// One of the well-known Istio Standard Metrics.
+	// One of the well-known [Istio Standard Metrics](https://istio.io/latest/docs/reference/config/metrics/).
 	Metric MetricSelector_IstioMetric `protobuf:"varint,1,opt,name=metric,proto3,enum=istio.telemetry.v1alpha1.MetricSelector_IstioMetric,oneof"`
 }
 
@@ -1000,16 +1000,16 @@ type MetricsOverrides struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Match allows provides the scope of the override. It can be used to select
-	// individual metrics, as well as the workload modes (server and/or client)
+	// Match allows providing the scope of the override. It can be used to select
+	// individual metrics, as well as the workload modes (server, client, or both)
 	// in which the metrics will be generated.
 	//
 	// If match is not specified, the overrides will apply to *all* metrics for
 	// *both* modes of operation (client and server).
 	Match *MetricSelector `protobuf:"bytes,1,opt,name=match,proto3" json:"match,omitempty"`
-	// Optional. Must explicitly set this to "true" to turn off metrics reporting
-	// for the listed metrics. If disabled has been set to "true" in a parent
-	// configuration, it must explicitly be set to "false" to turn metrics
+	// Optional. Must explicitly set this to `true` to turn off metrics reporting
+	// for the listed metrics. If disabled has been set to `true` in a parent
+	// configuration, it must explicitly be set to `false` to turn metrics
 	// reporting on in the workloads selected by the Telemetry resource.
 	Disabled *wrappers.BoolValue `protobuf:"bytes,2,opt,name=disabled,proto3" json:"disabled,omitempty"`
 	// Optional. Collection of tag names and tag expressions to override in the
@@ -1497,8 +1497,8 @@ type MetricsOverrides_TagOverride struct {
 	Operation MetricsOverrides_TagOverride_Operation `protobuf:"varint,1,opt,name=operation,proto3,enum=istio.telemetry.v1alpha1.MetricsOverrides_TagOverride_Operation" json:"operation,omitempty"`
 	// Value is only considered if the operation is `UPSERT`.
 	// Values are [CEL expressions](https://opensource.google/projects/cel) over
-	// attributes. Examples include: "string(destination.port)" and
-	// "request.host". Istio exposes all standard [Envoy
+	// attributes. Examples include: `string(destination.port)` and
+	// `request.host`. Istio exposes all standard [Envoy
 	// attributes](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes).
 	// Additionally, Istio exposes node metadata as attributes.
 	// More information is provided in the [customization
@@ -1555,9 +1555,9 @@ func (x *MetricsOverrides_TagOverride) GetValue() string {
 // LogSelector provides a coarse-grained ability to configure logging behavior
 // based on certain traffic metadata (such as traffic direction). LogSelector
 // applies to traffic metadata which is not represented in the attribute set
-// currently supported by Filters. It allows control planes to limit the
-// configuration sent to individual workloads. Finer-grained logging behavior
-// can be further configured via `filter`.
+// currently supported by [filters](https://istio.io/latest/docs/reference/config/telemetry/#AccessLogging-Filter).
+// It allows control planes to limit the configuration sent to individual workloads.
+// Finer-grained logging behavior can be further configured via `filter`.
 type AccessLogging_LogSelector struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/telemetry/v1alpha1/telemetry.pb.html
+++ b/telemetry/v1alpha1/telemetry.pb.html
@@ -21,7 +21,7 @@ selecting any given workload.</p>
 <li>Namespace-specific configuration</li>
 <li>Root namespace configuration</li>
 </ol>
-<p>Examples:</p>
+<h4 id="examples">Examples</h4>
 <p>Policy to enable random sampling for 10% of traffic:</p>
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
@@ -33,7 +33,7 @@ spec:
   tracing:
   - randomSamplingPercentage: 10.00
 </code></pre>
-<p>Policy to disable trace reporting for the &ldquo;foo&rdquo; workload (note: tracing
+<p>Policy to disable trace reporting for the <code>foo</code> workload (note: tracing
 context will still be propagated):</p>
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
@@ -113,7 +113,7 @@ spec:
         request_host:
           value: &quot;request.host&quot;
 </code></pre>
-<p>Policy to remove the response_code dimension on some Prometheus metrics for
+<p>Policy to remove the <code>response_code</code> dimension on some Prometheus metrics for
 the <code>bar.foo</code> workload:</p>
 <pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
@@ -208,13 +208,13 @@ No
 <td><code>targetRef</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#PolicyTargetReference">PolicyTargetReference</a></code></td>
 <td>
-<p>Optional. The targetRef specifies the gateway the policy should be
+<p>Optional. The <code>targetRef</code> specifies the gateway the policy should be
 applied to. The targeted resource specified will determine which
 workloads the telemetry policy applies to. The targeted resource
-must be a k8s gateway. The resource must be in the same namespace as
+must be a Kubernetes gateway. The resource must be in the same namespace as
 the Telemetry policy.</p>
 <p>If not set, the policy is applied as defined by the selector.
-At most, only one of the selector or targetRef can be set for a given policy.
+At most, only one of the selector or <code>targetRef</code> can be set for a given policy.
 Waypoint proxies will not respect selectors even if they match.</p>
 
 </td>
@@ -238,7 +238,7 @@ No
 <td><code>metrics</code></td>
 <td><code><a href="#Metrics">Metrics[]</a></code></td>
 <td>
-<p>Optional. Metrics configure the metrics behavior for all
+<p>Optional. Metrics configures the metrics behavior for all
 selected workloads.</p>
 
 </td>
@@ -250,7 +250,7 @@ No
 <td><code>accessLogging</code></td>
 <td><code><a href="#AccessLogging">AccessLogging[]</a></code></td>
 <td>
-<p>Optional. AccessLogging configures the access logging behavior for all
+<p>Optional. Access logging configures the access logging behavior for all
 selected workloads.</p>
 
 </td>
@@ -372,7 +372,7 @@ targeted customization.</p>
 <td><code>name</code></td>
 <td><code>string</code></td>
 <td>
-<p>Required. Name of Telemetry provider in MeshConfig.</p>
+<p>Required. Name of Telemetry provider in <a href="https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider">MeshConfig</a>.</p>
 
 </td>
 <td>
@@ -470,7 +470,7 @@ behaviors.</p>
 <td><code>metric</code></td>
 <td><code><a href="#MetricSelector-IstioMetric">IstioMetric (oneof)</a></code></td>
 <td>
-<p>One of the well-known Istio Standard Metrics.</p>
+<p>One of the well-known <a href="https://istio.io/latest/docs/reference/config/metrics/">Istio Standard Metrics</a>.</p>
 
 </td>
 <td>
@@ -493,8 +493,8 @@ No
 <td><code>mode</code></td>
 <td><code><a href="#WorkloadMode">WorkloadMode</a></code></td>
 <td>
-<p>Controls which mode of metrics generation is selected: CLIENT and/or
-SERVER.</p>
+<p>Controls which mode of metrics generation is selected: <code>CLIENT</code>, <code>SERVER</code>,
+or <code>CLIENT_AND_SERVER</code>.</p>
 
 </td>
 <td>
@@ -523,8 +523,8 @@ metric or the set of all standard metrics.</p>
 <td><code>match</code></td>
 <td><code><a href="#MetricSelector">MetricSelector</a></code></td>
 <td>
-<p>Match allows provides the scope of the override. It can be used to select
-individual metrics, as well as the workload modes (server and/or client)
+<p>Match allows providing the scope of the override. It can be used to select
+individual metrics, as well as the workload modes (server, client, or both)
 in which the metrics will be generated.</p>
 <p>If match is not specified, the overrides will apply to <em>all</em> metrics for
 <em>both</em> modes of operation (client and server).</p>
@@ -538,9 +538,9 @@ No
 <td><code>disabled</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#boolvalue">BoolValue</a></code></td>
 <td>
-<p>Optional. Must explicitly set this to &ldquo;true&rdquo; to turn off metrics reporting
-for the listed metrics. If disabled has been set to &ldquo;true&rdquo; in a parent
-configuration, it must explicitly be set to &ldquo;false&rdquo; to turn metrics
+<p>Optional. Must explicitly set this to <code>true</code> to turn off metrics reporting
+for the listed metrics. If disabled has been set to <code>true</code> in a parent
+configuration, it must explicitly be set to <code>false</code> to turn metrics
 reporting on in the workloads selected by the Telemetry resource.</p>
 
 </td>
@@ -858,8 +858,8 @@ No
 <td>
 <p>Value is only considered if the operation is <code>UPSERT</code>.
 Values are <a href="https://opensource.google/projects/cel">CEL expressions</a> over
-attributes. Examples include: &ldquo;string(destination.port)&rdquo; and
-&ldquo;request.host&rdquo;. Istio exposes all standard <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes">Envoy
+attributes. Examples include: <code>string(destination.port)</code> and
+<code>request.host</code>. Istio exposes all standard <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes">Envoy
 attributes</a>.
 Additionally, Istio exposes node metadata as attributes.
 More information is provided in the <a href="https://istio.io/latest/docs/tasks/observability/metrics/customize-metrics/#use-expressions-for-values">customization
@@ -878,9 +878,9 @@ No
 <p>LogSelector provides a coarse-grained ability to configure logging behavior
 based on certain traffic metadata (such as traffic direction). LogSelector
 applies to traffic metadata which is not represented in the attribute set
-currently supported by Filters. It allows control planes to limit the
-configuration sent to individual workloads. Finer-grained logging behavior
-can be further configured via <code>filter</code>.</p>
+currently supported by <a href="https://istio.io/latest/docs/reference/config/telemetry/#AccessLogging-Filter">filters</a>.
+It allows control planes to limit the configuration sent to individual workloads.
+Finer-grained logging behavior can be further configured via <code>filter</code>.</p>
 
 <table class="message-fields">
 <thead>
@@ -1111,7 +1111,7 @@ traffic.</p>
 <td><code>UPSERT</code></td>
 <td>
 <p>Insert or Update the tag with the provided value expression. The
-<code>value</code> field MUST be specified if UPSERT is used as the operation.</p>
+<code>value</code> field MUST be specified if <code>UPSERT</code> is used as the operation.</p>
 
 </td>
 </tr>
@@ -1129,10 +1129,10 @@ generated.</p>
 <h2 id="WorkloadMode">WorkloadMode</h2>
 <section>
 <p>WorkloadMode allows selection of the role of the underlying workload in
-network traffic. A workload is considered as acting as a SERVER if it is
+network traffic. A workload is considered as acting as a <code>SERVER</code> if it is
 the destination of the traffic (that is, traffic direction, from the
 perspective of the workload is <em>inbound</em>). If the workload is the source of
-the network traffic, it is considered to be in CLIENT mode (traffic is
+the network traffic, it is considered to be in <code>CLIENT</code> mode (traffic is
 <em>outbound</em> from the workload).</p>
 
 <table class="enum-values">

--- a/telemetry/v1alpha1/telemetry.proto
+++ b/telemetry/v1alpha1/telemetry.proto
@@ -42,7 +42,7 @@ import "google/protobuf/wrappers.proto";
 // 2. Namespace-specific configuration
 // 3. Root namespace configuration
 //
-// Examples:
+// ## Examples
 //
 // Policy to enable random sampling for 10% of traffic:
 // ```yaml
@@ -57,7 +57,7 @@ import "google/protobuf/wrappers.proto";
 //   - randomSamplingPercentage: 10.00
 // ```
 //
-// Policy to disable trace reporting for the "foo" workload (note: tracing
+// Policy to disable trace reporting for the `foo` workload (note: tracing
 // context will still be propagated):
 // ```yaml
 // apiVersion: telemetry.istio.io/v1alpha1
@@ -147,7 +147,7 @@ import "google/protobuf/wrappers.proto";
 //           value: "request.host"
 // ```
 //
-// Policy to remove the response_code dimension on some Prometheus metrics for
+// Policy to remove the `response_code` dimension on some Prometheus metrics for
 // the `bar.foo` workload:
 // ```yaml
 // apiVersion: telemetry.istio.io/v1alpha1
@@ -252,14 +252,14 @@ message Telemetry {
   // At most, only one of the selector or targetRef can be set for a given policy.
   istio.type.v1beta1.WorkloadSelector selector = 1;
 
-  // Optional. The targetRef specifies the gateway the policy should be 
+  // Optional. The `targetRef` specifies the gateway the policy should be 
   // applied to. The targeted resource specified will determine which 
   // workloads the telemetry policy applies to. The targeted resource
-  // must be a k8s gateway. The resource must be in the same namespace as
+  // must be a Kubernetes gateway. The resource must be in the same namespace as
   // the Telemetry policy.
   //
   // If not set, the policy is applied as defined by the selector.
-  // At most, only one of the selector or targetRef can be set for a given policy.
+  // At most, only one of the selector or `targetRef` can be set for a given policy.
   // Waypoint proxies will not respect selectors even if they match.
   istio.type.v1beta1.PolicyTargetReference targetRef = 5;
 
@@ -267,11 +267,11 @@ message Telemetry {
   // selected workloads.
   repeated Tracing tracing = 2;
 
-  // Optional. Metrics configure the metrics behavior for all
+  // Optional. Metrics configures the metrics behavior for all
   // selected workloads.
   repeated Metrics metrics = 3;
 
-  // Optional. AccessLogging configures the access logging behavior for all
+  // Optional. Access logging configures the access logging behavior for all
   // selected workloads.
   repeated AccessLogging access_logging = 4;
 }
@@ -387,7 +387,7 @@ message Tracing {
 // Used to bind Telemetry configuration to specific providers for
 // targeted customization.
 message ProviderRef {
-  // Required. Name of Telemetry provider in MeshConfig.
+  // Required. Name of Telemetry provider in [MeshConfig](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider).
   // +kubebuilder:validation:MinLength=1
   string name = 1 [(google.api.field_behavior) = REQUIRED];
 }
@@ -424,10 +424,10 @@ message Metrics {
 }
 
 // WorkloadMode allows selection of the role of the underlying workload in
-// network traffic. A workload is considered as acting as a SERVER if it is
+// network traffic. A workload is considered as acting as a `SERVER` if it is
 // the destination of the traffic (that is, traffic direction, from the
 // perspective of the workload is *inbound*). If the workload is the source of
-// the network traffic, it is considered to be in CLIENT mode (traffic is
+// the network traffic, it is considered to be in `CLIENT` mode (traffic is
 // *outbound* from the workload).
 enum WorkloadMode {
   // Selects for scenarios when the workload is either the
@@ -558,7 +558,7 @@ message MetricSelector {
 
   // Controls which metric(s) are selected by the selector.
   oneof metric_match {
-    // One of the well-known Istio Standard Metrics.
+    // One of the well-known [Istio Standard Metrics](https://istio.io/latest/docs/reference/config/metrics/).
     IstioMetric metric = 1;
 
     // Allows free-form specification of a metric. No validation of custom
@@ -567,8 +567,8 @@ message MetricSelector {
     string custom_metric = 2;
   }
 
-  // Controls which mode of metrics generation is selected: CLIENT and/or
-  // SERVER.
+  // Controls which mode of metrics generation is selected: `CLIENT`, `SERVER`,
+  // or `CLIENT_AND_SERVER`.
   WorkloadMode mode = 3;
 }
 
@@ -576,17 +576,17 @@ message MetricSelector {
 // metric or the set of all standard metrics.
 message MetricsOverrides {
 
-  // Match allows provides the scope of the override. It can be used to select
-  // individual metrics, as well as the workload modes (server and/or client)
+  // Match allows providing the scope of the override. It can be used to select
+  // individual metrics, as well as the workload modes (server, client, or both)
   // in which the metrics will be generated.
   //
   // If match is not specified, the overrides will apply to *all* metrics for
   // *both* modes of operation (client and server).
   MetricSelector match = 1;
 
-  // Optional. Must explicitly set this to "true" to turn off metrics reporting
-  // for the listed metrics. If disabled has been set to "true" in a parent
-  // configuration, it must explicitly be set to "false" to turn metrics
+  // Optional. Must explicitly set this to `true` to turn off metrics reporting
+  // for the listed metrics. If disabled has been set to `true` in a parent
+  // configuration, it must explicitly be set to `false` to turn metrics
   // reporting on in the workloads selected by the Telemetry resource.
   google.protobuf.BoolValue disabled = 2;
 
@@ -598,7 +598,7 @@ message MetricsOverrides {
   message TagOverride {
     enum Operation {
       // Insert or Update the tag with the provided value expression. The
-      // `value` field MUST be specified if UPSERT is used as the operation.
+      // `value` field MUST be specified if `UPSERT` is used as the operation.
       UPSERT = 0;
 
       // Specifies that the tag should not be included in the metric when
@@ -611,8 +611,8 @@ message MetricsOverrides {
 
     // Value is only considered if the operation is `UPSERT`.
     // Values are [CEL expressions](https://opensource.google/projects/cel) over
-    // attributes. Examples include: "string(destination.port)" and
-    // "request.host". Istio exposes all standard [Envoy
+    // attributes. Examples include: `string(destination.port)` and
+    // `request.host`. Istio exposes all standard [Envoy
     // attributes](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes).
     // Additionally, Istio exposes node metadata as attributes.
     // More information is provided in the [customization
@@ -637,9 +637,9 @@ message AccessLogging {
   // LogSelector provides a coarse-grained ability to configure logging behavior
   // based on certain traffic metadata (such as traffic direction). LogSelector
   // applies to traffic metadata which is not represented in the attribute set
-  // currently supported by Filters. It allows control planes to limit the
-  // configuration sent to individual workloads. Finer-grained logging behavior
-  // can be further configured via `filter`.
+  // currently supported by [filters](https://istio.io/latest/docs/reference/config/telemetry/#AccessLogging-Filter).
+  // It allows control planes to limit the configuration sent to individual workloads.
+  // Finer-grained logging behavior can be further configured via `filter`.
   message LogSelector {
     // This determines whether or not to apply the access logging configuration
     // based on the direction of traffic relative to the proxied workload.


### PR DESCRIPTION
Minor formatting fixes, typos, and adding a link or two as references.