### PR TITLE
[release-1.22] Show the latest API Version in Examples

### DIFF
--- a/networking/v1/destination_rule.pb.go
+++ b/networking/v1/destination_rule.pb.go
@@ -630,7 +630,7 @@ func (x *TrafficPolicy) GetProxyProtocol() *TrafficPolicy_ProxyProtocol {
 // labels (version:v3).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -740,7 +740,7 @@ func (x *Subset) GetTrafficPolicy() *TrafficPolicy {
 // for all traffic going to the ratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -760,7 +760,7 @@ func (x *Subset) GetTrafficPolicy() *TrafficPolicy {
 // the User cookie as the hash key.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -896,7 +896,7 @@ func (*LoadBalancerSettings_ConsistentHash) isLoadBalancerSettings_LbPolicy() {}
 // service called myredissrv with a connect timeout of 30ms
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -989,7 +989,7 @@ func (x *ConnectionPoolSettings) GetHttp() *ConnectionPoolSettings_HTTPSettings 
 // times with a 502, 503, or 504 error code will be ejected for 15 minutes.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1191,7 +1191,7 @@ func (x *OutlierDetection) GetMinHealthPercent() int32 {
 // for connections to upstream database cluster.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1213,7 +1213,7 @@ func (x *OutlierDetection) GetMinHealthPercent() int32 {
 // foreign service whose domain matches *.foo.com.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1232,7 +1232,7 @@ func (x *OutlierDetection) GetMinHealthPercent() int32 {
 // to rating services.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //

--- a/networking/v1/destination_rule.proto
+++ b/networking/v1/destination_rule.proto
@@ -273,7 +273,7 @@ message TrafficPolicy {
 // labels (version:v3).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -324,7 +324,7 @@ message Subset {
 // for all traffic going to the ratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -340,7 +340,7 @@ message Subset {
 // the User cookie as the hash key.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -502,7 +502,7 @@ message LoadBalancerSettings {
 // service called myredissrv with a connect timeout of 30ms
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-redis
@@ -643,7 +643,7 @@ message ConnectionPoolSettings {
 // times with a 502, 503, or 504 error code will be ejected for 15 minutes.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: reviews-cb-policy
@@ -748,7 +748,7 @@ message OutlierDetection {
 // for connections to upstream database cluster.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: db-mtls
@@ -766,7 +766,7 @@ message OutlierDetection {
 // foreign service whose domain matches *.foo.com.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: tls-foo
@@ -781,7 +781,7 @@ message OutlierDetection {
 // to rating services.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: ratings-istio-mtls

--- a/networking/v1/gateway.pb.go
+++ b/networking/v1/gateway.pb.go
@@ -459,7 +459,7 @@ func (x *Gateway) GetSelector() map[string]string {
 // port. For example,
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //
@@ -482,7 +482,7 @@ func (x *Gateway) GetSelector() map[string]string {
 // # Another example
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //
@@ -505,7 +505,7 @@ func (x *Gateway) GetSelector() map[string]string {
 // # The following is an example of TLS configuration for port 443
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //

--- a/networking/v1/gateway.proto
+++ b/networking/v1/gateway.proto
@@ -242,7 +242,7 @@ message Gateway {
 // port. For example,
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-ingress
@@ -261,7 +261,7 @@ message Gateway {
 // Another example
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-tcp-ingress
@@ -280,7 +280,7 @@ message Gateway {
 // The following is an example of TLS configuration for port 443
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-tls-ingress

--- a/networking/v1/virtual_service.pb.go
+++ b/networking/v1/virtual_service.pb.go
@@ -389,7 +389,7 @@ func (x *VirtualService) GetExportTo() []string {
 // some to subset v2, in a Kubernetes environment.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -422,7 +422,7 @@ func (x *VirtualService) GetExportTo() []string {
 // # And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -453,7 +453,7 @@ func (x *VirtualService) GetExportTo() []string {
 // not have an impact in resolving the name of the productpage service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -479,7 +479,7 @@ func (x *VirtualService) GetExportTo() []string {
 // Service for wikipedia.org and set a timeout of 5s for HTTP requests.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //
@@ -497,7 +497,7 @@ func (x *VirtualService) GetExportTo() []string {
 //	resolution: DNS
 //
 // ---
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -838,7 +838,7 @@ func (x *HTTPRoute) GetHeaders() *Headers {
 // forward the traffic to `/reviews` by a delegate VirtualService named `reviews`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -867,7 +867,7 @@ func (x *HTTPRoute) GetHeaders() *Headers {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -890,7 +890,7 @@ func (x *HTTPRoute) GetHeaders() *Headers {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -972,7 +972,7 @@ func (x *Delegate) GetNamespace() string {
 // coming from the `v1` subset (version) of the `reviews` service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1067,7 +1067,7 @@ func (x *Headers) GetResponse() *Headers_HeaderOperations {
 // services in the mesh based on the SNI value.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1161,7 +1161,7 @@ func (x *TLSRoute) GetRoute() []*RouteDestination {
 // mongo.prod.svc.cluster.local to another Mongo server on port 5555.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1248,7 +1248,7 @@ func (x *TCPRoute) GetRoute() []*RouteDestination {
 // with value `jason`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1535,7 +1535,7 @@ func (x *HTTPMatchRequest) GetStatPrefix() string {
 // "v1".
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1561,7 +1561,7 @@ func (x *HTTPMatchRequest) GetStatPrefix() string {
 // # And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1585,7 +1585,7 @@ func (x *HTTPMatchRequest) GetStatPrefix() string {
 // traffic to reviews.com to dev.reviews.com
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1957,7 +1957,7 @@ func (x *TLSMatchAttributes) GetSourceNamespace() string {
 // /v1/bookRatings provided by the bookratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2110,7 +2110,7 @@ func (*HTTPRedirect_DerivePort) isHTTPRedirect_RedirectPort() {}
 // to requests for /v1/getProductRatings API.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2136,7 +2136,7 @@ func (*HTTPRedirect_DerivePort) isHTTPRedirect_RedirectPort() {}
 // This is mostly useful for non text-based protocols such as gRPC.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2163,7 +2163,7 @@ func (*HTTPRedirect_DerivePort) isHTTPRedirect_RedirectPort() {}
 // the returned Content-Type.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2336,7 +2336,7 @@ func (*HTTPBody_Bytes) isHTTPBody_Specifier() {}
 // ratings service before making the actual API call.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2600,7 +2600,7 @@ func (*StringMatch_Regex) isStringMatch_MatchType() {}
 // or when the upstream server responds with Service Unavailable(503).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2718,7 +2718,7 @@ func (x *HTTPRetry) GetRetryRemoteLocalities() *wrappers.BoolValue {
 // exposes `X-Foo-bar` header and sets an expiry period of 1 day.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -3165,7 +3165,7 @@ func (x *Headers_HeaderOperations) GetRemove() []string {
 // service from all pods with label env: prod
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -3307,7 +3307,7 @@ func (*HTTPFaultInjection_Delay_ExponentialDelay) isHTTPFaultInjection_Delay_Htt
 // error code for 1 out of every 1000 requests to the "ratings" service "v1".
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //

--- a/networking/v1/virtual_service.proto
+++ b/networking/v1/virtual_service.proto
@@ -254,7 +254,7 @@ message VirtualService {
 // some to subset v2, in a Kubernetes environment.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route
@@ -283,7 +283,7 @@ message VirtualService {
 // And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: reviews-destination
@@ -310,7 +310,7 @@ message VirtualService {
 // not have an impact in resolving the name of the productpage service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: my-productpage-rule
@@ -332,7 +332,7 @@ message VirtualService {
 // Service for wikipedia.org and set a timeout of 5s for HTTP requests.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-wikipedia
@@ -346,7 +346,7 @@ message VirtualService {
 //     protocol: HTTP
 //   resolution: DNS
 // ---
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: my-wiki-rule
@@ -503,7 +503,7 @@ message HTTPRoute {
 // forward the traffic to `/reviews` by a delegate VirtualService named `reviews`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo
@@ -528,7 +528,7 @@ message HTTPRoute {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: productpage
@@ -547,7 +547,7 @@ message HTTPRoute {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews
@@ -576,7 +576,7 @@ message Delegate {
 // coming from the `v1` subset (version) of the `reviews` service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route
@@ -628,7 +628,7 @@ message Headers {
 // services in the mesh based on the SNI value.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo-sni
@@ -669,7 +669,7 @@ message TLSRoute {
 // mongo.prod.svc.cluster.local to another Mongo server on port 5555.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo-mongo
@@ -703,7 +703,7 @@ message TCPRoute {
 // with value `jason`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -867,7 +867,7 @@ message HTTPMatchRequest {
 // "v1".
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route
@@ -889,7 +889,7 @@ message HTTPMatchRequest {
 // And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: reviews-destination
@@ -909,7 +909,7 @@ message HTTPMatchRequest {
 // traffic to reviews.com to dev.reviews.com
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route-two-domains
@@ -1034,7 +1034,7 @@ message TLSMatchAttributes {
 // /v1/bookRatings provided by the bookratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1090,7 +1090,7 @@ message HTTPRedirect {
 // to requests for /v1/getProductRatings API.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1112,7 +1112,7 @@ message HTTPRedirect {
 // This is mostly useful for non text-based protocols such as gRPC.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1135,7 +1135,7 @@ message HTTPRedirect {
 // the returned Content-Type.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1183,7 +1183,7 @@ message HTTPBody {
 // ratings service before making the actual API call.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1256,7 +1256,7 @@ message StringMatch {
 // or when the upstream server responds with Service Unavailable(503).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1310,7 +1310,7 @@ message HTTPRetry {
 // exposes `X-Foo-bar` header and sets an expiry period of 1 day.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1391,7 +1391,7 @@ message HTTPFaultInjection {
   // service from all pods with label env: prod
   //
   // ```yaml
-  // apiVersion: networking.istio.io/v1beta1
+  // apiVersion: networking.istio.io/v1
   // kind: VirtualService
   // metadata:
   //   name: reviews-route
@@ -1441,7 +1441,7 @@ message HTTPFaultInjection {
   // error code for 1 out of every 1000 requests to the "ratings" service "v1".
   //
   // ```yaml
-  // apiVersion: networking.istio.io/v1beta1
+  // apiVersion: networking.istio.io/v1
   // kind: VirtualService
   // metadata:
   //   name: ratings-route

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -32,7 +32,7 @@
 // ratings service would look as follows:
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -50,7 +50,7 @@
 // pods) with labels (version:v3).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -77,7 +77,7 @@
 // traffic to the port 9080.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings-port
@@ -100,7 +100,7 @@
 // specific workload using the workloadSelector configuration.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: configure-client-mtls-dr-with-workloadselector
@@ -654,7 +654,7 @@ func (x *TrafficPolicy) GetProxyProtocol() *TrafficPolicy_ProxyProtocol {
 // labels (version:v3).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -764,7 +764,7 @@ func (x *Subset) GetTrafficPolicy() *TrafficPolicy {
 // for all traffic going to the ratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -784,7 +784,7 @@ func (x *Subset) GetTrafficPolicy() *TrafficPolicy {
 // the User cookie as the hash key.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -920,7 +920,7 @@ func (*LoadBalancerSettings_ConsistentHash) isLoadBalancerSettings_LbPolicy() {}
 // service called myredissrv with a connect timeout of 30ms
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1013,7 +1013,7 @@ func (x *ConnectionPoolSettings) GetHttp() *ConnectionPoolSettings_HTTPSettings 
 // times with a 502, 503, or 504 error code will be ejected for 15 minutes.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1215,7 +1215,7 @@ func (x *OutlierDetection) GetMinHealthPercent() int32 {
 // for connections to upstream database cluster.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1237,7 +1237,7 @@ func (x *OutlierDetection) GetMinHealthPercent() int32 {
 // foreign service whose domain matches *.foo.com.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1256,7 +1256,7 @@ func (x *OutlierDetection) GetMinHealthPercent() int32 {
 // to rating services.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -14,7 +14,7 @@ for load balancing, connection pool size from the sidecar, and outlier
 detection settings to detect and evict unhealthy hosts from the load
 balancing pool. For example, a simple load balancing policy for the
 ratings service would look as follows:</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: bookinfo-ratings
@@ -29,7 +29,7 @@ spec:
 following rule uses a round robin load balancing policy for all traffic
 going to a subset named testversion that is composed of endpoints (e.g.,
 pods) with labels (version:v3).</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: bookinfo-ratings
@@ -52,7 +52,7 @@ a route rule explicitly sends traffic to this subset.</p>
 following rule uses the least connection load balancing policy for all
 traffic to port 80, while uses a round robin load balancing setting for
 traffic to the port 9080.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: bookinfo-ratings-port
@@ -72,7 +72,7 @@ spec:
 <p>Destination Rules can be customized to specific workloads as well.
 The following example shows how a destination rule can be applied to a
 specific workload using the workloadSelector configuration.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: configure-client-mtls-dr-with-workloadselector
@@ -309,7 +309,7 @@ service-level can be overridden at a subset-level. The following rule
 uses a round robin load balancing policy for all traffic going to a
 subset named testversion that is composed of endpoints (e.g., pods) with
 labels (version:v3).</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: bookinfo-ratings
@@ -393,7 +393,7 @@ load balancing
 for more details.</p>
 <p>For example, the following rule uses a round robin load balancing policy
 for all traffic going to the ratings service.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: bookinfo-ratings
@@ -406,7 +406,7 @@ spec:
 <p>The following example sets up sticky sessions for the ratings service
 hashing-based load balancer for the same ratings service using the
 the User cookie as the hash key.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: bookinfo-ratings
@@ -490,7 +490,7 @@ for more details. Connection pool settings can be applied at the TCP
 level as well as at HTTP level.</p>
 <p>For example, the following rule sets a limit of 100 connections to redis
 service called myredissrv with a connect timeout of 30ms</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: bookinfo-redis
@@ -557,7 +557,7 @@ with no more than 10 req/connection to the &ldquo;reviews&rdquo; service. In add
 it sets a limit of 1000 concurrent HTTP2 requests and configures upstream
 hosts to be scanned every 5 mins so that any host that fails 7 consecutive
 times with a 502, 503, or 504 error code will be ejected for 15 minutes.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: reviews-cb-policy
@@ -726,7 +726,7 @@ context</a>
 for more details. These settings are common to both HTTP and TCP upstreams.</p>
 <p>For example, the following rule configures a client to use mutual TLS
 for connections to upstream database cluster.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: db-mtls
@@ -741,7 +741,7 @@ spec:
 </code></pre>
 <p>The following rule configures a client to use TLS when talking to a
 foreign service whose domain matches *.foo.com.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: tls-foo
@@ -753,7 +753,7 @@ spec:
 </code></pre>
 <p>The following rule configures a client to use Istio mutual TLS when talking
 to rating services.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: ratings-istio-mtls

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -33,7 +33,7 @@ import "type/v1beta1/selector.proto";
 // ratings service would look as follows:
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -51,7 +51,7 @@ import "type/v1beta1/selector.proto";
 // pods) with labels (version:v3).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -78,7 +78,7 @@ import "type/v1beta1/selector.proto";
 // traffic to the port 9080.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings-port
@@ -101,7 +101,7 @@ import "type/v1beta1/selector.proto";
 // specific workload using the workloadSelector configuration.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: configure-client-mtls-dr-with-workloadselector
@@ -297,7 +297,7 @@ message TrafficPolicy {
 // labels (version:v3).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -348,7 +348,7 @@ message Subset {
 // for all traffic going to the ratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -364,7 +364,7 @@ message Subset {
 // the User cookie as the hash key.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -526,7 +526,7 @@ message LoadBalancerSettings {
 // service called myredissrv with a connect timeout of 30ms
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-redis
@@ -667,7 +667,7 @@ message ConnectionPoolSettings {
 // times with a 502, 503, or 504 error code will be ejected for 15 minutes.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: reviews-cb-policy
@@ -772,7 +772,7 @@ message OutlierDetection {
 // for connections to upstream database cluster.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: db-mtls
@@ -790,7 +790,7 @@ message OutlierDetection {
 // foreign service whose domain matches *.foo.com.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: tls-foo
@@ -805,7 +805,7 @@ message OutlierDetection {
 // to rating services.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: ratings-istio-mtls

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -38,7 +38,7 @@
 // external traffic to these ports are allowed into the mesh.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-gateway
@@ -106,7 +106,7 @@
 // gets redirected to `https://uk.bookinfo.com` (i.e. 80 redirects to 443).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo-rule
@@ -149,7 +149,7 @@
 // reserved name `mesh`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo-mongo
@@ -176,7 +176,7 @@
 // foo.bar.com host in the ns2 namespace to bind to it.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-gateway
@@ -459,7 +459,7 @@ func (x *Gateway) GetSelector() map[string]string {
 // port. For example,
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //
@@ -482,7 +482,7 @@ func (x *Gateway) GetSelector() map[string]string {
 // # Another example
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //
@@ -505,7 +505,7 @@ func (x *Gateway) GetSelector() map[string]string {
 // # The following is an example of TLS configuration for port 443
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -18,7 +18,7 @@ as a load balancer exposing port 80 and 9080 (http), 443 (https),
 applied to the proxy running on a pod with labels <code>app: my-gateway-controller</code>. While Istio will configure the proxy to listen
 on these ports, it is the responsibility of the user to ensure that
 external traffic to these ports are allowed into the mesh.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: my-gateway
@@ -82,7 +82,7 @@ in the qa version. The same rule is also applicable inside the mesh for
 requests to the &ldquo;reviews.prod.svc.cluster.local&rdquo; service. This rule is
 applicable across ports 443, 9080. Note that <code>http://uk.bookinfo.com</code>
 gets redirected to <code>https://uk.bookinfo.com</code> (i.e. 80 redirects to 443).</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: bookinfo-rule
@@ -122,7 +122,7 @@ spec:
 port 27017 to internal Mongo server on port 5555. This rule is not
 applicable internally in the mesh as the gateway list omits the
 reserved name <code>mesh</code>.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: bookinfo-mongo
@@ -146,7 +146,7 @@ a gateway server using the namespace/hostname syntax in the hosts field.
 For example, the following Gateway allows any virtual service in the ns1
 namespace to bind to it, while restricting only the virtual service with
 foo.bar.com host in the ns2 namespace to bind to it.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: my-gateway
@@ -219,7 +219,7 @@ No
 <section>
 <p><code>Server</code> describes the properties of the proxy on a given load balancer
 port. For example,</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: my-ingress
@@ -235,7 +235,7 @@ spec:
     - &quot;*&quot;
 </code></pre>
 <p>Another example</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: my-tcp-ingress
@@ -251,7 +251,7 @@ spec:
     - &quot;*&quot;
 </code></pre>
 <p>The following is an example of TLS configuration for port 443</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: my-tls-ingress

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -36,7 +36,7 @@ import "google/api/field_behavior.proto";
 // external traffic to these ports are allowed into the mesh.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-gateway
@@ -104,7 +104,7 @@ import "google/api/field_behavior.proto";
 // gets redirected to `https://uk.bookinfo.com` (i.e. 80 redirects to 443).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo-rule
@@ -147,7 +147,7 @@ import "google/api/field_behavior.proto";
 // reserved name `mesh`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo-mongo
@@ -174,7 +174,7 @@ import "google/api/field_behavior.proto";
 // foo.bar.com host in the ns2 namespace to bind to it.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-gateway
@@ -242,7 +242,7 @@ message Gateway {
 // port. For example,
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-ingress
@@ -261,7 +261,7 @@ message Gateway {
 // Another example
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-tcp-ingress
@@ -280,7 +280,7 @@ message Gateway {
 // The following is an example of TLS configuration for port 443
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-tls-ingress

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -45,7 +45,7 @@
 // ClientHello message to route to the appropriate external service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-https
@@ -68,7 +68,7 @@
 // to initiate mTLS connections to the database instances.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-mongocluster
@@ -91,7 +91,7 @@
 // and the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: mtls-mongocluster
@@ -110,7 +110,7 @@
 // an internal egress firewall.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-redirect
@@ -129,7 +129,7 @@
 // And the associated VirtualService to route based on the SNI value.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: tls-routing
@@ -160,7 +160,7 @@
 // namespaces.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-httpbin
@@ -181,7 +181,7 @@
 // Define a gateway to handle all egress traffic.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //  name: istio-egressgateway
@@ -206,7 +206,7 @@
 // a managed middle proxy like this is a common practice.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: gateway-routing
@@ -242,7 +242,7 @@
 // to connect to a specific IP), the resolution mode must be set to `NONE`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-wildcard-example
@@ -262,7 +262,7 @@
 // set to STATIC to use Unix address endpoints.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: unix-domain-socket-example
@@ -288,7 +288,7 @@
 // uk.foo.bar.com:9080, and in.foo.bar.com:7080
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-dns
@@ -323,7 +323,7 @@
 // whose format conforms to the [SPIFFE standard](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md):
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: httpbin
@@ -353,7 +353,7 @@
 // VMs and Kubernetes.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadEntry
 // metadata:
 //   name: details-vm-1
@@ -364,7 +364,7 @@
 //     app: details
 //     instance-id: vm1
 // ---
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadEntry
 // metadata:
 //   name: details-vm-2
@@ -382,7 +382,7 @@
 // Kubernetes:
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: details-svc

--- a/networking/v1alpha3/service_entry.pb.html
+++ b/networking/v1alpha3/service_entry.pb.html
@@ -26,7 +26,7 @@ services.</p>
 <p>The following example declares a few external APIs accessed by internal
 applications over HTTPS. The sidecar inspects the SNI value in the
 ClientHello message to route to the appropriate external service.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-svc-https
@@ -46,7 +46,7 @@ spec:
 unmanaged VMs to Istio&rsquo;s registry, so that these services can be treated
 as any other service in the mesh. The associated DestinationRule is used
 to initiate mTLS connections to the database instances.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-svc-mongocluster
@@ -66,7 +66,7 @@ spec:
   - address: 3.3.3.3
 </code></pre>
 <p>and the associated DestinationRule</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: mtls-mongocluster
@@ -82,7 +82,7 @@ spec:
 <p>The following example uses a combination of service entry and TLS
 routing in a virtual service to steer traffic based on the SNI value to
 an internal egress firewall.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-svc-redirect
@@ -98,7 +98,7 @@ spec:
   resolution: NONE
 </code></pre>
 <p>And the associated VirtualService to route based on the SNI value.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: tls-routing
@@ -125,7 +125,7 @@ declaration to other namespaces in the mesh. By default, a service is exported
 to all namespaces. The following example restricts the visibility to the
 current namespace, represented by &ldquo;.&rdquo;, so that it cannot be used by other
 namespaces.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-svc-httpbin
@@ -143,7 +143,7 @@ spec:
   resolution: DNS
 </code></pre>
 <p>Define a gateway to handle all egress traffic.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
  name: istio-egressgateway
@@ -165,7 +165,7 @@ well as route from the gateway to the external service. Note that the
 virtual service is exported to all namespaces enabling them to route traffic
 through the gateway to the external service. Forcing traffic to go through
 a managed middle proxy like this is a common practice.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: gateway-routing
@@ -198,7 +198,7 @@ spec:
 external services. If the connection has to be routed to the IP address
 requested by the application (i.e. application resolves DNS and attempts
 to connect to a specific IP), the resolution mode must be set to <code>NONE</code>.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-svc-wildcard-example
@@ -215,7 +215,7 @@ spec:
 <p>The following example demonstrates a service that is available via a
 Unix Domain Socket on the host of the client. The resolution must be
 set to STATIC to use Unix address endpoints.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: unix-domain-socket-example
@@ -238,7 +238,7 @@ reroute API calls for the <code>VirtualService</code> to a chosen backend. For
 example, the following configuration creates a non-existent external
 service called foo.bar.com backed by three domains: us.foo.bar.com:8080,
 uk.foo.bar.com:9080, and in.foo.bar.com:7080</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-svc-dns
@@ -269,7 +269,7 @@ be translated to <code>http://uk.foo.bar.com/baz</code>.</p>
 <p>The following example illustrates the usage of a <code>ServiceEntry</code>
 containing a subject alternate name
 whose format conforms to the <a href="https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md">SPIFFE standard</a>:</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: httpbin
@@ -296,7 +296,7 @@ VM-based instances with sidecars as well as a set of Kubernetes
 pods managed by a standard deployment object. Consumers of this
 service in the mesh will be automatically load balanced across the
 VMs and Kubernetes.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: details-vm-1
@@ -307,7 +307,7 @@ spec:
     app: details
     instance-id: vm1
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: details-vm-2
@@ -322,7 +322,7 @@ spec:
 <code>app: details</code> using the same service account <code>details</code>, the
 following service entry declares a service spanning both VMs and
 Kubernetes:</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: details-svc

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -45,7 +45,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // ClientHello message to route to the appropriate external service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-https
@@ -68,7 +68,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // to initiate mTLS connections to the database instances.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-mongocluster
@@ -91,7 +91,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // and the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: mtls-mongocluster
@@ -110,7 +110,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // an internal egress firewall.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-redirect
@@ -129,7 +129,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // And the associated VirtualService to route based on the SNI value.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: tls-routing
@@ -160,7 +160,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // namespaces.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-httpbin
@@ -181,7 +181,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // Define a gateway to handle all egress traffic.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //  name: istio-egressgateway
@@ -206,7 +206,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // a managed middle proxy like this is a common practice.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: gateway-routing
@@ -242,7 +242,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // to connect to a specific IP), the resolution mode must be set to `NONE`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-wildcard-example
@@ -262,7 +262,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // set to STATIC to use Unix address endpoints.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: unix-domain-socket-example
@@ -288,7 +288,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // uk.foo.bar.com:9080, and in.foo.bar.com:7080
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-dns
@@ -323,7 +323,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // whose format conforms to the [SPIFFE standard](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md):
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: httpbin
@@ -353,7 +353,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // VMs and Kubernetes.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadEntry
 // metadata:
 //   name: details-vm-1
@@ -364,7 +364,7 @@ import "networking/v1alpha3/workload_entry.proto";
 //     app: details
 //     instance-id: vm1
 // ---
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadEntry
 // metadata:
 //   name: details-vm-2
@@ -382,7 +382,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // Kubernetes:
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: details-svc

--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -69,7 +69,7 @@
 // `istio-system` namespace.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: default
@@ -88,7 +88,7 @@
 // `istio-system` namespaces.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: default
@@ -111,7 +111,7 @@
 // 9080 for services in the `prod-us1` namespace.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: ratings
@@ -153,7 +153,7 @@
 // MySQL service at `mysql.foo.com:3306`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: no-ip-tables
@@ -183,7 +183,7 @@
 // And the associated service entry for routing to `mysql.foo.com:3306`
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-mysql
@@ -213,7 +213,7 @@
 // implying that IP tables based traffic capture is active.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: partial-ip-tables
@@ -254,7 +254,7 @@
 // This feature is currently experimental.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: ratings
@@ -289,7 +289,7 @@
 //   selector:
 //     app: ratings
 // ---
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //   name: ratings-peer-auth
@@ -314,7 +314,7 @@
 // from the settings pushed to all clients.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: connection-pool-settings

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -46,7 +46,7 @@ in the root namespace called <code>istio-config</code>, that configures
 sidecars in all namespaces to allow egress traffic only to other
 workloads in the same namespace as well as to services in the
 <code>istio-system</code> namespace.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: default
@@ -62,7 +62,7 @@ spec:
 above, and configures the sidecars in the namespace to allow egress
 traffic to public services in the <code>prod-us1</code>, <code>prod-apis</code>, and the
 <code>istio-system</code> namespaces.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: default
@@ -82,7 +82,7 @@ the attached workload instance listening on a Unix domain
 socket. In the egress direction, in addition to the <code>istio-system</code>
 namespace, the sidecar proxies only HTTP traffic bound for port
 9080 for services in the <code>prod-us1</code> namespace.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: ratings
@@ -121,7 +121,7 @@ it to the application listening on <code>127.0.0.1:8080</code>. It also allows
 the application to communicate with a backing MySQL database on
 <code>127.0.0.1:3306</code>, that then gets proxied to the externally hosted
 MySQL service at <code>mysql.foo.com:3306</code>.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: no-ip-tables
@@ -148,7 +148,7 @@ spec:
     - &quot;*/mysql.foo.com&quot;
 </code></pre>
 <p>And the associated service entry for routing to <code>mysql.foo.com:3306</code></p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-svc-mysql
@@ -174,7 +174,7 @@ listener on <code>172.16.1.32:80</code> (the VM&rsquo;s IP) for traffic arriving
 <p><strong>NOTE</strong>: The <code>ISTIO_META_INTERCEPTION_MODE</code> metadata on the
 proxy in the VM should contain <code>REDIRECT</code> or <code>TPROXY</code> as its value,
 implying that IP tables based traffic capture is active.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: partial-ip-tables
@@ -212,7 +212,7 @@ in order to set mTLS mode to &ldquo;DISABLE&rdquo; on specific
 ports.
 In this example, the mTLS mode is disabled on PORT 80.
 This feature is currently experimental.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: ratings
@@ -247,7 +247,7 @@ spec:
   selector:
     app: ratings
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: ratings-peer-auth
@@ -269,7 +269,7 @@ connections to the service) as well as servers (for inbound connections to a ser
 instance). Using the <code>InboundConnectionPool</code> and per-port <code>ConnectionPool</code> settings
 in a <code>Sidecar</code> allow you to control those connection pools for the server separately
 from the settings pushed to all clients.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: connection-pool-settings

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -70,7 +70,7 @@ import "networking/v1alpha3/virtual_service.proto";
 // `istio-system` namespace.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: default
@@ -89,7 +89,7 @@ import "networking/v1alpha3/virtual_service.proto";
 // `istio-system` namespaces.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: default
@@ -112,7 +112,7 @@ import "networking/v1alpha3/virtual_service.proto";
 // 9080 for services in the `prod-us1` namespace.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: ratings
@@ -154,7 +154,7 @@ import "networking/v1alpha3/virtual_service.proto";
 // MySQL service at `mysql.foo.com:3306`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: no-ip-tables
@@ -184,7 +184,7 @@ import "networking/v1alpha3/virtual_service.proto";
 // And the associated service entry for routing to `mysql.foo.com:3306`
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-mysql
@@ -214,7 +214,7 @@ import "networking/v1alpha3/virtual_service.proto";
 // implying that IP tables based traffic capture is active.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: partial-ip-tables
@@ -255,7 +255,7 @@ import "networking/v1alpha3/virtual_service.proto";
 // This feature is currently experimental.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: ratings
@@ -290,7 +290,7 @@ import "networking/v1alpha3/virtual_service.proto";
 //   selector:
 //     app: ratings
 // ---
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //   name: ratings-peer-auth
@@ -315,7 +315,7 @@ import "networking/v1alpha3/virtual_service.proto";
 // from the settings pushed to all clients.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Sidecar
 // metadata:
 //   name: connection-pool-settings

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -68,7 +68,7 @@
 //
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route
@@ -100,7 +100,7 @@
 // `DestinationRule`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: reviews-destination
@@ -390,7 +390,7 @@ func (x *VirtualService) GetExportTo() []string {
 // some to subset v2, in a Kubernetes environment.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -423,7 +423,7 @@ func (x *VirtualService) GetExportTo() []string {
 // # And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -454,7 +454,7 @@ func (x *VirtualService) GetExportTo() []string {
 // not have an impact in resolving the name of the productpage service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -480,7 +480,7 @@ func (x *VirtualService) GetExportTo() []string {
 // Service for wikipedia.org and set a timeout of 5s for HTTP requests.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //
@@ -498,7 +498,7 @@ func (x *VirtualService) GetExportTo() []string {
 //	resolution: DNS
 //
 // ---
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -839,7 +839,7 @@ func (x *HTTPRoute) GetHeaders() *Headers {
 // forward the traffic to `/reviews` by a delegate VirtualService named `reviews`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -868,7 +868,7 @@ func (x *HTTPRoute) GetHeaders() *Headers {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -891,7 +891,7 @@ func (x *HTTPRoute) GetHeaders() *Headers {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -973,7 +973,7 @@ func (x *Delegate) GetNamespace() string {
 // coming from the `v1` subset (version) of the `reviews` service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1068,7 +1068,7 @@ func (x *Headers) GetResponse() *Headers_HeaderOperations {
 // services in the mesh based on the SNI value.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1162,7 +1162,7 @@ func (x *TLSRoute) GetRoute() []*RouteDestination {
 // mongo.prod.svc.cluster.local to another Mongo server on port 5555.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1249,7 +1249,7 @@ func (x *TCPRoute) GetRoute() []*RouteDestination {
 // with value `jason`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1536,7 +1536,7 @@ func (x *HTTPMatchRequest) GetStatPrefix() string {
 // "v1".
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1562,7 +1562,7 @@ func (x *HTTPMatchRequest) GetStatPrefix() string {
 // # And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1586,7 +1586,7 @@ func (x *HTTPMatchRequest) GetStatPrefix() string {
 // traffic to reviews.com to dev.reviews.com
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1958,7 +1958,7 @@ func (x *TLSMatchAttributes) GetSourceNamespace() string {
 // /v1/bookRatings provided by the bookratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2111,7 +2111,7 @@ func (*HTTPRedirect_DerivePort) isHTTPRedirect_RedirectPort() {}
 // to requests for /v1/getProductRatings API.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2137,7 +2137,7 @@ func (*HTTPRedirect_DerivePort) isHTTPRedirect_RedirectPort() {}
 // This is mostly useful for non text-based protocols such as gRPC.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2164,7 +2164,7 @@ func (*HTTPRedirect_DerivePort) isHTTPRedirect_RedirectPort() {}
 // the returned Content-Type.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2337,7 +2337,7 @@ func (*HTTPBody_Bytes) isHTTPBody_Specifier() {}
 // ratings service before making the actual API call.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2601,7 +2601,7 @@ func (*StringMatch_Regex) isStringMatch_MatchType() {}
 // or when the upstream server responds with Service Unavailable(503).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2719,7 +2719,7 @@ func (x *HTTPRetry) GetRetryRemoteLocalities() *wrappers.BoolValue {
 // exposes `X-Foo-bar` header and sets an expiry period of 1 day.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -3166,7 +3166,7 @@ func (x *Headers_HeaderOperations) GetRemove() []string {
 // service from all pods with label env: prod
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -3308,7 +3308,7 @@ func (*HTTPFaultInjection_Delay_ExponentialDelay) isHTTPFaultInjection_Delay_Htt
 // error code for 1 out of every 1000 requests to the "ratings" service "v1".
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -41,7 +41,7 @@ to be customized for specific client contexts.</p>
 pods of the reviews service with label &ldquo;version: v1&rdquo;. In addition,
 HTTP requests with path starting with /wpcatalog/ or /consumercatalog/ will
 be rewritten to /newcatalog and sent to pods with label &ldquo;version: v2&rdquo;.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews-route
@@ -70,7 +70,7 @@ spec:
 <p>A subset/version of a route destination is identified with a reference
 to a named service subset which must be declared in a corresponding
 <code>DestinationRule</code>.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: reviews-destination
@@ -247,7 +247,7 @@ domain names over short names.</em></p>
 <p>The following Kubernetes example routes all traffic by default to pods
 of the reviews service with label &ldquo;version: v1&rdquo; (i.e., subset v1), and
 some to subset v2, in a Kubernetes environment.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews-route
@@ -273,7 +273,7 @@ spec:
         subset: v1
 </code></pre>
 <p>And the associated DestinationRule</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: reviews-destination
@@ -297,7 +297,7 @@ that this rule is set in the istio-system namespace but uses the fully
 qualified domain name of the productpage service,
 productpage.prod.svc.cluster.local. Therefore the rule&rsquo;s namespace does
 not have an impact in resolving the name of the productpage service.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: my-productpage-rule
@@ -316,7 +316,7 @@ services must first be added to Istio&rsquo;s internal service registry using th
 ServiceEntry resource. VirtualServices can then be defined to control traffic
 bound to these external services. For example, the following rules define a
 Service for wikipedia.org and set a timeout of 5s for HTTP requests.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-svc-wikipedia
@@ -330,7 +330,7 @@ spec:
     protocol: HTTP
   resolution: DNS
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: my-wiki-rule
@@ -636,7 +636,7 @@ No
 <p>Describes the delegate VirtualService.
 The following routing rules forward the traffic to <code>/productpage</code> by a delegate VirtualService named <code>productpage</code>,
 forward the traffic to <code>/reviews</code> by a delegate VirtualService named <code>reviews</code>.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: bookinfo
@@ -659,7 +659,7 @@ spec:
         name: reviews
         namespace: nsB
 </code></pre>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: productpage
@@ -676,7 +676,7 @@ spec:
     - destination:
         host: productpage.nsA.svc.cluster.local
 </code></pre>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews
@@ -733,7 +733,7 @@ The following VirtualService adds a <code>test</code> header with the value <cod
 to requests that are routed to any <code>reviews</code> service destination.
 It also removes the <code>foo</code> response header, but only from responses
 coming from the <code>v1</code> subset (version) of the <code>reviews</code> service.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews-route
@@ -803,7 +803,7 @@ No
 traffic (TLS/HTTPS) The following routing rule forwards unterminated TLS
 traffic arriving at port 443 of gateway called &ldquo;mygateway&rdquo; to internal
 services in the mesh based on the SNI value.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: bookinfo-sni
@@ -872,7 +872,7 @@ No
 <p>Describes match conditions and actions for routing TCP traffic. The
 following routing rule forwards traffic arriving at port 27017 for
 mongo.prod.svc.cluster.local to another Mongo server on port 5555.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: bookinfo-mongo
@@ -934,7 +934,7 @@ rule to be applied to the HTTP request. For example, the following
 restricts the rule to match only requests where the URL path
 starts with /ratings/v2/ and the request contains a custom <code>end-user</code> header
 with value <code>jason</code>.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings-route
@@ -1244,7 +1244,7 @@ determine the proportion of traffic it receives. For example, the
 following rule will route 25% of traffic for the &ldquo;reviews&rdquo; service to
 instances with the &ldquo;v2&rdquo; tag and the remaining traffic (i.e., 75%) to
 &ldquo;v1&rdquo;.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews-route
@@ -1263,7 +1263,7 @@ spec:
       weight: 75
 </code></pre>
 <p>And the associated DestinationRule</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: reviews-destination
@@ -1280,7 +1280,7 @@ spec:
 <p>Traffic can also be split across two entirely different services without
 having to define new subsets. For example, the following rule forwards 25% of
 traffic to reviews.com to dev.reviews.com</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews-route-two-domains
@@ -1575,7 +1575,7 @@ where the Authority/Host and the URI in the response can be swapped with
 the specified values. For example, the following rule redirects
 requests for /v1/getProductRatings API on the ratings service to
 /v1/bookRatings provided by the bookratings service.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings-route
@@ -1687,7 +1687,7 @@ No
 <p>HTTPDirectResponse can be used to send a fixed response to clients.
 For example, the following rule returns a fixed 503 status with a body
 to requests for /v1/getProductRatings API.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings-route
@@ -1706,7 +1706,7 @@ spec:
 </code></pre>
 <p>It is also possible to specify a binary response body.
 This is mostly useful for non text-based protocols such as gRPC.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings-route
@@ -1726,7 +1726,7 @@ spec:
 <p>It is good practice to add headers in the HTTPRoute
 as well as the direct_response, for example to specify
 the returned Content-Type.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings-route
@@ -1828,7 +1828,7 @@ before forwarding the request to the destination. Rewrite primitive can
 be used only with HTTPRouteDestination. The following example
 demonstrates how to rewrite the URL prefix for api call (/ratings) to
 ratings service before making the actual API call.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings-route
@@ -1998,7 +1998,7 @@ example, the following rule sets the maximum number of retries to 3 when
 calling ratings:v1 service, with a 2s timeout per retry attempt.
 A retry will be attempted if there is a connect-failure, refused_stream
 or when the upstream server responds with Service Unavailable(503).</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings-route
@@ -2095,7 +2095,7 @@ the following rule restricts cross origin requests to those originating
 from example.com domain using HTTP POST/GET, and sets the
 <code>Access-Control-Allow-Credentials</code> header to false. In addition, it only
 exposes <code>X-Foo-bar</code> header and sets an expiry period of 1 day.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings-route
@@ -2411,7 +2411,7 @@ No
 forwarding path. The following example will introduce a 5 second delay
 in 1 out of every 1000 requests to the &ldquo;v1&rdquo; version of the &ldquo;reviews&rdquo;
 service from all pods with label env: prod</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews-route
@@ -2491,7 +2491,7 @@ No
 <p>Abort specification is used to prematurely abort a request with a
 pre-specified error code. The following example will return an HTTP 400
 error code for 1 out of every 1000 requests to the &ldquo;ratings&rdquo; service &ldquo;v1&rdquo;.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings-route

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -68,7 +68,7 @@ import "google/protobuf/wrappers.proto";
 //
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route
@@ -100,7 +100,7 @@ import "google/protobuf/wrappers.proto";
 // `DestinationRule`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: reviews-destination
@@ -255,7 +255,7 @@ message VirtualService {
 // some to subset v2, in a Kubernetes environment.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route
@@ -284,7 +284,7 @@ message VirtualService {
 // And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: reviews-destination
@@ -311,7 +311,7 @@ message VirtualService {
 // not have an impact in resolving the name of the productpage service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: my-productpage-rule
@@ -333,7 +333,7 @@ message VirtualService {
 // Service for wikipedia.org and set a timeout of 5s for HTTP requests.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-wikipedia
@@ -347,7 +347,7 @@ message VirtualService {
 //     protocol: HTTP
 //   resolution: DNS
 // ---
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: my-wiki-rule
@@ -504,7 +504,7 @@ message HTTPRoute {
 // forward the traffic to `/reviews` by a delegate VirtualService named `reviews`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo
@@ -529,7 +529,7 @@ message HTTPRoute {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: productpage
@@ -548,7 +548,7 @@ message HTTPRoute {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews
@@ -577,7 +577,7 @@ message Delegate {
 // coming from the `v1` subset (version) of the `reviews` service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route
@@ -629,7 +629,7 @@ message Headers {
 // services in the mesh based on the SNI value.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo-sni
@@ -670,7 +670,7 @@ message TLSRoute {
 // mongo.prod.svc.cluster.local to another Mongo server on port 5555.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo-mongo
@@ -704,7 +704,7 @@ message TCPRoute {
 // with value `jason`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -868,7 +868,7 @@ message HTTPMatchRequest {
 // "v1".
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route
@@ -890,7 +890,7 @@ message HTTPMatchRequest {
 // And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: reviews-destination
@@ -910,7 +910,7 @@ message HTTPMatchRequest {
 // traffic to reviews.com to dev.reviews.com
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route-two-domains
@@ -1035,7 +1035,7 @@ message TLSMatchAttributes {
 // /v1/bookRatings provided by the bookratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1091,7 +1091,7 @@ message HTTPRedirect {
 // to requests for /v1/getProductRatings API.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1113,7 +1113,7 @@ message HTTPRedirect {
 // This is mostly useful for non text-based protocols such as gRPC.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1136,7 +1136,7 @@ message HTTPRedirect {
 // the returned Content-Type.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1184,7 +1184,7 @@ message HTTPBody {
 // ratings service before making the actual API call.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1257,7 +1257,7 @@ message StringMatch {
 // or when the upstream server responds with Service Unavailable(503).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1311,7 +1311,7 @@ message HTTPRetry {
 // exposes `X-Foo-bar` header and sets an expiry period of 1 day.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1392,7 +1392,7 @@ message HTTPFaultInjection {
   // service from all pods with label env: prod
   //
   // ```yaml
-  // apiVersion: networking.istio.io/v1beta1
+  // apiVersion: networking.istio.io/v1
   // kind: VirtualService
   // metadata:
   //   name: reviews-route
@@ -1442,7 +1442,7 @@ message HTTPFaultInjection {
   // error code for 1 out of every 1000 requests to the "ratings" service "v1".
   //
   // ```yaml
-  // apiVersion: networking.istio.io/v1beta1
+  // apiVersion: networking.istio.io/v1
   // kind: VirtualService
   // metadata:
   //   name: ratings-route

--- a/networking/v1alpha3/workload_entry.pb.go
+++ b/networking/v1alpha3/workload_entry.pb.go
@@ -48,7 +48,7 @@
 // forward it to the application on localhost on the same port.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadEntry
 // metadata:
 //   name: details-svc
@@ -67,7 +67,7 @@
 // and the associated service entry
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: details-svc
@@ -94,7 +94,7 @@
 // forwarding the request.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadEntry
 // metadata:
 //   name: details-svc
@@ -113,7 +113,7 @@
 // and the associated service entry
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: details-svc
@@ -140,7 +140,7 @@
 // the actual workloads in a given remote network.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadEntry
 // metadata:
 //   name: foo-workloads-cluster-2

--- a/networking/v1alpha3/workload_entry.pb.html
+++ b/networking/v1alpha3/workload_entry.pb.html
@@ -28,7 +28,7 @@ account. The service is exposed on port 80 to applications in the
 mesh. The HTTP traffic to this service is wrapped in Istio mutual
 TLS and sent to sidecars on VMs on target port 8080, that in turn
 forward it to the application on localhost on the same port.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: details-svc
@@ -44,7 +44,7 @@ spec:
     instance-id: vm1
 </code></pre>
 <p>and the associated service entry</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: details-svc
@@ -67,7 +67,7 @@ its fully qualified DNS name. The service entry&rsquo;s resolution
 mode should be changed to DNS to indicate that the client-side
 sidecars should dynamically resolve the DNS name at runtime before
 forwarding the request.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: details-svc
@@ -83,7 +83,7 @@ spec:
     instance-id: vm1
 </code></pre>
 <p>and the associated service entry</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: details-svc
@@ -107,7 +107,7 @@ to write a <code>WorkloadEntry</code> in the local cluster that represents
 the Workload(s) in the remote network with the given labels. A
 single <code>WorkloadEntry</code> with weights represent the aggregate of all
 the actual workloads in a given remote network.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: foo-workloads-cluster-2

--- a/networking/v1alpha3/workload_entry.proto
+++ b/networking/v1alpha3/workload_entry.proto
@@ -44,7 +44,7 @@ syntax = "proto3";
 // forward it to the application on localhost on the same port.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadEntry
 // metadata:
 //   name: details-svc
@@ -63,7 +63,7 @@ syntax = "proto3";
 // and the associated service entry
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: details-svc
@@ -90,7 +90,7 @@ syntax = "proto3";
 // forwarding the request.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadEntry
 // metadata:
 //   name: details-svc
@@ -109,7 +109,7 @@ syntax = "proto3";
 // and the associated service entry
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: details-svc
@@ -136,7 +136,7 @@ syntax = "proto3";
 // the actual workloads in a given remote network.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadEntry
 // metadata:
 //   name: foo-workloads-cluster-2

--- a/networking/v1alpha3/workload_group.pb.go
+++ b/networking/v1alpha3/workload_group.pb.go
@@ -39,7 +39,7 @@
 // `app.kubernetes.io/version` is just an arbitrary example of a label.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadGroup
 // metadata:
 //   name: reviews

--- a/networking/v1alpha3/workload_group.pb.html
+++ b/networking/v1alpha3/workload_group.pb.html
@@ -20,7 +20,7 @@ of workloads that will be registered under <code>reviews</code> in namespace
 instance during the bootstrap process, and the ports 3550 and 8080
 will be associated with the workload group and use service account <code>default</code>.
 <code>app.kubernetes.io/version</code> is just an arbitrary example of a label.</p>
-<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: reviews

--- a/networking/v1alpha3/workload_group.proto
+++ b/networking/v1alpha3/workload_group.proto
@@ -38,7 +38,7 @@ import "networking/v1alpha3/workload_entry.proto";
 // `app.kubernetes.io/version` is just an arbitrary example of a label.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: WorkloadGroup
 // metadata:
 //   name: reviews

--- a/networking/v1beta1/destination_rule.pb.go
+++ b/networking/v1beta1/destination_rule.pb.go
@@ -631,7 +631,7 @@ func (x *TrafficPolicy) GetProxyProtocol() *TrafficPolicy_ProxyProtocol {
 // labels (version:v3).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -741,7 +741,7 @@ func (x *Subset) GetTrafficPolicy() *TrafficPolicy {
 // for all traffic going to the ratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -761,7 +761,7 @@ func (x *Subset) GetTrafficPolicy() *TrafficPolicy {
 // the User cookie as the hash key.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -897,7 +897,7 @@ func (*LoadBalancerSettings_ConsistentHash) isLoadBalancerSettings_LbPolicy() {}
 // service called myredissrv with a connect timeout of 30ms
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -990,7 +990,7 @@ func (x *ConnectionPoolSettings) GetHttp() *ConnectionPoolSettings_HTTPSettings 
 // times with a 502, 503, or 504 error code will be ejected for 15 minutes.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1192,7 +1192,7 @@ func (x *OutlierDetection) GetMinHealthPercent() int32 {
 // for connections to upstream database cluster.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1214,7 +1214,7 @@ func (x *OutlierDetection) GetMinHealthPercent() int32 {
 // foreign service whose domain matches *.foo.com.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1233,7 +1233,7 @@ func (x *OutlierDetection) GetMinHealthPercent() int32 {
 // to rating services.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //

--- a/networking/v1beta1/destination_rule.proto
+++ b/networking/v1beta1/destination_rule.proto
@@ -274,7 +274,7 @@ message TrafficPolicy {
 // labels (version:v3).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -325,7 +325,7 @@ message Subset {
 // for all traffic going to the ratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -341,7 +341,7 @@ message Subset {
 // the User cookie as the hash key.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-ratings
@@ -503,7 +503,7 @@ message LoadBalancerSettings {
 // service called myredissrv with a connect timeout of 30ms
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: bookinfo-redis
@@ -644,7 +644,7 @@ message ConnectionPoolSettings {
 // times with a 502, 503, or 504 error code will be ejected for 15 minutes.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: reviews-cb-policy
@@ -749,7 +749,7 @@ message OutlierDetection {
 // for connections to upstream database cluster.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: db-mtls
@@ -767,7 +767,7 @@ message OutlierDetection {
 // foreign service whose domain matches *.foo.com.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: tls-foo
@@ -782,7 +782,7 @@ message OutlierDetection {
 // to rating services.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: ratings-istio-mtls

--- a/networking/v1beta1/gateway.pb.go
+++ b/networking/v1beta1/gateway.pb.go
@@ -460,7 +460,7 @@ func (x *Gateway) GetSelector() map[string]string {
 // port. For example,
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //
@@ -483,7 +483,7 @@ func (x *Gateway) GetSelector() map[string]string {
 // # Another example
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //
@@ -506,7 +506,7 @@ func (x *Gateway) GetSelector() map[string]string {
 // # The following is an example of TLS configuration for port 443
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //

--- a/networking/v1beta1/gateway.proto
+++ b/networking/v1beta1/gateway.proto
@@ -243,7 +243,7 @@ message Gateway {
 // port. For example,
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-ingress
@@ -262,7 +262,7 @@ message Gateway {
 // Another example
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-tcp-ingress
@@ -281,7 +281,7 @@ message Gateway {
 // The following is an example of TLS configuration for port 443
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: Gateway
 // metadata:
 //   name: my-tls-ingress

--- a/networking/v1beta1/virtual_service.pb.go
+++ b/networking/v1beta1/virtual_service.pb.go
@@ -390,7 +390,7 @@ func (x *VirtualService) GetExportTo() []string {
 // some to subset v2, in a Kubernetes environment.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -423,7 +423,7 @@ func (x *VirtualService) GetExportTo() []string {
 // # And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -454,7 +454,7 @@ func (x *VirtualService) GetExportTo() []string {
 // not have an impact in resolving the name of the productpage service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -480,7 +480,7 @@ func (x *VirtualService) GetExportTo() []string {
 // Service for wikipedia.org and set a timeout of 5s for HTTP requests.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //
@@ -498,7 +498,7 @@ func (x *VirtualService) GetExportTo() []string {
 //	resolution: DNS
 //
 // ---
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -839,7 +839,7 @@ func (x *HTTPRoute) GetHeaders() *Headers {
 // forward the traffic to `/reviews` by a delegate VirtualService named `reviews`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -868,7 +868,7 @@ func (x *HTTPRoute) GetHeaders() *Headers {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -891,7 +891,7 @@ func (x *HTTPRoute) GetHeaders() *Headers {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -973,7 +973,7 @@ func (x *Delegate) GetNamespace() string {
 // coming from the `v1` subset (version) of the `reviews` service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1068,7 +1068,7 @@ func (x *Headers) GetResponse() *Headers_HeaderOperations {
 // services in the mesh based on the SNI value.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1162,7 +1162,7 @@ func (x *TLSRoute) GetRoute() []*RouteDestination {
 // mongo.prod.svc.cluster.local to another Mongo server on port 5555.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1249,7 +1249,7 @@ func (x *TCPRoute) GetRoute() []*RouteDestination {
 // with value `jason`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1536,7 +1536,7 @@ func (x *HTTPMatchRequest) GetStatPrefix() string {
 // "v1".
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1562,7 +1562,7 @@ func (x *HTTPMatchRequest) GetStatPrefix() string {
 // # And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //
@@ -1586,7 +1586,7 @@ func (x *HTTPMatchRequest) GetStatPrefix() string {
 // traffic to reviews.com to dev.reviews.com
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -1958,7 +1958,7 @@ func (x *TLSMatchAttributes) GetSourceNamespace() string {
 // /v1/bookRatings provided by the bookratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2111,7 +2111,7 @@ func (*HTTPRedirect_DerivePort) isHTTPRedirect_RedirectPort() {}
 // to requests for /v1/getProductRatings API.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2137,7 +2137,7 @@ func (*HTTPRedirect_DerivePort) isHTTPRedirect_RedirectPort() {}
 // This is mostly useful for non text-based protocols such as gRPC.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2164,7 +2164,7 @@ func (*HTTPRedirect_DerivePort) isHTTPRedirect_RedirectPort() {}
 // the returned Content-Type.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2337,7 +2337,7 @@ func (*HTTPBody_Bytes) isHTTPBody_Specifier() {}
 // ratings service before making the actual API call.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2601,7 +2601,7 @@ func (*StringMatch_Regex) isStringMatch_MatchType() {}
 // or when the upstream server responds with Service Unavailable(503).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -2719,7 +2719,7 @@ func (x *HTTPRetry) GetRetryRemoteLocalities() *wrappers.BoolValue {
 // exposes `X-Foo-bar` header and sets an expiry period of 1 day.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -3166,7 +3166,7 @@ func (x *Headers_HeaderOperations) GetRemove() []string {
 // service from all pods with label env: prod
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //
@@ -3308,7 +3308,7 @@ func (*HTTPFaultInjection_Delay_ExponentialDelay) isHTTPFaultInjection_Delay_Htt
 // error code for 1 out of every 1000 requests to the "ratings" service "v1".
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //

--- a/networking/v1beta1/virtual_service.proto
+++ b/networking/v1beta1/virtual_service.proto
@@ -255,7 +255,7 @@ message VirtualService {
 // some to subset v2, in a Kubernetes environment.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route
@@ -284,7 +284,7 @@ message VirtualService {
 // And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: reviews-destination
@@ -311,7 +311,7 @@ message VirtualService {
 // not have an impact in resolving the name of the productpage service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: my-productpage-rule
@@ -333,7 +333,7 @@ message VirtualService {
 // Service for wikipedia.org and set a timeout of 5s for HTTP requests.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: ServiceEntry
 // metadata:
 //   name: external-svc-wikipedia
@@ -347,7 +347,7 @@ message VirtualService {
 //     protocol: HTTP
 //   resolution: DNS
 // ---
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: my-wiki-rule
@@ -504,7 +504,7 @@ message HTTPRoute {
 // forward the traffic to `/reviews` by a delegate VirtualService named `reviews`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo
@@ -529,7 +529,7 @@ message HTTPRoute {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: productpage
@@ -548,7 +548,7 @@ message HTTPRoute {
 // ```
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews
@@ -577,7 +577,7 @@ message Delegate {
 // coming from the `v1` subset (version) of the `reviews` service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route
@@ -629,7 +629,7 @@ message Headers {
 // services in the mesh based on the SNI value.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo-sni
@@ -670,7 +670,7 @@ message TLSRoute {
 // mongo.prod.svc.cluster.local to another Mongo server on port 5555.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: bookinfo-mongo
@@ -704,7 +704,7 @@ message TCPRoute {
 // with value `jason`.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -868,7 +868,7 @@ message HTTPMatchRequest {
 // "v1".
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route
@@ -890,7 +890,7 @@ message HTTPMatchRequest {
 // And the associated DestinationRule
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: DestinationRule
 // metadata:
 //   name: reviews-destination
@@ -910,7 +910,7 @@ message HTTPMatchRequest {
 // traffic to reviews.com to dev.reviews.com
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: reviews-route-two-domains
@@ -1035,7 +1035,7 @@ message TLSMatchAttributes {
 // /v1/bookRatings provided by the bookratings service.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1091,7 +1091,7 @@ message HTTPRedirect {
 // to requests for /v1/getProductRatings API.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1113,7 +1113,7 @@ message HTTPRedirect {
 // This is mostly useful for non text-based protocols such as gRPC.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1136,7 +1136,7 @@ message HTTPRedirect {
 // the returned Content-Type.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1184,7 +1184,7 @@ message HTTPBody {
 // ratings service before making the actual API call.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1257,7 +1257,7 @@ message StringMatch {
 // or when the upstream server responds with Service Unavailable(503).
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1311,7 +1311,7 @@ message HTTPRetry {
 // exposes `X-Foo-bar` header and sets an expiry period of 1 day.
 //
 // ```yaml
-// apiVersion: networking.istio.io/v1beta1
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: ratings-route
@@ -1392,7 +1392,7 @@ message HTTPFaultInjection {
   // service from all pods with label env: prod
   //
   // ```yaml
-  // apiVersion: networking.istio.io/v1beta1
+  // apiVersion: networking.istio.io/v1
   // kind: VirtualService
   // metadata:
   //   name: reviews-route
@@ -1442,7 +1442,7 @@ message HTTPFaultInjection {
   // error code for 1 out of every 1000 requests to the "ratings" service "v1".
   //
   // ```yaml
-  // apiVersion: networking.istio.io/v1beta1
+  // apiVersion: networking.istio.io/v1
   // kind: VirtualService
   // metadata:
   //   name: ratings-route

--- a/security/v1/authorization_policy.pb.go
+++ b/security/v1/authorization_policy.pb.go
@@ -288,7 +288,7 @@ const (
 	// `my-custom-authz` if the request path has prefix `/admin/`.
 	//
 	// ```yaml
-	// apiVersion: security.istio.io/v1beta1
+	// apiVersion: security.istio.io/v1
 	// kind: AuthorizationPolicy
 	// metadata:
 	//

--- a/security/v1/authorization_policy.proto
+++ b/security/v1/authorization_policy.proto
@@ -341,7 +341,7 @@ message AuthorizationPolicy {
     // `my-custom-authz` if the request path has prefix `/admin/`.
     //
     // ```yaml
-    // apiVersion: security.istio.io/v1beta1
+    // apiVersion: security.istio.io/v1
     // kind: AuthorizationPolicy
     // metadata:
     //   name: ext-authz

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -286,7 +286,7 @@ const (
 	// `my-custom-authz` if the request path has prefix `/admin/`.
 	//
 	// ```yaml
-	// apiVersion: security.istio.io/v1beta1
+	// apiVersion: security.istio.io/v1
 	// kind: AuthorizationPolicy
 	// metadata:
 	//

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -818,7 +818,7 @@ One example use case of the extension is to integrate with a custom external aut
 the authorization decision to it.</p>
 <p>The following authorization policy applies to an ingress gateway and delegates the authorization check to a named extension
 <code>my-custom-authz</code> if the request path has prefix <code>/admin/</code>.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: ext-authz

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -340,7 +340,7 @@ message AuthorizationPolicy {
     // `my-custom-authz` if the request path has prefix `/admin/`.
     //
     // ```yaml
-    // apiVersion: security.istio.io/v1beta1
+    // apiVersion: security.istio.io/v1
     // kind: AuthorizationPolicy
     // metadata:
     //   name: ext-authz

--- a/security/v1beta1/peer_authentication.pb.go
+++ b/security/v1beta1/peer_authentication.pb.go
@@ -106,7 +106,7 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 //
 // Policy to allow mTLS traffic for all workloads under namespace `foo`:
 // ```yaml
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //
@@ -124,7 +124,7 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 // Policies to allow both mTLS and plaintext traffic for all workloads under namespace `foo`, but
 // require mTLS for workload `finance`.
 // ```yaml
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //
@@ -137,7 +137,7 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 //	  mode: PERMISSIVE
 //
 // ---
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //
@@ -157,7 +157,7 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 // plaintext. Note the port value in the `portLevelMtls` field refers to the port
 // of the workload, not the port of the Kubernetes service.
 // ```yaml
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //
@@ -179,7 +179,7 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 // Policy that inherits mTLS mode from namespace (or mesh) settings, and disables
 // mTLS for workload port `8080`.
 // ```yaml
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //

--- a/security/v1beta1/peer_authentication.pb.html
+++ b/security/v1beta1/peer_authentication.pb.html
@@ -16,7 +16,7 @@ Development of PeerAuthentication is currently frozen and likely to be replaced 
 PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.</p>
 <p>Examples:</p>
 <p>Policy to allow mTLS traffic for all workloads under namespace <code>foo</code>:</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -28,7 +28,7 @@ spec:
 <p>For mesh level, put the policy in root-namespace according to your Istio installation.</p>
 <p>Policies to allow both mTLS and plaintext traffic for all workloads under namespace <code>foo</code>, but
 require mTLS for workload <code>finance</code>.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -37,7 +37,7 @@ spec:
   mtls:
     mode: PERMISSIVE
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: finance
@@ -52,7 +52,7 @@ spec:
 <p>Policy that enables strict mTLS for all <code>finance</code> workloads, but leaves the port <code>8080</code> to
 plaintext. Note the port value in the <code>portLevelMtls</code> field refers to the port
 of the workload, not the port of the Kubernetes service.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -69,7 +69,7 @@ spec:
 </code></pre>
 <p>Policy that inherits mTLS mode from namespace (or mesh) settings, and disables
 mTLS for workload port <code>8080</code>.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default

--- a/security/v1beta1/peer_authentication.proto
+++ b/security/v1beta1/peer_authentication.proto
@@ -34,7 +34,7 @@ option go_package="istio.io/api/security/v1beta1";
 //
 // Policy to allow mTLS traffic for all workloads under namespace `foo`:
 // ```yaml
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //   name: default
@@ -48,7 +48,7 @@ option go_package="istio.io/api/security/v1beta1";
 // Policies to allow both mTLS and plaintext traffic for all workloads under namespace `foo`, but
 // require mTLS for workload `finance`.
 // ```yaml
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //   name: default
@@ -57,7 +57,7 @@ option go_package="istio.io/api/security/v1beta1";
 //   mtls:
 //     mode: PERMISSIVE
 // ---
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //   name: finance
@@ -73,7 +73,7 @@ option go_package="istio.io/api/security/v1beta1";
 // plaintext. Note the port value in the `portLevelMtls` field refers to the port
 // of the workload, not the port of the Kubernetes service.
 // ```yaml
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //   name: default
@@ -91,7 +91,7 @@ option go_package="istio.io/api/security/v1beta1";
 // Policy that inherits mTLS mode from namespace (or mesh) settings, and disables
 // mTLS for workload port `8080`.
 // ```yaml
-// apiVersion: security.istio.io/v1beta1
+// apiVersion: security.istio.io/v1
 // kind: PeerAuthentication
 // metadata:
 //   name: default

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -250,7 +250,7 @@ const (
 //	      requestPrincipals: ["*"]
 //
 // ---
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -177,7 +177,7 @@ spec:
     - source:
         requestPrincipals: [&quot;*&quot;]
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: route-jwt

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -199,7 +199,7 @@ option go_package="istio.io/api/security/v1beta1";
 //     - source:
 //         requestPrincipals: ["*"]
 // ---
-// apiVersion: networking.istio.io/v1alpha3
+// apiVersion: networking.istio.io/v1
 // kind: VirtualService
 // metadata:
 //   name: route-jwt

--- a/telemetry/v1alpha1/telemetry.pb.go
+++ b/telemetry/v1alpha1/telemetry.pb.go
@@ -44,7 +44,7 @@
 // ## Examples
 // Policy to enable random sampling for 10% of traffic:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: mesh-default
@@ -58,7 +58,7 @@
 // Policy to disable trace reporting for the `foo` workload (note: tracing
 // context will still be propagated):
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: foo-tracing
@@ -73,7 +73,7 @@
 //
 // Policy to select the alternate zipkin provider for trace reporting:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: foo-tracing-alternate
@@ -90,7 +90,7 @@
 //
 // Policy to tailor the zipkin provider to sample traces from Client workloads only:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: mesh-default
@@ -105,7 +105,7 @@
 //
 // Policy to add a custom tag from a literal value:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: mesh-default
@@ -122,7 +122,7 @@
 //
 // Policy to disable server-side metrics for Prometheus for an entire mesh:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: mesh-default
@@ -141,7 +141,7 @@
 //
 // Policy to add dimensions to all Prometheus metrics for the `foo` namespace:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: namespace-metrics
@@ -163,7 +163,7 @@
 // Policy to remove the `response_code` dimension on some Prometheus metrics for
 // the `bar.foo` workload:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: remove-response-code
@@ -200,7 +200,7 @@
 //
 // Policy to enable access logging for the entire mesh:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: mesh-default
@@ -218,7 +218,7 @@
 //
 // Policy to disable access logging for the `foo` namespace:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: namespace-no-log

--- a/telemetry/v1alpha1/telemetry.pb.html
+++ b/telemetry/v1alpha1/telemetry.pb.html
@@ -23,7 +23,7 @@ selecting any given workload.</p>
 </ol>
 <h4 id="examples">Examples</h4>
 <p>Policy to enable random sampling for 10% of traffic:</p>
-<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
+<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -35,7 +35,7 @@ spec:
 </code></pre>
 <p>Policy to disable trace reporting for the <code>foo</code> workload (note: tracing
 context will still be propagated):</p>
-<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
+<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: foo-tracing
@@ -48,7 +48,7 @@ spec:
   - disableSpanReporting: true
 </code></pre>
 <p>Policy to select the alternate zipkin provider for trace reporting:</p>
-<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
+<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: foo-tracing-alternate
@@ -63,7 +63,7 @@ spec:
     randomSamplingPercentage: 10.00
 </code></pre>
 <p>Policy to tailor the zipkin provider to sample traces from Client workloads only:</p>
-<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
+<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -76,7 +76,7 @@ spec:
     - name: &quot;zipkin&quot;
 </code></pre>
 <p>Policy to add a custom tag from a literal value:</p>
-<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
+<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -91,7 +91,7 @@ spec:
           value: &quot;foo&quot;
 </code></pre>
 <p>Policy to disable server-side metrics for Prometheus for an entire mesh:</p>
-<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
+<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -108,7 +108,7 @@ spec:
       disabled: true
 </code></pre>
 <p>Policy to add dimensions to all Prometheus metrics for the <code>foo</code> namespace:</p>
-<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
+<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: namespace-metrics
@@ -128,7 +128,7 @@ spec:
 </code></pre>
 <p>Policy to remove the <code>response_code</code> dimension on some Prometheus metrics for
 the <code>bar.foo</code> workload:</p>
-<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
+<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: remove-response-code
@@ -163,7 +163,7 @@ spec:
           operation: REMOVE
 </code></pre>
 <p>Policy to enable access logging for the entire mesh:</p>
-<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
+<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -179,7 +179,7 @@ spec:
     # those cases, `disabled: false` must be set explicitly to override.
 </code></pre>
 <p>Policy to disable access logging for the <code>foo</code> namespace:</p>
-<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1alpha1
+<pre><code class="language-yaml">apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: namespace-no-log

--- a/telemetry/v1alpha1/telemetry.proto
+++ b/telemetry/v1alpha1/telemetry.proto
@@ -45,7 +45,7 @@ import "google/protobuf/wrappers.proto";
 // ## Examples
 // Policy to enable random sampling for 10% of traffic:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: mesh-default
@@ -59,7 +59,7 @@ import "google/protobuf/wrappers.proto";
 // Policy to disable trace reporting for the `foo` workload (note: tracing
 // context will still be propagated):
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: foo-tracing
@@ -74,7 +74,7 @@ import "google/protobuf/wrappers.proto";
 //
 // Policy to select the alternate zipkin provider for trace reporting:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: foo-tracing-alternate
@@ -91,7 +91,7 @@ import "google/protobuf/wrappers.proto";
 //
 // Policy to tailor the zipkin provider to sample traces from Client workloads only:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: mesh-default
@@ -106,7 +106,7 @@ import "google/protobuf/wrappers.proto";
 //
 // Policy to add a custom tag from a literal value:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: mesh-default
@@ -123,7 +123,7 @@ import "google/protobuf/wrappers.proto";
 //
 // Policy to disable server-side metrics for Prometheus for an entire mesh:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: mesh-default
@@ -142,7 +142,7 @@ import "google/protobuf/wrappers.proto";
 //
 // Policy to add dimensions to all Prometheus metrics for the `foo` namespace:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: namespace-metrics
@@ -164,7 +164,7 @@ import "google/protobuf/wrappers.proto";
 // Policy to remove the `response_code` dimension on some Prometheus metrics for
 // the `bar.foo` workload:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: remove-response-code
@@ -201,7 +201,7 @@ import "google/protobuf/wrappers.proto";
 //
 // Policy to enable access logging for the entire mesh:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: mesh-default
@@ -219,7 +219,7 @@ import "google/protobuf/wrappers.proto";
 //
 // Policy to disable access logging for the `foo` namespace:
 // ```yaml
-// apiVersion: telemetry.istio.io/v1alpha1
+// apiVersion: telemetry.istio.io/v1
 // kind: Telemetry
 // metadata:
 //   name: namespace-no-log


### PR DESCRIPTION
This is an manual cherry-pick of #3192 since the automated one #3207 requires `make gen` to be run