### PR TITLE
Update PeerAuthentication docs

### DIFF
--- a/security/v1/peer_authentication_alias.gen.go
+++ b/security/v1/peer_authentication_alias.gen.go
@@ -3,14 +3,19 @@ package v1
 
 import "istio.io/api/security/v1beta1"
 
-// {{< warning >}}
-// Development of PeerAuthentication is currently frozen and likely to be replaced in Ambient.
-// {{< /warning >}}
-// PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.
+// PeerAuthentication defines mutual TLS (mTLS) requirements for incoming connections.
+//
+// In sidecar mode, PeerAuthentication determines whether or not mTLS is allowed or required
+// for connections to an Envoy proxy sidecar.
+//
+// In ambient mode, security is transparently enabled for a pod by the ztunnel node agent.
+// (Traffic between proxies uses the HBONE protocol, which includes encryption with mTLS.)
+// Because of this, `DISABLE` mode is not supported.
+// `STRICT` mode is useful to ensure that connections that bypass the mesh are not possible.
 //
 // Examples:
 //
-// Policy to allow mTLS traffic for all workloads under namespace `foo`:
+// Policy to require mTLS traffic for all workloads under namespace `foo`:
 // ```yaml
 // apiVersion: security.istio.io/v1
 // kind: PeerAuthentication

--- a/security/v1beta1/peer_authentication.pb.go
+++ b/security/v1beta1/peer_authentication.pb.go
@@ -97,9 +97,11 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 	return file_security_v1beta1_peer_authentication_proto_rawDescGZIP(), []int{0, 0, 0}
 }
 
-// PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.
+// PeerAuthentication defines mutual TLS (mTLS) requirements for incoming connections.
 //
-// Ambient mode implies mTLS, and so DISABLE mode is not supported.
+// In sidecar mode, PeerAuthentication determines whether or not mTLS is enabled, or required, for connections to an Envoy proxy sidecar.
+//
+// In ambient mode, security is transparently enabled for a pod by the ztunnel node agent. (Traffic between proxies uses the HBONE protocol, which includes encryption with mTLS.) Because of this, DISABLE mode is not supported.
 //
 // Examples:
 //

--- a/security/v1beta1/peer_authentication.pb.go
+++ b/security/v1beta1/peer_authentication.pb.go
@@ -99,9 +99,13 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 
 // PeerAuthentication defines mutual TLS (mTLS) requirements for incoming connections.
 //
-// In sidecar mode, PeerAuthentication determines whether or not mTLS is enabled, or required, for connections to an Envoy proxy sidecar.
+// In sidecar mode, PeerAuthentication determines whether or not mTLS is allowed or required
+// for connections to an Envoy proxy sidecar.
 //
-// In ambient mode, security is transparently enabled for a pod by the ztunnel node agent. (Traffic between proxies uses the HBONE protocol, which includes encryption with mTLS.) Because of this, DISABLE mode is not supported.
+// In ambient mode, security is transparently enabled for a pod by the ztunnel node agent.
+// (Traffic between proxies uses the HBONE protocol, which includes encryption with mTLS.)
+// Because of this, `DISABLE` mode is not supported.
+// `STRICT` mode is useful to ensure that connections that bypass the mesh are not possible.
 //
 // Examples:
 //

--- a/security/v1beta1/peer_authentication.pb.go
+++ b/security/v1beta1/peer_authentication.pb.go
@@ -97,14 +97,13 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 	return file_security_v1beta1_peer_authentication_proto_rawDescGZIP(), []int{0, 0, 0}
 }
 
-// {{< warning >}}
-// Development of PeerAuthentication is currently frozen and likely to be replaced in Ambient.
-// {{< /warning >}}
 // PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.
+//
+// Ambient mode implies mTLS, and so DISABLE mode is not supported.
 //
 // Examples:
 //
-// Policy to allow mTLS traffic for all workloads under namespace `foo`:
+// Policy to require mTLS traffic for all workloads under namespace `foo`:
 // ```yaml
 // apiVersion: security.istio.io/v1
 // kind: PeerAuthentication

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -11,8 +11,12 @@ number_of_entries: 3
 <h2 id="PeerAuthentication">PeerAuthentication</h2>
 <section>
 <p>PeerAuthentication defines mutual TLS (mTLS) requirements for incoming connections.</p>
-<p>In sidecar mode, PeerAuthentication determines whether or not mTLS is enabled, or required, for connections to an Envoy proxy sidecar.</p>
-<p>In ambient mode, security is transparently enabled for a pod by the ztunnel node agent. (Traffic between proxies uses the HBONE protocol, which includes encryption with mTLS.) Because of this, DISABLE mode is not supported.</p>
+<p>In sidecar mode, PeerAuthentication determines whether or not mTLS is allowed or required
+for connections to an Envoy proxy sidecar.</p>
+<p>In ambient mode, security is transparently enabled for a pod by the ztunnel node agent.
+(Traffic between proxies uses the HBONE protocol, which includes encryption with mTLS.)
+Because of this, <code>DISABLE</code> mode is not supported.
+<code>STRICT</code> mode is useful to ensure that connections that bypass the mesh are not possible.</p>
 <p>Examples:</p>
 <p>Policy to allow mTLS traffic for all workloads under namespace <code>foo</code>:</p>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -10,8 +10,9 @@ number_of_entries: 3
 ---
 <h2 id="PeerAuthentication">PeerAuthentication</h2>
 <section>
