### PR TITLE
Improvements to CEL validations

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -135,6 +135,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -1873,6 +1875,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -3484,6 +3488,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -5095,6 +5101,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -5987,6 +5995,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -11656,6 +11666,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -11895,6 +11907,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -12032,6 +12046,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -12109,6 +12125,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -12248,6 +12266,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -12393,6 +12413,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -12642,6 +12664,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
@@ -12973,6 +12997,8 @@ spec:
                     maxProperties: 4096
                     type: object
                     x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains('*'))
                     - message: wildcard not allowed in label value match
                       rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -132,7 +132,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
               sha256:
                 description: SHA256 checksum that will be used to verify Wasm module
@@ -1866,7 +1870,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
             required:
             - host
@@ -3473,7 +3481,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
             required:
             - host
@@ -5080,7 +5092,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
             required:
             - host
@@ -5968,7 +5984,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
             type: object
           status:
@@ -11633,7 +11653,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
               targetRef:
                 properties:
@@ -11868,7 +11892,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
               targetRef:
                 properties:
@@ -12001,7 +12029,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
             type: object
           status:
@@ -12074,7 +12106,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
             type: object
           status:
@@ -12209,7 +12245,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
               targetRef:
                 properties:
@@ -12350,7 +12390,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
               targetRef:
                 properties:
@@ -12595,7 +12639,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
               targetRef:
                 properties:
@@ -12922,7 +12970,11 @@ spec:
                       type: string
                     description: One or more labels that indicate a specific set of
                       pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
                     type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label value match
+                      rule: self.map(key, self[key]).all(v, !v.contains('*'))
                 type: object
               targetRef:
                 properties:

--- a/tests/testdata/wasm-invalid.yaml
+++ b/tests/testdata/wasm-invalid.yaml
@@ -59,29 +59,18 @@ spec:
   url: "http://test"
   pluginName: ""
 ---
-# TODO: validator is currently not catching this
-#_err: 'spec.pluginName in body should be at least'
-#apiVersion: extensions.istio.io/v1alpha1
-#kind: WasmPlugin
-#metadata:
-#  name: duplicate-ports
-#spec:
-#  url: "http://test"
-#  ports:
-#    - number: 1
-#    - number: 1
-#---
-#_err: 'spec.pluginName in body should be at least'
-#apiVersion: extensions.istio.io/v1alpha1
-#kind: WasmPlugin
-#metadata:
-#  name: duplicate-env
-#spec:
-#  url: "http://test"
-#  vmConfig:
-#    env:
-#    - name: a
-#    - name: a
+_err: 'Duplicate value'
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: duplicate-env
+spec:
+  url: "http://test"
+  vmConfig:
+    env:
+    - name: a
+    - name: a
+---
 _err: 'spec.vmConfig.env[0].name in body should be at least'
 apiVersion: extensions.istio.io/v1alpha1
 kind: WasmPlugin
@@ -144,3 +133,14 @@ spec:
   selector:
     matchLabels:
       istio: "bar*"
+---
+_err: 'wildcard not allowed in label key match'
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: invalid-selector
+spec:
+  url: "http://test"
+  selector:
+    matchLabels:
+      "istio*": "bar"

--- a/tests/testdata/wasm-invalid.yaml
+++ b/tests/testdata/wasm-invalid.yaml
@@ -134,3 +134,13 @@ metadata:
 spec:
   url:
 ---
+_err: 'wildcard not allowed in label value match'
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: invalid-selector
+spec:
+  url: "http://test"
+  selector:
+    matchLabels:
+      istio: "bar*"

--- a/type/v1beta1/selector.pb.go
+++ b/type/v1beta1/selector.pb.go
@@ -119,7 +119,7 @@ type WorkloadSelector struct {
 	// One or more labels that indicate a specific set of pods/VMs
 	// on which a policy should be applied. The scope of label search is restricted to
 	// the configuration namespace in which the resource is present.
-	// +kubebuildex:validation:XValidation:message="wildcard not allowed in label key match",rule="self.all(key, !key.contains('*'))"
+	// +kubebuilder:validation:XValidation:message="wildcard not allowed in label key match",rule="self.all(key, !key.contains('*'))"
 	// +kubebuilder:validation:XValidation:message="wildcard not allowed in label value match",rule="self.map(key, self[key]).all(v, !v.contains('*'))"
 	// +kubebuilder:validation:MaxProperties=4096
 	MatchLabels map[string]string `protobuf:"bytes,1,rep,name=match_labels,json=matchLabels,proto3" json:"match_labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`

--- a/type/v1beta1/selector.pb.go
+++ b/type/v1beta1/selector.pb.go
@@ -119,6 +119,9 @@ type WorkloadSelector struct {
 	// One or more labels that indicate a specific set of pods/VMs
 	// on which a policy should be applied. The scope of label search is restricted to
 	// the configuration namespace in which the resource is present.
+	// +kubebuildex:validation:XValidation:message="wildcard not allowed in label key match",rule="self.all(key, !key.contains('*'))"
+	// +kubebuilder:validation:XValidation:message="wildcard not allowed in label value match",rule="self.map(key, self[key]).all(v, !v.contains('*'))"
+	// +kubebuilder:validation:MaxProperties=4096
 	MatchLabels map[string]string `protobuf:"bytes,1,rep,name=match_labels,json=matchLabels,proto3" json:"match_labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 

--- a/type/v1beta1/selector.proto
+++ b/type/v1beta1/selector.proto
@@ -33,6 +33,9 @@ message WorkloadSelector {
   // One or more labels that indicate a specific set of pods/VMs
   // on which a policy should be applied. The scope of label search is restricted to
   // the configuration namespace in which the resource is present.
+  // +kubebuildex:validation:XValidation:message="wildcard not allowed in label key match",rule="self.all(key, !key.contains('*'))"
+  // +kubebuilder:validation:XValidation:message="wildcard not allowed in label value match",rule="self.map(key, self[key]).all(v, !v.contains('*'))"
+  // +kubebuilder:validation:MaxProperties=4096
   map<string, string> match_labels = 1;
 }
 

--- a/type/v1beta1/selector.proto
+++ b/type/v1beta1/selector.proto
@@ -33,7 +33,7 @@ message WorkloadSelector {
   // One or more labels that indicate a specific set of pods/VMs
   // on which a policy should be applied. The scope of label search is restricted to
   // the configuration namespace in which the resource is present.
-  // +kubebuildex:validation:XValidation:message="wildcard not allowed in label key match",rule="self.all(key, !key.contains('*'))"
+  // +kubebuilder:validation:XValidation:message="wildcard not allowed in label key match",rule="self.all(key, !key.contains('*'))"
   // +kubebuilder:validation:XValidation:message="wildcard not allowed in label value match",rule="self.map(key, self[key]).all(v, !v.contains('*'))"
   // +kubebuilder:validation:MaxProperties=4096
   map<string, string> match_labels = 1;


### PR DESCRIPTION
This gives WasmPlugin and Telemetry full parity with the webhook.
Verified by fuzzing, which I will merge into istio/istio after this
(tests fail before this lands)

Related: https://github.com/istio/istio/pull/51287