### PR TITLE
Add extended release channel flag to ProxyConfig

### DIFF
--- a/networking/v1beta1/proxy_config.pb.go
+++ b/networking/v1beta1/proxy_config.pb.go
@@ -114,6 +114,7 @@ const (
 // +cue-gen:ProxyConfig:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:ProxyConfig:subresource:status
 // +cue-gen:ProxyConfig:scope:Namespaced
+// +cue-gen:WasmPlugin:releaseChannel:extended
 // +cue-gen:ProxyConfig:resource:categories=istio-io,networking-istio-io,plural=proxyconfigs
 // +cue-gen:ProxyConfig:preserveUnknownFields:false
 // -->

--- a/networking/v1beta1/proxy_config.proto
+++ b/networking/v1beta1/proxy_config.proto
@@ -98,6 +98,7 @@ option go_package= "istio.io/api/networking/v1beta1";
 // +cue-gen:ProxyConfig:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:ProxyConfig:subresource:status
 // +cue-gen:ProxyConfig:scope:Namespaced
+// +cue-gen:WasmPlugin:releaseChannel:extended
 // +cue-gen:ProxyConfig:resource:categories=istio-io,networking-istio-io,plural=proxyconfigs
 // +cue-gen:ProxyConfig:preserveUnknownFields:false
 // -->


### PR DESCRIPTION
Part of [173](https://github.com/istio/enhancements/issues/173)

ProxyConfig was not promoted to v1. Stable channel is v1 only. 