### PR TITLE
Allow defining CRDs from a single version

### DIFF
--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -517,7 +517,7 @@ func (FailStrategy) EnumDescriptor() ([]byte, []int) {
 //
 // <!-- crd generation tags
 // +cue-gen:WasmPlugin:groupName:extensions.istio.io
-// +cue-gen:WasmPlugin:version:v1alpha1
+// +cue-gen:WasmPlugin:versions:v1alpha1
 // +cue-gen:WasmPlugin:storageVersion
 // +cue-gen:WasmPlugin:annotations:helm.sh/resource-policy=keep
 // +cue-gen:WasmPlugin:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -214,7 +214,7 @@ option go_package="istio.io/api/extensions/v1alpha1";
 //
 // <!-- crd generation tags
 // +cue-gen:WasmPlugin:groupName:extensions.istio.io
-// +cue-gen:WasmPlugin:version:v1alpha1
+// +cue-gen:WasmPlugin:versions:v1alpha1
 // +cue-gen:WasmPlugin:storageVersion
 // +cue-gen:WasmPlugin:annotations:helm.sh/resource-policy=keep
 // +cue-gen:WasmPlugin:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -10910,10 +10910,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: '`WorkloadGroup` enables specifying the properties of a single
-              workload for bootstrap and provides a template for `WorkloadEntry`,
-              similar to how `Deployment` specifies properties of workloads via `Pod`
-              templates.'
+            description: 'Describes a collection of workload instances. See more details
+              at: https://istio.io/docs/reference/config/networking/workload-group.html'
             properties:
               metadata:
                 description: Metadata that will be used for all corresponding `WorkloadEntries`.
@@ -11258,10 +11256,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: '`WorkloadGroup` enables specifying the properties of a single
-              workload for bootstrap and provides a template for `WorkloadEntry`,
-              similar to how `Deployment` specifies properties of workloads via `Pod`
-              templates.'
+            description: 'Describes a collection of workload instances. See more details
+              at: https://istio.io/docs/reference/config/networking/workload-group.html'
             properties:
               metadata:
                 description: Metadata that will be used for all corresponding `WorkloadEntries`.

--- a/networking/v1/destination_rule.pb.go
+++ b/networking/v1/destination_rule.pb.go
@@ -364,22 +364,6 @@ func (ClientTLSSettings_TLSmode) EnumDescriptor() ([]byte, []int) {
 // DestinationRule defines policies that apply to traffic intended for a service
 // after routing has occurred.
 //
-// <!-- crd generation tags
-// +cue-gen:DestinationRule:groupName:networking.istio.io
-// +cue-gen:DestinationRule:version:v1
-// +cue-gen:DestinationRule:annotations:helm.sh/resource-policy=keep
-// +cue-gen:DestinationRule:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:DestinationRule:subresource:status
-// +cue-gen:DestinationRule:scope:Namespaced
-// +cue-gen:DestinationRule:resource:categories=istio-io,networking-istio-io,shortNames=dr
-// +cue-gen:DestinationRule:printerColumn:name=Host,type=string,JSONPath=.spec.host,description="The name of a service from the service registry"
-// +cue-gen:DestinationRule:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:DestinationRule:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/destination_rule.proto
+++ b/networking/v1/destination_rule.proto
@@ -103,21 +103,6 @@ option go_package = "istio.io/api/networking/v1";
 // DestinationRule defines policies that apply to traffic intended for a service
 // after routing has occurred.
 //
-// <!-- crd generation tags
-// +cue-gen:DestinationRule:groupName:networking.istio.io
-// +cue-gen:DestinationRule:version:v1
-// +cue-gen:DestinationRule:annotations:helm.sh/resource-policy=keep
-// +cue-gen:DestinationRule:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:DestinationRule:subresource:status
-// +cue-gen:DestinationRule:scope:Namespaced
-// +cue-gen:DestinationRule:resource:categories=istio-io,networking-istio-io,shortNames=dr
-// +cue-gen:DestinationRule:printerColumn:name=Host,type=string,JSONPath=.spec.host,description="The name of a service from the service registry"
-// +cue-gen:DestinationRule:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:DestinationRule:preserveUnknownFields:false
-// -->
 //
 // <!-- go code generation tags
 // +kubetype-gen

--- a/networking/v1/gateway.pb.go
+++ b/networking/v1/gateway.pb.go
@@ -367,17 +367,6 @@ func (ServerTLSSettings_TLSProtocol) EnumDescriptor() ([]byte, []int) {
 // Gateway describes a load balancer operating at the edge of the mesh
 // receiving incoming or outgoing HTTP/TCP connections.
 //
-// <!-- crd generation tags
-// +cue-gen:Gateway:groupName:networking.istio.io
-// +cue-gen:Gateway:version:v1
-// +cue-gen:Gateway:annotations:helm.sh/resource-policy=keep
-// +cue-gen:Gateway:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:Gateway:subresource:status
-// +cue-gen:Gateway:scope:Namespaced
-// +cue-gen:Gateway:resource:categories=istio-io,networking-istio-io,shortNames=gw
-// +cue-gen:Gateway:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/gateway.proto
+++ b/networking/v1/gateway.proto
@@ -199,17 +199,6 @@ option go_package = "istio.io/api/networking/v1";
 // Gateway describes a load balancer operating at the edge of the mesh
 // receiving incoming or outgoing HTTP/TCP connections.
 //
-// <!-- crd generation tags
-// +cue-gen:Gateway:groupName:networking.istio.io
-// +cue-gen:Gateway:version:v1
-// +cue-gen:Gateway:annotations:helm.sh/resource-policy=keep
-// +cue-gen:Gateway:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:Gateway:subresource:status
-// +cue-gen:Gateway:scope:Namespaced
-// +cue-gen:Gateway:resource:categories=istio-io,networking-istio-io,shortNames=gw
-// +cue-gen:Gateway:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/service_entry.pb.go
+++ b/networking/v1/service_entry.pb.go
@@ -565,26 +565,6 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // ServiceEntry enables adding additional entries into Istio's internal
 // service registry.
 //
-// <!-- crd generation tags
-// +cue-gen:ServiceEntry:groupName:networking.istio.io
-// +cue-gen:ServiceEntry:version:v1
-// +cue-gen:ServiceEntry:annotations:helm.sh/resource-policy=keep
-// +cue-gen:ServiceEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:ServiceEntry:subresource:status
-// +cue-gen:ServiceEntry:scope:Namespaced
-// +cue-gen:ServiceEntry:resource:categories=istio-io,networking-istio-io,shortNames=se,plural=serviceentries
-// +cue-gen:ServiceEntry:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The hosts associated with the ServiceEntry"
-// +cue-gen:ServiceEntry:printerColumn:name=Location,type=string,JSONPath=.spec.location,description="Whether the service is external to the
-// mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)"
-// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service resolution mode for the hosts
-// (NONE, STATIC, or DNS)"
-// +cue-gen:ServiceEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:ServiceEntry:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/service_entry.proto
+++ b/networking/v1/service_entry.proto
@@ -407,26 +407,6 @@ option go_package = "istio.io/api/networking/v1";
 // ServiceEntry enables adding additional entries into Istio's internal
 // service registry.
 //
-// <!-- crd generation tags
-// +cue-gen:ServiceEntry:groupName:networking.istio.io
-// +cue-gen:ServiceEntry:version:v1
-// +cue-gen:ServiceEntry:annotations:helm.sh/resource-policy=keep
-// +cue-gen:ServiceEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:ServiceEntry:subresource:status
-// +cue-gen:ServiceEntry:scope:Namespaced
-// +cue-gen:ServiceEntry:resource:categories=istio-io,networking-istio-io,shortNames=se,plural=serviceentries
-// +cue-gen:ServiceEntry:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The hosts associated with the ServiceEntry"
-// +cue-gen:ServiceEntry:printerColumn:name=Location,type=string,JSONPath=.spec.location,description="Whether the service is external to the
-// mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)"
-// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service resolution mode for the hosts
-// (NONE, STATIC, or DNS)"
-// +cue-gen:ServiceEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:ServiceEntry:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/sidecar.pb.go
+++ b/networking/v1/sidecar.pb.go
@@ -409,17 +409,6 @@ func (OutboundTrafficPolicy_Mode) EnumDescriptor() ([]byte, []int) {
 // inbound and outbound communication of the workload instance to which it is
 // attached.
 //
-// <!-- crd generation tags
-// +cue-gen:Sidecar:groupName:networking.istio.io
-// +cue-gen:Sidecar:version:v1
-// +cue-gen:Sidecar:annotations:helm.sh/resource-policy=keep
-// +cue-gen:Sidecar:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:Sidecar:subresource:status
-// +cue-gen:Sidecar:scope:Namespaced
-// +cue-gen:Sidecar:resource:categories=istio-io,networking-istio-io
-// +cue-gen:Sidecar:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/sidecar.proto
+++ b/networking/v1/sidecar.proto
@@ -288,17 +288,6 @@ option go_package = "istio.io/api/networking/v1";
 // inbound and outbound communication of the workload instance to which it is
 // attached.
 //
-// <!-- crd generation tags
-// +cue-gen:Sidecar:groupName:networking.istio.io
-// +cue-gen:Sidecar:version:v1
-// +cue-gen:Sidecar:annotations:helm.sh/resource-policy=keep
-// +cue-gen:Sidecar:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:Sidecar:subresource:status
-// +cue-gen:Sidecar:scope:Namespaced
-// +cue-gen:Sidecar:resource:categories=istio-io,networking-istio-io
-// +cue-gen:Sidecar:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/virtual_service.pb.go
+++ b/networking/v1/virtual_service.pb.go
@@ -236,24 +236,6 @@ func (CorsPolicy_UnmatchedPreflights) EnumDescriptor() ([]byte, []int) {
 
 // Configuration affecting traffic routing.
 //
-// <!-- crd generation tags
-// +cue-gen:VirtualService:groupName:networking.istio.io
-// +cue-gen:VirtualService:version:v1
-// +cue-gen:VirtualService:annotations:helm.sh/resource-policy=keep
-// +cue-gen:VirtualService:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:VirtualService:subresource:status
-// +cue-gen:VirtualService:scope:Namespaced
-// +cue-gen:VirtualService:resource:categories=istio-io,networking-istio-io,shortNames=vs
-// +cue-gen:VirtualService:printerColumn:name=Gateways,type=string,JSONPath=.spec.gateways,description="The names of gateways and sidecars
-// that should apply these routes"
-// +cue-gen:VirtualService:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The destination hosts to which traffic is being sent"
-// +cue-gen:VirtualService:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:VirtualService:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/virtual_service.proto
+++ b/networking/v1/virtual_service.proto
@@ -120,24 +120,6 @@ option go_package = "istio.io/api/networking/v1";
 
 // Configuration affecting traffic routing.
 //
-// <!-- crd generation tags
-// +cue-gen:VirtualService:groupName:networking.istio.io
-// +cue-gen:VirtualService:version:v1
-// +cue-gen:VirtualService:annotations:helm.sh/resource-policy=keep
-// +cue-gen:VirtualService:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:VirtualService:subresource:status
-// +cue-gen:VirtualService:scope:Namespaced
-// +cue-gen:VirtualService:resource:categories=istio-io,networking-istio-io,shortNames=vs
-// +cue-gen:VirtualService:printerColumn:name=Gateways,type=string,JSONPath=.spec.gateways,description="The names of gateways and sidecars
-// that should apply these routes"
-// +cue-gen:VirtualService:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The destination hosts to which traffic is being sent"
-// +cue-gen:VirtualService:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:VirtualService:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/workload_entry.pb.go
+++ b/networking/v1/workload_entry.pb.go
@@ -170,22 +170,6 @@ const (
 
 // WorkloadEntry enables specifying the properties of a single non-Kubernetes workload such a VM or a bare metal services that can be referred to by service entries.
 //
-// <!-- crd generation tags
-// +cue-gen:WorkloadEntry:groupName:networking.istio.io
-// +cue-gen:WorkloadEntry:version:v1
-// +cue-gen:WorkloadEntry:annotations:helm.sh/resource-policy=keep
-// +cue-gen:WorkloadEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:WorkloadEntry:subresource:status
-// +cue-gen:WorkloadEntry:scope:Namespaced
-// +cue-gen:WorkloadEntry:resource:categories=istio-io,networking-istio-io,shortNames=we,plural=workloadentries
-// +cue-gen:WorkloadEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
-// +cue-gen:WorkloadEntry:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/workload_entry.proto
+++ b/networking/v1/workload_entry.proto
@@ -153,22 +153,6 @@ option go_package = "istio.io/api/networking/v1";
 
 // WorkloadEntry enables specifying the properties of a single non-Kubernetes workload such a VM or a bare metal services that can be referred to by service entries.
 //
-// <!-- crd generation tags
-// +cue-gen:WorkloadEntry:groupName:networking.istio.io
-// +cue-gen:WorkloadEntry:version:v1
-// +cue-gen:WorkloadEntry:annotations:helm.sh/resource-policy=keep
-// +cue-gen:WorkloadEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:WorkloadEntry:subresource:status
-// +cue-gen:WorkloadEntry:scope:Namespaced
-// +cue-gen:WorkloadEntry:resource:categories=istio-io,networking-istio-io,shortNames=we,plural=workloadentries
-// +cue-gen:WorkloadEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
-// +cue-gen:WorkloadEntry:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/workload_group.pb.go
+++ b/networking/v1/workload_group.pb.go
@@ -94,20 +94,6 @@ const (
 // `WorkloadGroup` has no relationship to resources which control service registry like `ServiceEntry`
 // and as such doesn't configure host name for these workloads.
 //
-// <!-- crd generation tags
-// +cue-gen:WorkloadGroup:groupName:networking.istio.io
-// +cue-gen:WorkloadGroup:version:v1
-// +cue-gen:WorkloadGroup:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:WorkloadGroup:subresource:status
-// +cue-gen:WorkloadGroup:scope:Namespaced
-// +cue-gen:WorkloadGroup:resource:categories=istio-io,networking-istio-io,shortNames=wg,plural=workloadgroups
-// +cue-gen:WorkloadGroup:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:WorkloadGroup:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1/workload_group.proto
+++ b/networking/v1/workload_group.proto
@@ -79,20 +79,6 @@ option go_package = "istio.io/api/networking/v1";
 // `WorkloadGroup` has no relationship to resources which control service registry like `ServiceEntry` 
 // and as such doesn't configure host name for these workloads.
 //
-// <!-- crd generation tags
-// +cue-gen:WorkloadGroup:groupName:networking.istio.io
-// +cue-gen:WorkloadGroup:version:v1
-// +cue-gen:WorkloadGroup:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:WorkloadGroup:subresource:status
-// +cue-gen:WorkloadGroup:scope:Namespaced
-// +cue-gen:WorkloadGroup:resource:categories=istio-io,networking-istio-io,shortNames=wg,plural=workloadgroups
-// +cue-gen:WorkloadGroup:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:WorkloadGroup:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -390,7 +390,7 @@ func (ClientTLSSettings_TLSmode) EnumDescriptor() ([]byte, []int) {
 //
 // <!-- crd generation tags
 // +cue-gen:DestinationRule:groupName:networking.istio.io
-// +cue-gen:DestinationRule:version:v1alpha3
+// +cue-gen:DestinationRule:versions:v1beta1,v1alpha3,v1
 // +cue-gen:DestinationRule:annotations:helm.sh/resource-policy=keep
 // +cue-gen:DestinationRule:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:DestinationRule:subresource:status

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -129,7 +129,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //
 // <!-- crd generation tags
 // +cue-gen:DestinationRule:groupName:networking.istio.io
-// +cue-gen:DestinationRule:version:v1alpha3
+// +cue-gen:DestinationRule:versions:v1beta1,v1alpha3,v1
 // +cue-gen:DestinationRule:annotations:helm.sh/resource-policy=keep
 // +cue-gen:DestinationRule:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:DestinationRule:subresource:status

--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -805,7 +805,7 @@ func (EnvoyFilter_Patch_FilterClass) EnumDescriptor() ([]byte, []int) {
 //
 // <!-- crd generation tags
 // +cue-gen:EnvoyFilter:groupName:networking.istio.io
-// +cue-gen:EnvoyFilter:version:v1alpha3
+// +cue-gen:EnvoyFilter:versions:v1alpha3
 // +cue-gen:EnvoyFilter:storageVersion
 // +cue-gen:EnvoyFilter:annotations:helm.sh/resource-policy=keep
 // +cue-gen:EnvoyFilter:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -404,7 +404,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //
 // <!-- crd generation tags
 // +cue-gen:EnvoyFilter:groupName:networking.istio.io
-// +cue-gen:EnvoyFilter:version:v1alpha3
+// +cue-gen:EnvoyFilter:versions:v1alpha3
 // +cue-gen:EnvoyFilter:storageVersion
 // +cue-gen:EnvoyFilter:annotations:helm.sh/resource-policy=keep
 // +cue-gen:EnvoyFilter:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -369,7 +369,7 @@ func (ServerTLSSettings_TLSProtocol) EnumDescriptor() ([]byte, []int) {
 //
 // <!-- crd generation tags
 // +cue-gen:Gateway:groupName:networking.istio.io
-// +cue-gen:Gateway:version:v1alpha3
+// +cue-gen:Gateway:versions:v1beta1,v1alpha3,v1
 // +cue-gen:Gateway:annotations:helm.sh/resource-policy=keep
 // +cue-gen:Gateway:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:Gateway:subresource:status

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -201,7 +201,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //
 // <!-- crd generation tags
 // +cue-gen:Gateway:groupName:networking.istio.io
-// +cue-gen:Gateway:version:v1alpha3
+// +cue-gen:Gateway:versions:v1beta1,v1alpha3,v1
 // +cue-gen:Gateway:annotations:helm.sh/resource-policy=keep
 // +cue-gen:Gateway:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:Gateway:subresource:status

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -566,7 +566,7 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 //
 // <!-- crd generation tags
 // +cue-gen:ServiceEntry:groupName:networking.istio.io
-// +cue-gen:ServiceEntry:version:v1alpha3
+// +cue-gen:ServiceEntry:versions:v1beta1,v1alpha3,v1
 // +cue-gen:ServiceEntry:annotations:helm.sh/resource-policy=keep
 // +cue-gen:ServiceEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:ServiceEntry:subresource:status

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -408,7 +408,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //
 // <!-- crd generation tags
 // +cue-gen:ServiceEntry:groupName:networking.istio.io
-// +cue-gen:ServiceEntry:version:v1alpha3
+// +cue-gen:ServiceEntry:versions:v1beta1,v1alpha3,v1
 // +cue-gen:ServiceEntry:annotations:helm.sh/resource-policy=keep
 // +cue-gen:ServiceEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:ServiceEntry:subresource:status

--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -475,7 +475,7 @@ func (OutboundTrafficPolicy_Mode) EnumDescriptor() ([]byte, []int) {
 //
 // <!-- crd generation tags
 // +cue-gen:Sidecar:groupName:networking.istio.io
-// +cue-gen:Sidecar:version:v1alpha3
+// +cue-gen:Sidecar:versions:v1beta1,v1alpha3,v1
 // +cue-gen:Sidecar:annotations:helm.sh/resource-policy=keep
 // +cue-gen:Sidecar:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:Sidecar:subresource:status

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -354,7 +354,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //
 // <!-- crd generation tags
 // +cue-gen:Sidecar:groupName:networking.istio.io
-// +cue-gen:Sidecar:version:v1alpha3
+// +cue-gen:Sidecar:versions:v1beta1,v1alpha3,v1
 // +cue-gen:Sidecar:annotations:helm.sh/resource-policy=keep
 // +cue-gen:Sidecar:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:Sidecar:subresource:status

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -239,7 +239,7 @@ func (CorsPolicy_UnmatchedPreflights) EnumDescriptor() ([]byte, []int) {
 //
 // <!-- crd generation tags
 // +cue-gen:VirtualService:groupName:networking.istio.io
-// +cue-gen:VirtualService:version:v1alpha3
+// +cue-gen:VirtualService:versions:v1beta1,v1alpha3,v1
 // +cue-gen:VirtualService:annotations:helm.sh/resource-policy=keep
 // +cue-gen:VirtualService:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:VirtualService:subresource:status

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -123,7 +123,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //
 // <!-- crd generation tags
 // +cue-gen:VirtualService:groupName:networking.istio.io
-// +cue-gen:VirtualService:version:v1alpha3
+// +cue-gen:VirtualService:versions:v1beta1,v1alpha3,v1
 // +cue-gen:VirtualService:annotations:helm.sh/resource-policy=keep
 // +cue-gen:VirtualService:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:VirtualService:subresource:status

--- a/networking/v1alpha3/workload_entry.pb.go
+++ b/networking/v1alpha3/workload_entry.pb.go
@@ -171,7 +171,7 @@ const (
 //
 // <!-- crd generation tags
 // +cue-gen:WorkloadEntry:groupName:networking.istio.io
-// +cue-gen:WorkloadEntry:version:v1alpha3
+// +cue-gen:WorkloadEntry:versions:v1beta1,v1alpha3,v1
 // +cue-gen:WorkloadEntry:annotations:helm.sh/resource-policy=keep
 // +cue-gen:WorkloadEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadEntry:subresource:status

--- a/networking/v1alpha3/workload_entry.proto
+++ b/networking/v1alpha3/workload_entry.proto
@@ -154,7 +154,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //
 // <!-- crd generation tags
 // +cue-gen:WorkloadEntry:groupName:networking.istio.io
-// +cue-gen:WorkloadEntry:version:v1alpha3
+// +cue-gen:WorkloadEntry:versions:v1beta1,v1alpha3,v1
 // +cue-gen:WorkloadEntry:annotations:helm.sh/resource-policy=keep
 // +cue-gen:WorkloadEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadEntry:subresource:status

--- a/networking/v1alpha3/workload_group.pb.go
+++ b/networking/v1alpha3/workload_group.pb.go
@@ -96,7 +96,7 @@ const (
 //
 // <!-- crd generation tags
 // +cue-gen:WorkloadGroup:groupName:networking.istio.io
-// +cue-gen:WorkloadGroup:version:v1alpha3
+// +cue-gen:WorkloadGroup:versions:v1beta1,v1alpha3,v1
 // +cue-gen:WorkloadGroup:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadGroup:subresource:status
 // +cue-gen:WorkloadGroup:scope:Namespaced

--- a/networking/v1alpha3/workload_group.proto
+++ b/networking/v1alpha3/workload_group.proto
@@ -81,7 +81,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 //
 // <!-- crd generation tags
 // +cue-gen:WorkloadGroup:groupName:networking.istio.io
-// +cue-gen:WorkloadGroup:version:v1alpha3
+// +cue-gen:WorkloadGroup:versions:v1beta1,v1alpha3,v1
 // +cue-gen:WorkloadGroup:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
 // +cue-gen:WorkloadGroup:subresource:status
 // +cue-gen:WorkloadGroup:scope:Namespaced

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -364,23 +364,6 @@ func (ClientTLSSettings_TLSmode) EnumDescriptor() ([]byte, []int) {
 // DestinationRule defines policies that apply to traffic intended for a service
 // after routing has occurred.
 //
-// <!-- crd generation tags
-// +cue-gen:DestinationRule:groupName:networking.istio.io
-// +cue-gen:DestinationRule:version:v1beta1
-// +cue-gen:DestinationRule:storageVersion
-// +cue-gen:DestinationRule:annotations:helm.sh/resource-policy=keep
-// +cue-gen:DestinationRule:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:DestinationRule:subresource:status
-// +cue-gen:DestinationRule:scope:Namespaced
-// +cue-gen:DestinationRule:resource:categories=istio-io,networking-istio-io,shortNames=dr
-// +cue-gen:DestinationRule:printerColumn:name=Host,type=string,JSONPath=.spec.host,description="The name of a service from the service registry"
-// +cue-gen:DestinationRule:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:DestinationRule:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -103,23 +103,6 @@ option go_package = "istio.io/api/networking/v1beta1";
 // DestinationRule defines policies that apply to traffic intended for a service
 // after routing has occurred.
 //
-// <!-- crd generation tags
-// +cue-gen:DestinationRule:groupName:networking.istio.io
-// +cue-gen:DestinationRule:version:v1beta1
-// +cue-gen:DestinationRule:storageVersion
-// +cue-gen:DestinationRule:annotations:helm.sh/resource-policy=keep
-// +cue-gen:DestinationRule:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:DestinationRule:subresource:status
-// +cue-gen:DestinationRule:scope:Namespaced
-// +cue-gen:DestinationRule:resource:categories=istio-io,networking-istio-io,shortNames=dr
-// +cue-gen:DestinationRule:printerColumn:name=Host,type=string,JSONPath=.spec.host,description="The name of a service from the service registry"
-// +cue-gen:DestinationRule:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:DestinationRule:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/gateway.pb.go
+++ b/networking/v1beta1/gateway.pb.go
@@ -367,18 +367,6 @@ func (ServerTLSSettings_TLSProtocol) EnumDescriptor() ([]byte, []int) {
 // Gateway describes a load balancer operating at the edge of the mesh
 // receiving incoming or outgoing HTTP/TCP connections.
 //
-// <!-- crd generation tags
-// +cue-gen:Gateway:groupName:networking.istio.io
-// +cue-gen:Gateway:version:v1beta1
-// +cue-gen:Gateway:storageVersion
-// +cue-gen:Gateway:annotations:helm.sh/resource-policy=keep
-// +cue-gen:Gateway:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:Gateway:subresource:status
-// +cue-gen:Gateway:scope:Namespaced
-// +cue-gen:Gateway:resource:categories=istio-io,networking-istio-io,shortNames=gw
-// +cue-gen:Gateway:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/gateway.proto
+++ b/networking/v1beta1/gateway.proto
@@ -199,18 +199,6 @@ option go_package = "istio.io/api/networking/v1beta1";
 // Gateway describes a load balancer operating at the edge of the mesh
 // receiving incoming or outgoing HTTP/TCP connections.
 //
-// <!-- crd generation tags
-// +cue-gen:Gateway:groupName:networking.istio.io
-// +cue-gen:Gateway:version:v1beta1
-// +cue-gen:Gateway:storageVersion
-// +cue-gen:Gateway:annotations:helm.sh/resource-policy=keep
-// +cue-gen:Gateway:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:Gateway:subresource:status
-// +cue-gen:Gateway:scope:Namespaced
-// +cue-gen:Gateway:resource:categories=istio-io,networking-istio-io,shortNames=gw
-// +cue-gen:Gateway:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/proxy_config.pb.go
+++ b/networking/v1beta1/proxy_config.pb.go
@@ -108,7 +108,7 @@ const (
 //
 // <!-- crd generation tags
 // +cue-gen:ProxyConfig:groupName:networking.istio.io
-// +cue-gen:ProxyConfig:version:v1beta1
+// +cue-gen:ProxyConfig:versions:v1beta1
 // +cue-gen:ProxyConfig:storageVersion
 // +cue-gen:ProxyConfig:annotations:helm.sh/resource-policy=keep
 // +cue-gen:ProxyConfig:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio

--- a/networking/v1beta1/proxy_config.proto
+++ b/networking/v1beta1/proxy_config.proto
@@ -92,7 +92,7 @@ option go_package= "istio.io/api/networking/v1beta1";
 //
 // <!-- crd generation tags
 // +cue-gen:ProxyConfig:groupName:networking.istio.io
-// +cue-gen:ProxyConfig:version:v1beta1
+// +cue-gen:ProxyConfig:versions:v1beta1
 // +cue-gen:ProxyConfig:storageVersion
 // +cue-gen:ProxyConfig:annotations:helm.sh/resource-policy=keep
 // +cue-gen:ProxyConfig:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio

--- a/networking/v1beta1/service_entry.pb.go
+++ b/networking/v1beta1/service_entry.pb.go
@@ -565,27 +565,6 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // ServiceEntry enables adding additional entries into Istio's internal
 // service registry.
 //
-// <!-- crd generation tags
-// +cue-gen:ServiceEntry:groupName:networking.istio.io
-// +cue-gen:ServiceEntry:version:v1beta1
-// +cue-gen:ServiceEntry:storageVersion
-// +cue-gen:ServiceEntry:annotations:helm.sh/resource-policy=keep
-// +cue-gen:ServiceEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:ServiceEntry:subresource:status
-// +cue-gen:ServiceEntry:scope:Namespaced
-// +cue-gen:ServiceEntry:resource:categories=istio-io,networking-istio-io,shortNames=se,plural=serviceentries
-// +cue-gen:ServiceEntry:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The hosts associated with the ServiceEntry"
-// +cue-gen:ServiceEntry:printerColumn:name=Location,type=string,JSONPath=.spec.location,description="Whether the service is external to the
-// mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)"
-// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service resolution mode for the hosts
-// (NONE, STATIC, or DNS)"
-// +cue-gen:ServiceEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:ServiceEntry:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/service_entry.proto
+++ b/networking/v1beta1/service_entry.proto
@@ -407,27 +407,6 @@ option go_package = "istio.io/api/networking/v1beta1";
 // ServiceEntry enables adding additional entries into Istio's internal
 // service registry.
 //
-// <!-- crd generation tags
-// +cue-gen:ServiceEntry:groupName:networking.istio.io
-// +cue-gen:ServiceEntry:version:v1beta1
-// +cue-gen:ServiceEntry:storageVersion
-// +cue-gen:ServiceEntry:annotations:helm.sh/resource-policy=keep
-// +cue-gen:ServiceEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:ServiceEntry:subresource:status
-// +cue-gen:ServiceEntry:scope:Namespaced
-// +cue-gen:ServiceEntry:resource:categories=istio-io,networking-istio-io,shortNames=se,plural=serviceentries
-// +cue-gen:ServiceEntry:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The hosts associated with the ServiceEntry"
-// +cue-gen:ServiceEntry:printerColumn:name=Location,type=string,JSONPath=.spec.location,description="Whether the service is external to the
-// mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)"
-// +cue-gen:ServiceEntry:printerColumn:name=Resolution,type=string,JSONPath=.spec.resolution,description="Service resolution mode for the hosts
-// (NONE, STATIC, or DNS)"
-// +cue-gen:ServiceEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:ServiceEntry:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/sidecar.pb.go
+++ b/networking/v1beta1/sidecar.pb.go
@@ -409,18 +409,6 @@ func (OutboundTrafficPolicy_Mode) EnumDescriptor() ([]byte, []int) {
 // inbound and outbound communication of the workload instance to which it is
 // attached.
 //
-// <!-- crd generation tags
-// +cue-gen:Sidecar:groupName:networking.istio.io
-// +cue-gen:Sidecar:version:v1beta1
-// +cue-gen:Sidecar:storageVersion
-// +cue-gen:Sidecar:annotations:helm.sh/resource-policy=keep
-// +cue-gen:Sidecar:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:Sidecar:subresource:status
-// +cue-gen:Sidecar:scope:Namespaced
-// +cue-gen:Sidecar:resource:categories=istio-io,networking-istio-io
-// +cue-gen:Sidecar:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/sidecar.proto
+++ b/networking/v1beta1/sidecar.proto
@@ -288,18 +288,6 @@ option go_package = "istio.io/api/networking/v1beta1";
 // inbound and outbound communication of the workload instance to which it is
 // attached.
 //
-// <!-- crd generation tags
-// +cue-gen:Sidecar:groupName:networking.istio.io
-// +cue-gen:Sidecar:version:v1beta1
-// +cue-gen:Sidecar:storageVersion
-// +cue-gen:Sidecar:annotations:helm.sh/resource-policy=keep
-// +cue-gen:Sidecar:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:Sidecar:subresource:status
-// +cue-gen:Sidecar:scope:Namespaced
-// +cue-gen:Sidecar:resource:categories=istio-io,networking-istio-io
-// +cue-gen:Sidecar:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -236,25 +236,6 @@ func (CorsPolicy_UnmatchedPreflights) EnumDescriptor() ([]byte, []int) {
 
 // Configuration affecting traffic routing.
 //
-// <!-- crd generation tags
-// +cue-gen:VirtualService:groupName:networking.istio.io
-// +cue-gen:VirtualService:version:v1beta1
-// +cue-gen:VirtualService:storageVersion
-// +cue-gen:VirtualService:annotations:helm.sh/resource-policy=keep
-// +cue-gen:VirtualService:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:VirtualService:subresource:status
-// +cue-gen:VirtualService:scope:Namespaced
-// +cue-gen:VirtualService:resource:categories=istio-io,networking-istio-io,shortNames=vs
-// +cue-gen:VirtualService:printerColumn:name=Gateways,type=string,JSONPath=.spec.gateways,description="The names of gateways and sidecars
-// that should apply these routes"
-// +cue-gen:VirtualService:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The destination hosts to which traffic is being sent"
-// +cue-gen:VirtualService:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:VirtualService:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -120,25 +120,6 @@ option go_package = "istio.io/api/networking/v1beta1";
 
 // Configuration affecting traffic routing.
 //
-// <!-- crd generation tags
-// +cue-gen:VirtualService:groupName:networking.istio.io
-// +cue-gen:VirtualService:version:v1beta1
-// +cue-gen:VirtualService:storageVersion
-// +cue-gen:VirtualService:annotations:helm.sh/resource-policy=keep
-// +cue-gen:VirtualService:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:VirtualService:subresource:status
-// +cue-gen:VirtualService:scope:Namespaced
-// +cue-gen:VirtualService:resource:categories=istio-io,networking-istio-io,shortNames=vs
-// +cue-gen:VirtualService:printerColumn:name=Gateways,type=string,JSONPath=.spec.gateways,description="The names of gateways and sidecars
-// that should apply these routes"
-// +cue-gen:VirtualService:printerColumn:name=Hosts,type=string,JSONPath=.spec.hosts,description="The destination hosts to which traffic is being sent"
-// +cue-gen:VirtualService:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:VirtualService:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/workload_entry.pb.go
+++ b/networking/v1beta1/workload_entry.pb.go
@@ -170,23 +170,6 @@ const (
 
 // WorkloadEntry enables specifying the properties of a single non-Kubernetes workload such a VM or a bare metal services that can be referred to by service entries.
 //
-// <!-- crd generation tags
-// +cue-gen:WorkloadEntry:groupName:networking.istio.io
-// +cue-gen:WorkloadEntry:version:v1beta1
-// +cue-gen:WorkloadEntry:storageVersion
-// +cue-gen:WorkloadEntry:annotations:helm.sh/resource-policy=keep
-// +cue-gen:WorkloadEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:WorkloadEntry:subresource:status
-// +cue-gen:WorkloadEntry:scope:Namespaced
-// +cue-gen:WorkloadEntry:resource:categories=istio-io,networking-istio-io,shortNames=we,plural=workloadentries
-// +cue-gen:WorkloadEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
-// +cue-gen:WorkloadEntry:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/workload_entry.proto
+++ b/networking/v1beta1/workload_entry.proto
@@ -153,23 +153,6 @@ option go_package = "istio.io/api/networking/v1beta1";
 
 // WorkloadEntry enables specifying the properties of a single non-Kubernetes workload such a VM or a bare metal services that can be referred to by service entries.
 //
-// <!-- crd generation tags
-// +cue-gen:WorkloadEntry:groupName:networking.istio.io
-// +cue-gen:WorkloadEntry:version:v1beta1
-// +cue-gen:WorkloadEntry:storageVersion
-// +cue-gen:WorkloadEntry:annotations:helm.sh/resource-policy=keep
-// +cue-gen:WorkloadEntry:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:WorkloadEntry:subresource:status
-// +cue-gen:WorkloadEntry:scope:Namespaced
-// +cue-gen:WorkloadEntry:resource:categories=istio-io,networking-istio-io,shortNames=we,plural=workloadentries
-// +cue-gen:WorkloadEntry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:WorkloadEntry:printerColumn:name=Address,type=string,JSONPath=.spec.address,description="Address associated with the network endpoint."
-// +cue-gen:WorkloadEntry:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/workload_group.pb.go
+++ b/networking/v1beta1/workload_group.pb.go
@@ -94,21 +94,6 @@ const (
 // `WorkloadGroup` has no relationship to resources which control service registry like `ServiceEntry`
 // and as such doesn't configure host name for these workloads.
 //
-// <!-- crd generation tags
-// +cue-gen:WorkloadGroup:groupName:networking.istio.io
-// +cue-gen:WorkloadGroup:version:v1beta1
-// +cue-gen:WorkloadGroup:storageVersion
-// +cue-gen:WorkloadGroup:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:WorkloadGroup:subresource:status
-// +cue-gen:WorkloadGroup:scope:Namespaced
-// +cue-gen:WorkloadGroup:resource:categories=istio-io,networking-istio-io,shortNames=wg,plural=workloadgroups
-// +cue-gen:WorkloadGroup:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:WorkloadGroup:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/networking/v1beta1/workload_group.proto
+++ b/networking/v1beta1/workload_group.proto
@@ -79,21 +79,6 @@ option go_package = "istio.io/api/networking/v1beta1";
 // `WorkloadGroup` has no relationship to resources which control service registry like `ServiceEntry` 
 // and as such doesn't configure host name for these workloads.
 //
-// <!-- crd generation tags
-// +cue-gen:WorkloadGroup:groupName:networking.istio.io
-// +cue-gen:WorkloadGroup:version:v1beta1
-// +cue-gen:WorkloadGroup:storageVersion
-// +cue-gen:WorkloadGroup:labels:app=istio-pilot,chart=istio,heritage=Tiller,release=istio
-// +cue-gen:WorkloadGroup:subresource:status
-// +cue-gen:WorkloadGroup:scope:Namespaced
-// +cue-gen:WorkloadGroup:resource:categories=istio-io,networking-istio-io,shortNames=wg,plural=workloadgroups
-// +cue-gen:WorkloadGroup:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// +cue-gen:WorkloadGroup:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=networking.istio.io/v1beta1

--- a/security/v1/authorization_policy.pb.go
+++ b/security/v1/authorization_policy.pb.go
@@ -357,22 +357,6 @@ func (AuthorizationPolicy_Action) EnumDescriptor() ([]byte, []int) {
 
 // AuthorizationPolicy enables access control on workloads.
 //
-// <!-- crd generation tags
-// +cue-gen:AuthorizationPolicy:groupName:security.istio.io
-// +cue-gen:AuthorizationPolicy:version:v1
-// +cue-gen:AuthorizationPolicy:annotations:helm.sh/resource-policy=keep
-// +cue-gen:AuthorizationPolicy:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio
-// +cue-gen:AuthorizationPolicy:subresource:status
-// +cue-gen:AuthorizationPolicy:scope:Namespaced
-// +cue-gen:AuthorizationPolicy:resource:categories=istio-io,security-istio-io,shortNames=ap,plural=authorizationpolicies
-// +cue-gen:AuthorizationPolicy:preserveUnknownFields:false
-// +cue-gen:AuthorizationPolicy:printerColumn:name=Action,type=string,JSONPath=.spec.action,description="The operation to take."
-// +cue-gen:AuthorizationPolicy:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=security.istio.io/v1

--- a/security/v1/authorization_policy.proto
+++ b/security/v1/authorization_policy.proto
@@ -250,22 +250,6 @@ option go_package="istio.io/api/security/v1";
 
 // AuthorizationPolicy enables access control on workloads.
 //
-// <!-- crd generation tags
-// +cue-gen:AuthorizationPolicy:groupName:security.istio.io
-// +cue-gen:AuthorizationPolicy:version:v1
-// +cue-gen:AuthorizationPolicy:annotations:helm.sh/resource-policy=keep
-// +cue-gen:AuthorizationPolicy:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio
-// +cue-gen:AuthorizationPolicy:subresource:status
-// +cue-gen:AuthorizationPolicy:scope:Namespaced
-// +cue-gen:AuthorizationPolicy:resource:categories=istio-io,security-istio-io,shortNames=ap,plural=authorizationpolicies
-// +cue-gen:AuthorizationPolicy:preserveUnknownFields:false
-// +cue-gen:AuthorizationPolicy:printerColumn:name=Action,type=string,JSONPath=.spec.action,description="The operation to take."
-// +cue-gen:AuthorizationPolicy:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=security.istio.io/v1

--- a/security/v1/peer_authentication.pb.go
+++ b/security/v1/peer_authentication.pb.go
@@ -200,22 +200,6 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 //
 // ```
 //
-// <!-- crd generation tags
-// +cue-gen:PeerAuthentication:groupName:security.istio.io
-// +cue-gen:PeerAuthentication:version:v1
-// +cue-gen:PeerAuthentication:annotations:helm.sh/resource-policy=keep
-// +cue-gen:PeerAuthentication:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio
-// +cue-gen:PeerAuthentication:subresource:status
-// +cue-gen:PeerAuthentication:scope:Namespaced
-// +cue-gen:PeerAuthentication:resource:categories=istio-io,security-istio-io,shortNames=pa
-// +cue-gen:PeerAuthentication:preserveUnknownFields:false
-// +cue-gen:PeerAuthentication:printerColumn:name=Mode,type=string,JSONPath=.spec.mtls.mode,description="Defines the mTLS mode used for peer authentication."
-// +cue-gen:PeerAuthentication:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=security.istio.io/v1

--- a/security/v1/peer_authentication.proto
+++ b/security/v1/peer_authentication.proto
@@ -108,22 +108,6 @@ option go_package="istio.io/api/security/v1";
 //       mode: DISABLE
 // ```
 //
-// <!-- crd generation tags
-// +cue-gen:PeerAuthentication:groupName:security.istio.io
-// +cue-gen:PeerAuthentication:version:v1
-// +cue-gen:PeerAuthentication:annotations:helm.sh/resource-policy=keep
-// +cue-gen:PeerAuthentication:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio
-// +cue-gen:PeerAuthentication:subresource:status
-// +cue-gen:PeerAuthentication:scope:Namespaced
-// +cue-gen:PeerAuthentication:resource:categories=istio-io,security-istio-io,shortNames=pa
-// +cue-gen:PeerAuthentication:preserveUnknownFields:false
-// +cue-gen:PeerAuthentication:printerColumn:name=Mode,type=string,JSONPath=.spec.mtls.mode,description="Defines the mTLS mode used for peer authentication."
-// +cue-gen:PeerAuthentication:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp is a timestamp
-// representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-// Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=security.istio.io/v1

--- a/security/v1/request_authentication.pb.go
+++ b/security/v1/request_authentication.pb.go
@@ -282,17 +282,6 @@ const (
 //
 // ```
 //
-// <!-- crd generation tags
-// +cue-gen:RequestAuthentication:groupName:security.istio.io
-// +cue-gen:RequestAuthentication:version:v1
-// +cue-gen:RequestAuthentication:annotations:helm.sh/resource-policy=keep
-// +cue-gen:RequestAuthentication:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio
-// +cue-gen:RequestAuthentication:subresource:status
-// +cue-gen:RequestAuthentication:scope:Namespaced
-// +cue-gen:RequestAuthentication:resource:categories=istio-io,security-istio-io,shortNames=ra
-// +cue-gen:RequestAuthentication:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=security.istio.io/v1

--- a/security/v1/request_authentication.proto
+++ b/security/v1/request_authentication.proto
@@ -227,17 +227,6 @@ option go_package="istio.io/api/security/v1";
 //         subset: v1
 // ```
 //
-// <!-- crd generation tags
-// +cue-gen:RequestAuthentication:groupName:security.istio.io
-// +cue-gen:RequestAuthentication:version:v1
-// +cue-gen:RequestAuthentication:annotations:helm.sh/resource-policy=keep
-// +cue-gen:RequestAuthentication:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio
-// +cue-gen:RequestAuthentication:subresource:status
-// +cue-gen:RequestAuthentication:scope:Namespaced
-// +cue-gen:RequestAuthentication:resource:categories=istio-io,security-istio-io,shortNames=ra
-// +cue-gen:RequestAuthentication:preserveUnknownFields:false
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=security.istio.io/v1

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -357,7 +357,7 @@ func (AuthorizationPolicy_Action) EnumDescriptor() ([]byte, []int) {
 //
 // <!-- crd generation tags
 // +cue-gen:AuthorizationPolicy:groupName:security.istio.io
-// +cue-gen:AuthorizationPolicy:version:v1beta1
+// +cue-gen:AuthorizationPolicy:versions:v1beta1,v1
 // +cue-gen:AuthorizationPolicy:storageVersion
 // +cue-gen:AuthorizationPolicy:annotations:helm.sh/resource-policy=keep
 // +cue-gen:AuthorizationPolicy:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -250,7 +250,7 @@ option go_package="istio.io/api/security/v1beta1";
 //
 // <!-- crd generation tags
 // +cue-gen:AuthorizationPolicy:groupName:security.istio.io
-// +cue-gen:AuthorizationPolicy:version:v1beta1
+// +cue-gen:AuthorizationPolicy:versions:v1beta1,v1
 // +cue-gen:AuthorizationPolicy:storageVersion
 // +cue-gen:AuthorizationPolicy:annotations:helm.sh/resource-policy=keep
 // +cue-gen:AuthorizationPolicy:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio

--- a/security/v1beta1/peer_authentication.pb.go
+++ b/security/v1beta1/peer_authentication.pb.go
@@ -201,7 +201,7 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 //
 // <!-- crd generation tags
 // +cue-gen:PeerAuthentication:groupName:security.istio.io
-// +cue-gen:PeerAuthentication:version:v1beta1
+// +cue-gen:PeerAuthentication:versions:v1beta1,v1
 // +cue-gen:PeerAuthentication:storageVersion
 // +cue-gen:PeerAuthentication:annotations:helm.sh/resource-policy=keep
 // +cue-gen:PeerAuthentication:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio

--- a/security/v1beta1/peer_authentication.proto
+++ b/security/v1beta1/peer_authentication.proto
@@ -109,7 +109,7 @@ option go_package="istio.io/api/security/v1beta1";
 //
 // <!-- crd generation tags
 // +cue-gen:PeerAuthentication:groupName:security.istio.io
-// +cue-gen:PeerAuthentication:version:v1beta1
+// +cue-gen:PeerAuthentication:versions:v1beta1,v1
 // +cue-gen:PeerAuthentication:storageVersion
 // +cue-gen:PeerAuthentication:annotations:helm.sh/resource-policy=keep
 // +cue-gen:PeerAuthentication:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -282,7 +282,7 @@ const (
 //
 // <!-- crd generation tags
 // +cue-gen:RequestAuthentication:groupName:security.istio.io
-// +cue-gen:RequestAuthentication:version:v1beta1
+// +cue-gen:RequestAuthentication:versions:v1beta1,v1
 // +cue-gen:RequestAuthentication:storageVersion
 // +cue-gen:RequestAuthentication:annotations:helm.sh/resource-policy=keep
 // +cue-gen:RequestAuthentication:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -227,7 +227,7 @@ option go_package="istio.io/api/security/v1beta1";
 //
 // <!-- crd generation tags
 // +cue-gen:RequestAuthentication:groupName:security.istio.io
-// +cue-gen:RequestAuthentication:version:v1beta1
+// +cue-gen:RequestAuthentication:versions:v1beta1,v1
 // +cue-gen:RequestAuthentication:storageVersion
 // +cue-gen:RequestAuthentication:annotations:helm.sh/resource-policy=keep
 // +cue-gen:RequestAuthentication:labels:app=istio-pilot,chart=istio,istio=security,heritage=Tiller,release=istio

--- a/telemetry/v1/telemetry.pb.go
+++ b/telemetry/v1/telemetry.pb.go
@@ -522,23 +522,6 @@ func (MetricsOverrides_TagOverride_Operation) EnumDescriptor() ([]byte, []int) {
 	return file_telemetry_v1_telemetry_proto_rawDescGZIP(), []int{5, 0, 0}
 }
 
-// <!-- crd generation tags
-// +cue-gen:Telemetry:groupName:telemetry.istio.io
-// +cue-gen:Telemetry:version:v1
-// +cue-gen:Telemetry:annotations:helm.sh/resource-policy=keep
-// +cue-gen:Telemetry:labels:app=istio-pilot,chart=istio,istio=telemetry,heritage=Tiller,release=istio
-// +cue-gen:Telemetry:subresource:status
-// +cue-gen:Telemetry:scope:Namespaced
-// +cue-gen:Telemetry:resource:categories=istio-io,telemetry-istio-io,shortNames=telemetry,plural=telemetries
-// +cue-gen:Telemetry:preserveUnknownFields:false
-// +cue-gen:Telemetry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp
-// is a timestamp representing the server time when this object was created. It
-// is not guaranteed to be set in happens-before order across separate
-// operations. Clients may not set this value. It is represented in RFC3339 form
-// and is in UTC. Populated by the system. Read-only. Null for lists. More info:
-// https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=telemetry.istio.io/v1

--- a/telemetry/v1/telemetry.proto
+++ b/telemetry/v1/telemetry.proto
@@ -236,23 +236,6 @@ package istio.telemetry.v1;
 
 option go_package = "istio.io/api/telemetry/v1";
 
-// <!-- crd generation tags
-// +cue-gen:Telemetry:groupName:telemetry.istio.io
-// +cue-gen:Telemetry:version:v1
-// +cue-gen:Telemetry:annotations:helm.sh/resource-policy=keep
-// +cue-gen:Telemetry:labels:app=istio-pilot,chart=istio,istio=telemetry,heritage=Tiller,release=istio
-// +cue-gen:Telemetry:subresource:status
-// +cue-gen:Telemetry:scope:Namespaced
-// +cue-gen:Telemetry:resource:categories=istio-io,telemetry-istio-io,shortNames=telemetry,plural=telemetries
-// +cue-gen:Telemetry:preserveUnknownFields:false
-// +cue-gen:Telemetry:printerColumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp,description="CreationTimestamp
-// is a timestamp representing the server time when this object was created. It
-// is not guaranteed to be set in happens-before order across separate
-// operations. Clients may not set this value. It is represented in RFC3339 form
-// and is in UTC. Populated by the system. Read-only. Null for lists. More info:
-// https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-// -->
-//
 // <!-- go code generation tags
 // +kubetype-gen
 // +kubetype-gen:groupVersion=telemetry.istio.io/v1

--- a/telemetry/v1alpha1/telemetry.pb.go
+++ b/telemetry/v1alpha1/telemetry.pb.go
@@ -522,7 +522,7 @@ func (MetricsOverrides_TagOverride_Operation) EnumDescriptor() ([]byte, []int) {
 
 // <!-- crd generation tags
 // +cue-gen:Telemetry:groupName:telemetry.istio.io
-// +cue-gen:Telemetry:version:v1alpha1
+// +cue-gen:Telemetry:versions:v1alpha1,v1
 // +cue-gen:Telemetry:storageVersion
 // +cue-gen:Telemetry:annotations:helm.sh/resource-policy=keep
 // +cue-gen:Telemetry:labels:app=istio-pilot,chart=istio,istio=telemetry,heritage=Tiller,release=istio

--- a/telemetry/v1alpha1/telemetry.proto
+++ b/telemetry/v1alpha1/telemetry.proto
@@ -236,7 +236,7 @@ option go_package = "istio.io/api/telemetry/v1alpha1";
 
 // <!-- crd generation tags
 // +cue-gen:Telemetry:groupName:telemetry.istio.io
-// +cue-gen:Telemetry:version:v1alpha1
+// +cue-gen:Telemetry:versions:v1alpha1,v1
 // +cue-gen:Telemetry:storageVersion
 // +cue-gen:Telemetry:annotations:helm.sh/resource-policy=keep
 // +cue-gen:Telemetry:labels:app=istio-pilot,chart=istio,istio=telemetry,heritage=Tiller,release=istio


### PR DESCRIPTION
Part of https://github.com/istio/api/issues/3127. Goes with a
corresponding tools change; this will fail until that merges.

This just shows DR. The tool will support both the new and old way (we
can remove the old way if we want), so we don't have to move everything
at once. We will, though. I kept it to one so its easy to review first.
