### PR TITLE
 [release-1.22] Fix typo in closing tag for some code blocks

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -3955,7 +3955,7 @@ No
 <td><code>envoyDebugHeaders</code></td>
 <td><code><a href="#ProxyConfig-ProxyHeaders-EnvoyDebugHeaders">EnvoyDebugHeaders</a></code></td>
 <td>
-<p>Controls various <code>X-Envoy-*</code> headers, such as <code>X-Envoy-Overloaded</code> and `X-Envoy-Upstream-Service-Time. If enabled,
+<p>Controls various <code>X-Envoy-*</code> headers, such as <code>X-Envoy-Overloaded</code> and <code>X-Envoy-Upstream-Service-Time</code>. If enabled,
 these headers will be included.
 If disabled, these headers will not be set. If they are already present, they will be preserved.
 See the <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/router/v3/router.proto#envoy-v3-api-field-extensions-filters-http-router-v3-router-suppress-envoy-headers">Envoy documentation</a> for more details.

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -2289,7 +2289,7 @@ type ProxyConfig_ProxyHeaders struct {
 	// If disabled, this header will not be set. If it is already present, it will be preserved.
 	// This header is enabled by default if not configured.
 	AttemptCount *ProxyConfig_ProxyHeaders_AttemptCount `protobuf:"bytes,4,opt,name=attempt_count,json=attemptCount,proto3" json:"attempt_count,omitempty"`
-	// Controls various `X-Envoy-*` headers, such as `X-Envoy-Overloaded` and `X-Envoy-Upstream-Service-Time. If enabled,
+	// Controls various `X-Envoy-*` headers, such as `X-Envoy-Overloaded` and `X-Envoy-Upstream-Service-Time`. If enabled,
 	// these headers will be included.
 	// If disabled, these headers will not be set. If they are already present, they will be preserved.
 	// See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/router/v3/router.proto#envoy-v3-api-field-extensions-filters-http-router-v3-router-suppress-envoy-headers) for more details.

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -680,7 +680,7 @@ message ProxyConfig {
     // If disabled, this header will not be set. If it is already present, it will be preserved.
     // This header is enabled by default if not configured.
     AttemptCount attempt_count = 4;
-    // Controls various `X-Envoy-*` headers, such as `X-Envoy-Overloaded` and `X-Envoy-Upstream-Service-Time. If enabled,
+    // Controls various `X-Envoy-*` headers, such as `X-Envoy-Overloaded` and `X-Envoy-Upstream-Service-Time`. If enabled,
     // these headers will be included.
     // If disabled, these headers will not be set. If they are already present, they will be preserved.
     // See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/router/v3/router.proto#envoy-v3-api-field-extensions-filters-http-router-v3-router-suppress-envoy-headers) for more details.

--- a/security/v1/authorization_policy.pb.go
+++ b/security/v1/authorization_policy.pb.go
@@ -813,8 +813,8 @@ type Operation struct {
 	// - `/foo/{*}` matches `/foo/bar` but not `/foo/bar/baz`
 	// - `/foo/{**}/` matches `/foo/bar/`, `/foo/bar/baz.txt`, and `/foo//` but not `/foo/bar`
 	// - `/foo/{*}/bar/{**}` matches `/foo/buzz/bar/` and `/foo/buzz/bar/baz`
-	// - `/*/baz/{*}“ is not a valid path template since it includes `*` outside of a supported operator
-	// - `/**/baz/{*}“ is not a valid path template since it includes `**` outside of a supported operator
+	// - `/*/baz/{*}` is not a valid path template since it includes `*` outside of a supported operator
+	// - `/**/baz/{*}` is not a valid path template since it includes `**` outside of a supported operator
 	// - `/{**}/foo/{*}` is not a valid path template since `{**}` is not the last operator
 	// - `/foo/{*}.txt` is invalid since there are characters other than `{*}` in the path segment
 	//

--- a/security/v1/authorization_policy.proto
+++ b/security/v1/authorization_policy.proto
@@ -531,8 +531,8 @@ message Operation {
   // - `/foo/{*}` matches `/foo/bar` but not `/foo/bar/baz`
   // - `/foo/{**}/` matches `/foo/bar/`, `/foo/bar/baz.txt`, and `/foo//` but not `/foo/bar`
   // - `/foo/{*}/bar/{**}` matches `/foo/buzz/bar/` and `/foo/buzz/bar/baz`
-  // - `/*/baz/{*}`` is not a valid path template since it includes `*` outside of a supported operator
-  // - `/**/baz/{*}`` is not a valid path template since it includes `**` outside of a supported operator
+  // - `/*/baz/{*}` is not a valid path template since it includes `*` outside of a supported operator
+  // - `/**/baz/{*}` is not a valid path template since it includes `**` outside of a supported operator
   // - `/{**}/foo/{*}` is not a valid path template since `{**}` is not the last operator
   // - `/foo/{*}.txt` is invalid since there are characters other than `{*}` in the path segment
   //

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -812,8 +812,8 @@ type Operation struct {
 	// - `/foo/{*}` matches `/foo/bar` but not `/foo/bar/baz`
 	// - `/foo/{**}/` matches `/foo/bar/`, `/foo/bar/baz.txt`, and `/foo//` but not `/foo/bar`
 	// - `/foo/{*}/bar/{**}` matches `/foo/buzz/bar/` and `/foo/buzz/bar/baz`
-	// - `/*/baz/{*}“ is not a valid path template since it includes `*` outside of a supported operator
-	// - `/**/baz/{*}“ is not a valid path template since it includes `**` outside of a supported operator
+	// - `/*/baz/{*}` is not a valid path template since it includes `*` outside of a supported operator
+	// - `/**/baz/{*}` is not a valid path template since it includes `**` outside of a supported operator
 	// - `/{**}/foo/{*}` is not a valid path template since `{**}` is not the last operator
 	// - `/foo/{*}.txt` is invalid since there are characters other than `{*}` in the path segment
 	//

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -610,8 +610,8 @@ To be a valid path template, the path must not contain <code>*</code>, <code>{</
 <li><code>/foo/{*}</code> matches <code>/foo/bar</code> but not <code>/foo/bar/baz</code></li>
 <li><code>/foo/{**}/</code> matches <code>/foo/bar/</code>, <code>/foo/bar/baz.txt</code>, and <code>/foo//</code> but not <code>/foo/bar</code></li>
 <li><code>/foo/{*}/bar/{**}</code> matches <code>/foo/buzz/bar/</code> and <code>/foo/buzz/bar/baz</code></li>
-<li><code>/*/baz/{*}`` is not a valid path template since it includes </code>*` outside of a supported operator</li>
-<li><code>/**/baz/{*}`` is not a valid path template since it includes </code>**` outside of a supported operator</li>
+<li><code>/*/baz/{*}</code> is not a valid path template since it includes <code>*</code> outside of a supported operator</li>
+<li><code>/**/baz/{*}</code> is not a valid path template since it includes <code>**</code> outside of a supported operator</li>
 <li><code>/{**}/foo/{*}</code> is not a valid path template since <code>{**}</code> is not the last operator</li>
 <li><code>/foo/{*}.txt</code> is invalid since there are characters other than <code>{*}</code> in the path segment</li>
 </ul>

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -530,8 +530,8 @@ message Operation {
   // - `/foo/{*}` matches `/foo/bar` but not `/foo/bar/baz`
   // - `/foo/{**}/` matches `/foo/bar/`, `/foo/bar/baz.txt`, and `/foo//` but not `/foo/bar`
   // - `/foo/{*}/bar/{**}` matches `/foo/buzz/bar/` and `/foo/buzz/bar/baz`
-  // - `/*/baz/{*}`` is not a valid path template since it includes `*` outside of a supported operator
-  // - `/**/baz/{*}`` is not a valid path template since it includes `**` outside of a supported operator
+  // - `/*/baz/{*}` is not a valid path template since it includes `*` outside of a supported operator
+  // - `/**/baz/{*}` is not a valid path template since it includes `**` outside of a supported operator
   // - `/{**}/foo/{*}` is not a valid path template since `{**}` is not the last operator
   // - `/foo/{*}.txt` is invalid since there are characters other than `{*}` in the path segment
   //


### PR DESCRIPTION
This is a manual cherry-pick of #3196 since the automated one #3213 requires `make gen` to be run