### PR TITLE
Adds Service Type to PolicyTargetReference API Docs

### DIFF
--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -555,12 +555,13 @@ type WasmPlugin struct {
 	Selector *v1beta1.WorkloadSelector `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
 	// $hide_from_docs
 	TargetRef *v1beta1.PolicyTargetReference `protobuf:"bytes,15,opt,name=targetRef,proto3" json:"targetRef,omitempty"`
-	// Optional. The targetRef specifies the gateway the policy should be
-	// applied to. The targeted resource specified will determine which
-	// workloads the policy applies to.
+	// Optional. The targetRefs specifies a list of resources the policy should be
+	// applied to. The targeted resources specified will determine which workloads
+	// the policy applies to.
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/extensions/v1alpha1/wasm.pb.html
+++ b/extensions/v1alpha1/wasm.pb.html
@@ -203,12 +203,13 @@ No
 <td><code>targetRefs</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#PolicyTargetReference">PolicyTargetReference[]</a></code></td>
 <td>
-<p>Optional. The targetRef specifies the gateway the policy should be
-applied to. The targeted resource specified will determine which
-workloads the policy applies to.</p>
+<p>Optional. The targetRefs specifies a list of resources the policy should be
+applied to. The targeted resources specified will determine which workloads
+the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
+<li><code>kind: Service</code> with <code>&quot;&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -250,12 +250,13 @@ message WasmPlugin {
   // $hide_from_docs
   istio.type.v1beta1.PolicyTargetReference targetRef = 15;
 
-  // Optional. The targetRef specifies the gateway the policy should be
-  // applied to. The targeted resource specified will determine which
-  // workloads the policy applies to.
+  // Optional. The targetRefs specifies a list of resources the policy should be
+  // applied to. The targeted resources specified will determine which workloads
+  // the policy applies to.
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -834,12 +834,13 @@ type EnvoyFilter struct {
 	// in the config root namespace, it will be applied to all applicable
 	// workloads in any namespace.
 	WorkloadSelector *WorkloadSelector `protobuf:"bytes,3,opt,name=workload_selector,json=workloadSelector,proto3" json:"workload_selector,omitempty"`
-	// Optional. The targetRef specifies the gateway the policy should be
-	// applied to. The targeted resource specified will determine which
-	// workloads the policy applies to.
+	// Optional. The targetRefs specifies a list of resources the policy should be
+	// applied to. The targeted resources specified will determine which workloads
+	// the policy applies to.
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/networking/v1alpha3/envoy_filter.pb.html
+++ b/networking/v1alpha3/envoy_filter.pb.html
@@ -387,12 +387,13 @@ No
 <td><code>targetRefs</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#PolicyTargetReference">PolicyTargetReference[]</a></code></td>
 <td>
-<p>Optional. The targetRef specifies the gateway the policy should be
-applied to. The targeted resource specified will determine which
-workloads the policy applies to.</p>
+<p>Optional. The targetRefs specifies a list of resources the policy should be
+applied to. The targeted resources specified will determine which workloads
+the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
+<li><code>kind: Service</code> with <code>&quot;&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -849,12 +849,13 @@ message EnvoyFilter {
   // workloads in any namespace.
   WorkloadSelector workload_selector = 3;
 
-  // Optional. The targetRef specifies the gateway the policy should be
-  // applied to. The targeted resource specified will determine which
-  // workloads the policy applies to.
+  // Optional. The targetRefs specifies a list of resources the policy should be
+  // applied to. The targeted resources specified will determine which workloads
+  // the policy applies to.
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/security/v1/authorization_policy.pb.go
+++ b/security/v1/authorization_policy.pb.go
@@ -381,12 +381,13 @@ type AuthorizationPolicy struct {
 	Selector *v1beta1.WorkloadSelector `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
 	// $hide_from_docs
 	TargetRef *v1beta1.PolicyTargetReference `protobuf:"bytes,5,opt,name=targetRef,proto3" json:"targetRef,omitempty"`
-	// Optional. The targetRef specifies the gateway the policy should be
-	// applied to. The targeted resource specified will determine which
-	// workloads the policy applies to.
+	// Optional. The targetRefs specifies a list of resources the policy should be
+	// applied to. The targeted resources specified will determine which workloads
+	// the policy applies to.
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/security/v1/authorization_policy.proto
+++ b/security/v1/authorization_policy.proto
@@ -272,12 +272,13 @@ message AuthorizationPolicy {
   // $hide_from_docs
   istio.type.v1beta1.PolicyTargetReference targetRef = 5;
 
-  // Optional. The targetRef specifies the gateway the policy should be
-  // applied to. The targeted resource specified will determine which
-  // workloads the policy applies to.
+  // Optional. The targetRefs specifies a list of resources the policy should be
+  // applied to. The targeted resources specified will determine which workloads
+  // the policy applies to.
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/security/v1/request_authentication.pb.go
+++ b/security/v1/request_authentication.pb.go
@@ -308,12 +308,13 @@ type RequestAuthentication struct {
 	Selector *v1beta1.WorkloadSelector `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
 	// $hide_from_docs
 	TargetRef *v1beta1.PolicyTargetReference `protobuf:"bytes,3,opt,name=targetRef,proto3" json:"targetRef,omitempty"`
-	// Optional. The targetRef specifies the gateway the policy should be
-	// applied to. The targeted resource specified will determine which
-	// workloads the policy applies to.
+	// Optional. The targetRefs specifies a list of resources the policy should be
+	// applied to. The targeted resources specified will determine which workloads
+	// the policy applies to.
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/security/v1/request_authentication.proto
+++ b/security/v1/request_authentication.proto
@@ -250,12 +250,13 @@ message RequestAuthentication {
   // $hide_from_docs
   istio.type.v1beta1.PolicyTargetReference targetRef = 3;
 
-  // Optional. The targetRef specifies the gateway the policy should be
-  // applied to. The targeted resource specified will determine which
-  // workloads the policy applies to.
+  // Optional. The targetRefs specifies a list of resources the policy should be
+  // applied to. The targeted resources specified will determine which workloads
+  // the policy applies to.
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -396,12 +396,13 @@ type AuthorizationPolicy struct {
 	Selector *v1beta1.WorkloadSelector `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
 	// $hide_from_docs
 	TargetRef *v1beta1.PolicyTargetReference `protobuf:"bytes,5,opt,name=targetRef,proto3" json:"targetRef,omitempty"`
-	// Optional. The targetRef specifies the gateway the policy should be
-	// applied to. The targeted resource specified will determine which
-	// workloads the policy applies to.
+	// Optional. The targetRefs specifies a list of resources the policy should be
+	// applied to. The targeted resources specified will determine which workloads
+	// the policy applies to.
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -228,12 +228,13 @@ No
 <td><code>targetRefs</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#PolicyTargetReference">PolicyTargetReference[]</a></code></td>
 <td>
-<p>Optional. The targetRef specifies the gateway the policy should be
-applied to. The targeted resource specified will determine which
-workloads the policy applies to.</p>
+<p>Optional. The targetRefs specifies a list of resources the policy should be
+applied to. The targeted resources specified will determine which workloads
+the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
+<li><code>kind: Service</code> with <code>&quot;&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -287,12 +287,13 @@ message AuthorizationPolicy {
   // $hide_from_docs
   istio.type.v1beta1.PolicyTargetReference targetRef = 5;
 
-  // Optional. The targetRef specifies the gateway the policy should be
-  // applied to. The targeted resource specified will determine which
-  // workloads the policy applies to.
+  // Optional. The targetRefs specifies a list of resources the policy should be
+  // applied to. The targeted resources specified will determine which workloads
+  // the policy applies to.
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -318,12 +318,13 @@ type RequestAuthentication struct {
 	Selector *v1beta1.WorkloadSelector `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
 	// $hide_from_docs
 	TargetRef *v1beta1.PolicyTargetReference `protobuf:"bytes,3,opt,name=targetRef,proto3" json:"targetRef,omitempty"`
-	// Optional. The targetRef specifies the gateway the policy should be
-	// applied to. The targeted resource specified will determine which
-	// workloads the policy applies to.
+	// Optional. The targetRefs specifies a list of resources the policy should be
+	// applied to. The targeted resources specified will determine which workloads
+	// the policy applies to.
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -232,12 +232,13 @@ No
 <td><code>targetRefs</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#PolicyTargetReference">PolicyTargetReference[]</a></code></td>
 <td>
-<p>Optional. The targetRef specifies the gateway the policy should be
-applied to. The targeted resource specified will determine which
-workloads the policy applies to.</p>
+<p>Optional. The targetRefs specifies a list of resources the policy should be
+applied to. The targeted resources specified will determine which workloads
+the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
+<li><code>kind: Service</code> with <code>&quot;&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -260,12 +260,13 @@ message RequestAuthentication {
   // $hide_from_docs
   istio.type.v1beta1.PolicyTargetReference targetRef = 3;
 
-  // Optional. The targetRef specifies the gateway the policy should be
-  // applied to. The targeted resource specified will determine which
-  // workloads the policy applies to.
+  // Optional. The targetRefs specifies a list of resources the policy should be
+  // applied to. The targeted resources specified will determine which workloads
+  // the policy applies to.
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/telemetry/v1/telemetry.pb.go
+++ b/telemetry/v1/telemetry.pb.go
@@ -545,12 +545,13 @@ type Telemetry struct {
 	Selector *v1beta1.WorkloadSelector `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
 	// $hide_from_docs
 	TargetRef *v1beta1.PolicyTargetReference `protobuf:"bytes,5,opt,name=targetRef,proto3" json:"targetRef,omitempty"`
-	// Optional. The targetRef specifies the gateway the policy should be
-	// applied to. The targeted resource specified will determine which
-	// workloads the policy applies to.
+	// Optional. The targetRefs specifies a list of resources the policy should be
+	// applied to. The targeted resources specified will determine which workloads
+	// the policy applies to.
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/telemetry/v1/telemetry.proto
+++ b/telemetry/v1/telemetry.proto
@@ -257,12 +257,13 @@ message Telemetry {
   // $hide_from_docs
   istio.type.v1beta1.PolicyTargetReference targetRef = 5;
 
-  // Optional. The targetRef specifies the gateway the policy should be
-  // applied to. The targeted resource specified will determine which
-  // workloads the policy applies to.
+  // Optional. The targetRefs specifies a list of resources the policy should be
+  // applied to. The targeted resources specified will determine which workloads
+  // the policy applies to.
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/telemetry/v1alpha1/telemetry.pb.go
+++ b/telemetry/v1alpha1/telemetry.pb.go
@@ -560,12 +560,13 @@ type Telemetry struct {
 	Selector *v1beta1.WorkloadSelector `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
 	// $hide_from_docs
 	TargetRef *v1beta1.PolicyTargetReference `protobuf:"bytes,5,opt,name=targetRef,proto3" json:"targetRef,omitempty"`
-	// Optional. The targetRef specifies the gateway the policy should be
-	// applied to. The targeted resource specified will determine which
-	// workloads the policy applies to.
+	// Optional. The targetRefs specifies a list of resources the policy should be
+	// applied to. The targeted resources specified will determine which workloads
+	// the policy applies to.
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/telemetry/v1alpha1/telemetry.pb.html
+++ b/telemetry/v1alpha1/telemetry.pb.html
@@ -221,12 +221,13 @@ No
 <td><code>targetRefs</code></td>
 <td><code><a href="https://istio.io/docs/reference/config/type/workload-selector.html#PolicyTargetReference">PolicyTargetReference[]</a></code></td>
 <td>
-<p>Optional. The targetRef specifies the gateway the policy should be
-applied to. The targeted resource specified will determine which
-workloads the policy applies to.</p>
+<p>Optional. The targetRefs specifies a list of resources the policy should be
+applied to. The targeted resources specified will determine which workloads
+the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
+<li><code>kind: Service</code> with <code>&quot;&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/telemetry/v1alpha1/telemetry.proto
+++ b/telemetry/v1alpha1/telemetry.proto
@@ -272,12 +272,13 @@ message Telemetry {
   // $hide_from_docs
   istio.type.v1beta1.PolicyTargetReference targetRef = 5;
 
-  // Optional. The targetRef specifies the gateway the policy should be
-  // applied to. The targeted resource specified will determine which
-  // workloads the policy applies to.
+  // Optional. The targetRefs specifies a list of resources the policy should be
+  // applied to. The targeted resources specified will determine which workloads
+  // the policy applies to.
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/type/v1beta1/selector.pb.go
+++ b/type/v1beta1/selector.pb.go
@@ -213,10 +213,10 @@ func (x *PortSelector) GetNumber() uint32 {
 	return 0
 }
 
-// PolicyTargetReference format as defined by [GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/#policy-targetref-api).
+// PolicyTargetReference format as defined by [GEP-2648](https://gateway-api.sigs.k8s.io/geps/gep-2648/#direct-policy-design-rules).
 //
-// PolicyTargetReferences specifies the targeted resource which the policy
-// can be applied to. It must only target a single resource at a time, but it
+// PolicyTargetReference specifies the targeted resource which the policy
+// should be applied to. It must only target a single resource at a time, but it
 // can be used to target larger resources such as Gateways that may apply to
 // multiple child resources. The PolicyTargetReference will be used instead of
 // a WorkloadSelector in the RequestAuthentication, AuthorizationPolicy,
@@ -237,8 +237,8 @@ func (x *PortSelector) GetNumber() uint32 {
 //
 // spec:
 //
-//	targetRef:
-//	  name: waypoint
+//	targetRefs:
+//	- name: waypoint
 //	  kind: Gateway
 //	  group: gateway.networking.k8s.io
 //	action: DENY

--- a/type/v1beta1/selector.pb.html
+++ b/type/v1beta1/selector.pb.html
@@ -72,9 +72,9 @@ Yes
 </section>
 <h2 id="PolicyTargetReference">PolicyTargetReference</h2>
 <section>
-<p>PolicyTargetReference format as defined by <a href="https://gateway-api.sigs.k8s.io/geps/gep-713/#policy-targetref-api">GEP-713</a>.</p>
-<p>PolicyTargetReferences specifies the targeted resource which the policy
-can be applied to. It must only target a single resource at a time, but it
+<p>PolicyTargetReference format as defined by <a href="https://gateway-api.sigs.k8s.io/geps/gep-2648/#direct-policy-design-rules">GEP-2648</a>.</p>
+<p>PolicyTargetReference specifies the targeted resource which the policy
+should be applied to. It must only target a single resource at a time, but it
 can be used to target larger resources such as Gateways that may apply to
 multiple child resources. The PolicyTargetReference will be used instead of
 a WorkloadSelector in the RequestAuthentication, AuthorizationPolicy,
@@ -89,8 +89,8 @@ metadata:
   name: httpbin
   namespace: foo
 spec:
-  targetRef:
-    name: waypoint
+  targetRefs:
+  - name: waypoint
     kind: Gateway
     group: gateway.networking.k8s.io
   action: DENY

--- a/type/v1beta1/selector.proto
+++ b/type/v1beta1/selector.proto
@@ -69,10 +69,10 @@ enum WorkloadMode {
   CLIENT_AND_SERVER = 3;
 }
 
-// PolicyTargetReference format as defined by [GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/#policy-targetref-api).
+// PolicyTargetReference format as defined by [GEP-2648](https://gateway-api.sigs.k8s.io/geps/gep-2648/#direct-policy-design-rules).
 //
-// PolicyTargetReferences specifies the targeted resource which the policy
-// can be applied to. It must only target a single resource at a time, but it
+// PolicyTargetReference specifies the targeted resource which the policy
+// should be applied to. It must only target a single resource at a time, but it
 // can be used to target larger resources such as Gateways that may apply to
 // multiple child resources. The PolicyTargetReference will be used instead of
 // a WorkloadSelector in the RequestAuthentication, AuthorizationPolicy,
@@ -90,8 +90,8 @@ enum WorkloadMode {
 //   name: httpbin
 //   namespace: foo
 // spec:
-//   targetRef:
-//     name: waypoint
+//   targetRefs:
+//   - name: waypoint
 //     kind: Gateway
 //     group: gateway.networking.k8s.io
 //   action: DENY


### PR DESCRIPTION
Previously, only a Gateway resource was defined as a supported attachment type. This PR updates the API docs to include a Service as a supported type and also fixes an incorrect link to Gateway API documentation.