### PR TITLE
crds: deprecate old versions

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -252,6 +252,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: destinationrules.networking.istio.io version "v1alpha3" is
+      deprecated, use "v1beta1"
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -3556,7 +3559,10 @@ spec:
     singular: gateway
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    deprecationWarning: gateways.networking.istio.io version "v1alpha3" is deprecated,
+      use "v1beta1"
+    name: v1alpha3
     schema:
       openAPIV3Schema:
         properties:
@@ -3969,6 +3975,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: serviceentries.networking.istio.io version "v1alpha3" is deprecated,
+      use "v1beta1"
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -4257,7 +4266,10 @@ spec:
     singular: sidecar
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    deprecationWarning: sidecars.networking.istio.io version "v1alpha3" is deprecated,
+      use "v1beta1"
+    name: v1alpha3
     schema:
       openAPIV3Schema:
         properties:
@@ -5086,6 +5098,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: virtualservices.networking.istio.io version "v1alpha3" is
+      deprecated, use "v1beta1"
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -6940,6 +6955,9 @@ spec:
       jsonPath: .spec.address
       name: Address
       type: string
+    deprecated: true
+    deprecationWarning: workloadentries.networking.istio.io version "v1alpha3" is
+      deprecated, use "v1beta1"
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -7076,6 +7094,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: workloadgroups.networking.istio.io version "v1alpha3" is deprecated,
+      use "v1beta1"
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -7654,6 +7675,9 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: authorizationpolicies.security.istio.io version "v1beta1"
+      is deprecated, use "v1"
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -8101,7 +8125,10 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: requestauthentications.security.istio.io version "v1beta1"
+      is deprecated, use "v1"
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -491,6 +491,7 @@ func (ClientTLSSettings_TLSmode) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:DestinationRule:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:DestinationRule:subresource:status
 // +cue-gen:DestinationRule:scope:Namespaced
+// +cue-gen:DestinationRule:deprecationReplacement:v1beta1
 // +cue-gen:DestinationRule:resource:categories=istio-io,networking-istio-io,shortNames=dr
 // +cue-gen:DestinationRule:printerColumn:name=Host,type=string,JSONPath=.spec.host,description="The name of a service from the service registry"
 // +cue-gen:DestinationRule:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -230,6 +230,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:DestinationRule:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:DestinationRule:subresource:status
 // +cue-gen:DestinationRule:scope:Namespaced
+// +cue-gen:DestinationRule:deprecationReplacement:v1beta1
 // +cue-gen:DestinationRule:resource:categories=istio-io,networking-istio-io,shortNames=dr
 // +cue-gen:DestinationRule:printerColumn:name=Host,type=string,JSONPath=.spec.host,description="The name of a service from the service registry"
 // +cue-gen:DestinationRule:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -530,6 +530,7 @@ func (ServerTLSSettings_TLSProtocol) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:Gateway:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:Gateway:subresource:status
 // +cue-gen:Gateway:scope:Namespaced
+// +cue-gen:Gateway:deprecationReplacement:v1beta1
 // +cue-gen:Gateway:resource:categories=istio-io,networking-istio-io,shortNames=gw
 // +cue-gen:Gateway:preserveUnknownFields:false
 // -->

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -362,6 +362,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:Gateway:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:Gateway:subresource:status
 // +cue-gen:Gateway:scope:Namespaced
+// +cue-gen:Gateway:deprecationReplacement:v1beta1
 // +cue-gen:Gateway:resource:categories=istio-io,networking-istio-io,shortNames=gw
 // +cue-gen:Gateway:preserveUnknownFields:false
 // -->

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -939,6 +939,7 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:ServiceEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:ServiceEntry:subresource:status
 // +cue-gen:ServiceEntry:scope:Namespaced
+// +cue-gen:ServiceEntry:deprecationReplacement:v1beta1
 // +cue-gen:ServiceEntry:resource:categories=istio-io,networking-istio-io,shortNames=se,plural=serviceentries
 // +cue-gen:ServiceEntry:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The hosts associated with the ServiceEntry"
 // +cue-gen:ServiceEntry:printerColumn:name=Location,type=string,JSONPath=.spec.location,description="Whether the service is external to the

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -781,6 +781,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:ServiceEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:ServiceEntry:subresource:status
 // +cue-gen:ServiceEntry:scope:Namespaced
+// +cue-gen:ServiceEntry:deprecationReplacement:v1beta1
 // +cue-gen:ServiceEntry:resource:categories=istio-io,networking-istio-io,shortNames=se,plural=serviceentries
 // +cue-gen:ServiceEntry:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The hosts associated with the ServiceEntry"
 // +cue-gen:ServiceEntry:printerColumn:name=Location,type=string,JSONPath=.spec.location,description="Whether the service is external to the

--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -693,6 +693,7 @@ func (OutboundTrafficPolicy_Mode) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:Sidecar:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:Sidecar:subresource:status
 // +cue-gen:Sidecar:scope:Namespaced
+// +cue-gen:Sidecar:deprecationReplacement:v1beta1
 // +cue-gen:Sidecar:resource:categories=istio-io,networking-istio-io
 // +cue-gen:Sidecar:preserveUnknownFields:false
 // -->

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -572,6 +572,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:Sidecar:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:Sidecar:subresource:status
 // +cue-gen:Sidecar:scope:Namespaced
+// +cue-gen:Sidecar:deprecationReplacement:v1beta1
 // +cue-gen:Sidecar:resource:categories=istio-io,networking-istio-io
 // +cue-gen:Sidecar:preserveUnknownFields:false
 // -->

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -247,6 +247,7 @@ func (HTTPRedirect_RedirectPortSelection) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:VirtualService:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:VirtualService:subresource:status
 // +cue-gen:VirtualService:scope:Namespaced
