### PR TITLE
Doc: Add note on DR workloadSelector

### DIFF
--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -167,6 +167,12 @@
 // The following example shows how a destination rule can be applied to a
 // specific workload using the workloadSelector configuration.
 //
+// **Note:** The workloadSelector configuration in
+// Destination Rules reveals which workloads the traffic emanating from
+// uses this Destination Rule, unlike the workloadSelector configuration
+// in [ServiceEntries](https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry),
+// which is used to reveal which workloads the traffic is routed to.
+//
 // {{<tabset category-name="selector-example">}}
 // {{<tab name="v1alpha3" category-value="v1alpha3">}}
 // ```yaml

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -134,6 +134,11 @@ spec:
 <p>Destination Rules can be customized to specific workloads as well.
 The following example shows how a destination rule can be applied to a
 specific workload using the workloadSelector configuration.</p>
+<p><strong>Note:</strong> The workloadSelector configuration in
+Destination Rules reveals which workloads the traffic emanating from
+uses this Destination Rule, unlike the workloadSelector configuration
+in <a href="https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry">ServiceEntries</a>,
+which is used to reveal which workloads the traffic is routed to.</p>
 <p>{{<tabset category-name="selector-example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -168,6 +168,12 @@ import "type/v1beta1/selector.proto";
 // The following example shows how a destination rule can be applied to a
 // specific workload using the workloadSelector configuration.
 //
+// **Note:** The workloadSelector configuration in 
+// Destination Rules reveals which workloads the traffic emanating from 
+// uses this Destination Rule, unlike the workloadSelector configuration 
+// in [ServiceEntries](https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry), 
+// which is used to reveal which workloads the traffic is routed to.
+// 
 // {{<tabset category-name="selector-example">}}
 // {{<tab name="v1alpha3" category-value="v1alpha3">}}
 // ```yaml


### PR DESCRIPTION
Supplementary explanation based on https://github.com/istio/istio/issues/49111#issuecomment-1921674872.
The same field name WorkloadSelector has a different effect/behavior in DR and SE. WorkloadSelector in ServiceEntry indicates destination workloads of traffic, while in DR workloadSelector reveals which workloads the traffic emanating from uses the DR. 