### PR TITLE
Fix cloned path in breaking task check

### DIFF
--- a/scripts/breaking.sh
+++ b/scripts/breaking.sh
@@ -25,7 +25,7 @@ rm -rf "${d}"
 
 cwd="${PWD}"
 pushd "${d}" > /dev/null || exit
-git clone "${cwd}" -q -b "${branch}" > /dev/null
+git clone "${cwd}" -q -b "${branch}" api > /dev/null
 cd api
 buf build -o proto.bin
 popd  > /dev/null|| exit


### PR DESCRIPTION
After getting the latest master, I couldn't do the `make gen` task anymore. 

```
./scripts/breaking.sh: line 29: cd: api: No such file or directory
make[1]: *** [Makefile.core.mk:53: breaking] Error 1
make: *** [Makefile:44: gen] Error 2
```

@howardjohn helped me figured out the problem, sending this fix PR :) 