-<p>PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.</p>
-<p>Ambient mode implies mTLS, and so DISABLE mode is not supported.</p>
+<p>PeerAuthentication defines mutual TLS (mTLS) requirements for incoming connections.</p>
+<p>In sidecar mode, PeerAuthentication determines whether or not mTLS is enabled, or required, for connections to an Envoy proxy sidecar.</p>
+<p>In ambient mode, security is transparently enabled for a pod by the ztunnel node agent. (Traffic between proxies uses the HBONE protocol, which includes encryption with mTLS.) Because of this, DISABLE mode is not supported.</p>
 <p>Examples:</p>
 <p>Policy to allow mTLS traffic for all workloads under namespace <code>foo</code>:</p>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -18,7 +18,7 @@ for connections to an Envoy proxy sidecar.</p>
 Because of this, <code>DISABLE</code> mode is not supported.
 <code>STRICT</code> mode is useful to ensure that connections that bypass the mesh are not possible.</p>
 <p>Examples:</p>
-<p>Policy to allow mTLS traffic for all workloads under namespace <code>foo</code>:</p>
+<p>Policy to require mTLS traffic for all workloads under namespace <code>foo</code>:</p>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -10,10 +10,8 @@ number_of_entries: 3
 ---
 <h2 id="PeerAuthentication">PeerAuthentication</h2>
 <section>
-<p>{{&lt; warning &gt;}}
-Development of PeerAuthentication is currently frozen and likely to be replaced in Ambient.
-{{&lt; /warning &gt;}}
-PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.</p>
+<p>PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.</p>
+<p>Ambient mode implies mTLS, and so DISABLE mode is not supported.</p>
 <p>Examples:</p>
 <p>Policy to allow mTLS traffic for all workloads under namespace <code>foo</code>:</p>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1

--- a/security/v1beta1/peer_authentication.proto
+++ b/security/v1beta1/peer_authentication.proto
@@ -25,14 +25,13 @@ package istio.security.v1beta1;
 
 option go_package="istio.io/api/security/v1beta1";
 
-// {{< warning >}}
-// Development of PeerAuthentication is currently frozen and likely to be replaced in Ambient.
-// {{< /warning >}}
 // PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.
+//
+// Ambient mode implies mTLS, and so DISABLE mode is not supported.
 //
 // Examples:
 //
-// Policy to allow mTLS traffic for all workloads under namespace `foo`:
+// Policy to require mTLS traffic for all workloads under namespace `foo`:
 // ```yaml
 // apiVersion: security.istio.io/v1
 // kind: PeerAuthentication

--- a/security/v1beta1/peer_authentication.proto
+++ b/security/v1beta1/peer_authentication.proto
@@ -25,9 +25,11 @@ package istio.security.v1beta1;
 
 option go_package="istio.io/api/security/v1beta1";
 
-// PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.
+// PeerAuthentication defines mutual TLS (mTLS) requirements for incoming connections.
 //
-// Ambient mode implies mTLS, and so DISABLE mode is not supported.
+// In sidecar mode, PeerAuthentication determines whether or not mTLS is enabled, or required, for connections to an Envoy proxy sidecar.
+//
+// In ambient mode, security is transparently enabled for a pod by the ztunnel node agent. (Traffic between proxies uses the HBONE protocol, which includes encryption with mTLS.) Because of this, DISABLE mode is not supported.
 //
 // Examples:
 //

--- a/security/v1beta1/peer_authentication.proto
+++ b/security/v1beta1/peer_authentication.proto
@@ -27,9 +27,13 @@ option go_package="istio.io/api/security/v1beta1";
 
 // PeerAuthentication defines mutual TLS (mTLS) requirements for incoming connections.
 //
-// In sidecar mode, PeerAuthentication determines whether or not mTLS is enabled, or required, for connections to an Envoy proxy sidecar.
+// In sidecar mode, PeerAuthentication determines whether or not mTLS is allowed or required
+// for connections to an Envoy proxy sidecar.
 //
-// In ambient mode, security is transparently enabled for a pod by the ztunnel node agent. (Traffic between proxies uses the HBONE protocol, which includes encryption with mTLS.) Because of this, DISABLE mode is not supported.
+// In ambient mode, security is transparently enabled for a pod by the ztunnel node agent.
+// (Traffic between proxies uses the HBONE protocol, which includes encryption with mTLS.)
+// Because of this, `DISABLE` mode is not supported.
+// `STRICT` mode is useful to ensure that connections that bypass the mesh are not possible.
 //
 // Examples:
 //


### PR DESCRIPTION
Given we seem to have decided to keep `PeerAuthentication` around in ambient mode, update the docs to remove the warning, and add the caveat you can't `DISABLE` mTLS any more.

(This may or may not be the project's decision.)