+// +cue-gen:VirtualService:deprecationReplacement:v1beta1
 // +cue-gen:VirtualService:resource:categories=istio-io,networking-istio-io,shortNames=vs
 // +cue-gen:VirtualService:printerColumn:name=Gateways,type=string,JSONPath=.spec.gateways,description="The names of gateways and sidecars
 // that should apply these routes"

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -185,6 +185,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:VirtualService:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:VirtualService:subresource:status
 // +cue-gen:VirtualService:scope:Namespaced
+// +cue-gen:VirtualService:deprecationReplacement:v1beta1
 // +cue-gen:VirtualService:resource:categories=istio-io,networking-istio-io,shortNames=vs
 // +cue-gen:VirtualService:printerColumn:name=Gateways,type=string,JSONPath=.spec.gateways,description="The names of gateways and sidecars
 // that should apply these routes"

--- a/networking/v1alpha3/workload_entry.pb.go
+++ b/networking/v1alpha3/workload_entry.pb.go
@@ -295,6 +295,7 @@ const (
 // +cue-gen:WorkloadEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadEntry:subresource:status
 // +cue-gen:WorkloadEntry:scope:Namespaced
+// +cue-gen:WorkloadEntry:deprecationReplacement:v1beta1
 // +cue-gen:WorkloadEntry:resource:categories=istio-io,networking-istio-io,shortNames=we,plural=workloadentries
 // +cue-gen:WorkloadEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.

--- a/networking/v1alpha3/workload_entry.proto
+++ b/networking/v1alpha3/workload_entry.proto
@@ -278,6 +278,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:WorkloadEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadEntry:subresource:status
 // +cue-gen:WorkloadEntry:scope:Namespaced
+// +cue-gen:WorkloadEntry:deprecationReplacement:v1beta1
 // +cue-gen:WorkloadEntry:resource:categories=istio-io,networking-istio-io,shortNames=we,plural=workloadentries
 // +cue-gen:WorkloadEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.

--- a/networking/v1alpha3/workload_group.pb.go
+++ b/networking/v1alpha3/workload_group.pb.go
@@ -139,6 +139,7 @@ const (
 // +cue-gen:WorkloadGroup:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadGroup:subresource:status
 // +cue-gen:WorkloadGroup:scope:Namespaced
+// +cue-gen:WorkloadGroup:deprecationReplacement:v1beta1
 // +cue-gen:WorkloadGroup:resource:categories=istio-io,networking-istio-io,shortNames=wg,plural=workloadgroups
 // +cue-gen:WorkloadGroup:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.

--- a/networking/v1alpha3/workload_group.proto
+++ b/networking/v1alpha3/workload_group.proto
@@ -124,6 +124,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +cue-gen:WorkloadGroup:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadGroup:subresource:status
 // +cue-gen:WorkloadGroup:scope:Namespaced
+// +cue-gen:WorkloadGroup:deprecationReplacement:v1beta1
 // +cue-gen:WorkloadGroup:resource:categories=istio-io,networking-istio-io,shortNames=wg,plural=workloadgroups
 // +cue-gen:WorkloadGroup:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -558,6 +558,7 @@ func (AuthorizationPolicy_Action) EnumDescriptor() ([]byte, []int) {
 // +cue-gen:AuthorizationPolicy:scope:Namespaced
 // +cue-gen:AuthorizationPolicy:resource:categories=istio-io,security-istio-io,shortNames=ap,plural=authorizationpolicies
 // +cue-gen:AuthorizationPolicy:preserveUnknownFields:false
+// +cue-gen:AuthorizationPolicy:deprecationReplacement:v1
 // +cue-gen:AuthorizationPolicy:printerColumn:name=Action,type=string,JSONPath=.spec.action,description="The operation to take."
 // +cue-gen:AuthorizationPolicy:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -451,6 +451,7 @@ option go_package="istio.io/api/security/v1beta1";
 // +cue-gen:AuthorizationPolicy:scope:Namespaced
 // +cue-gen:AuthorizationPolicy:resource:categories=istio-io,security-istio-io,shortNames=ap,plural=authorizationpolicies
 // +cue-gen:AuthorizationPolicy:preserveUnknownFields:false
+// +cue-gen:AuthorizationPolicy:deprecationReplacement:v1
 // +cue-gen:AuthorizationPolicy:printerColumn:name=Action,type=string,JSONPath=.spec.action,description="The operation to take."
 // +cue-gen:AuthorizationPolicy:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
 // representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -521,6 +521,7 @@ const (
 // +cue-gen:RequestAuthentication:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio
 // +cue-gen:RequestAuthentication:subresource:status
 // +cue-gen:RequestAuthentication:scope:Namespaced
+// +cue-gen:RequestAuthentication:deprecationReplacement:v1
 // +cue-gen:RequestAuthentication:resource:categories=istio-io,security-istio-io,shortNames=ra
 // +cue-gen:RequestAuthentication:preserveUnknownFields:false
 // -->

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -426,6 +426,7 @@ option go_package="istio.io/api/security/v1beta1";
 // +cue-gen:RequestAuthentication:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio
 // +cue-gen:RequestAuthentication:subresource:status
 // +cue-gen:RequestAuthentication:scope:Namespaced
+// +cue-gen:RequestAuthentication:deprecationReplacement:v1
 // +cue-gen:RequestAuthentication:resource:categories=istio-io,security-istio-io,shortNames=ra
 // +cue-gen:RequestAuthentication:preserveUnknownFields:false
 // -->


### PR DESCRIPTION
This logs errors in Istiod, so we ought to upgrade there before we merge
