### PR TITLE
Fixed link to the https://github.com/google/re2/wiki/Syntax

### DIFF
--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -738,7 +738,7 @@ message HTTPMatchRequest {
   //
   // - `prefix: "value"` for prefix-based match
   //
-  // - `regex: "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+  // - `regex: "value"` for RE2 style regex-based match https://github.com/google/re2/wiki/Syntax
   //
   // **Note:** Case-insensitive matching could be enabled via the
   // `ignoreUriCase` flag.
@@ -751,7 +751,7 @@ message HTTPMatchRequest {
   //
   // - `prefix: "value"` for prefix-based match
   //
-  // - `regex: "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+  // - `regex: "value"` for RE2 style regex-based match https://github.com/google/re2/wiki/Syntax
   //
   StringMatch scheme = 2;
 
@@ -762,7 +762,7 @@ message HTTPMatchRequest {
   //
   // - `prefix: "value"` for prefix-based match
   //
-  // - `regex: "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+  // - `regex: "value"` for RE2 style regex-based match https://github.com/google/re2/wiki/Syntax
   //
   StringMatch method = 3;
 
@@ -773,7 +773,7 @@ message HTTPMatchRequest {
   //
   // - `prefix: "value"` for prefix-based match
   //
-  // - `regex: "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+  // - `regex: "value"` for RE2 style regex-based match https://github.com/google/re2/wiki/Syntax
   //
   StringMatch authority = 4;
 
@@ -786,7 +786,7 @@ message HTTPMatchRequest {
   //
   // - `prefix: "value"` for prefix-based match
   //
-  // - `regex: "value"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+  // - `regex: "value"` for RE2 style regex-based match https://github.com/google/re2/wiki/Syntax
   //
   // If the value is empty and only the name of header is specified, presence of the header is checked.
   // To provide an empty value, use `{}`, for example:
@@ -1214,7 +1214,7 @@ message HTTPRewrite {
 }
 
 message RegexRewrite {
-  // RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+  // RE2 style regex-based match https://github.com/google/re2/wiki/Syntax
   string match = 1;
 
   // The string that should replace into matching portions of original URI.
@@ -1242,7 +1242,7 @@ message StringMatch {
     // prefix-based match
     string prefix = 2;
 
-    // RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+    // RE2 style regex-based match https://github.com/google/re2/wiki/Syntax
     string regex = 3;
   }
 }

--- a/networking/v1beta1/virtual_service_alias.gen.go
+++ b/networking/v1beta1/virtual_service_alias.gen.go
@@ -668,7 +668,7 @@ type StringMatch_Exact = v1alpha3.StringMatch_Exact
 // prefix-based match
 type StringMatch_Prefix = v1alpha3.StringMatch_Prefix
 
-// RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+// RE2 style regex-based match https://github.com/google/re2/wiki/Syntax
 type StringMatch_Regex = v1alpha3.StringMatch_Regex
 
 // Describes the retry policy to use when a HTTP request fails. For


### PR DESCRIPTION
Removed `)` in the end of the link https://github.com/google/re2/wiki/Syntax

Fixes: https://github.com/istio/istio.io/pull/15231

Related to: https://github.com/istio/api/pull/3227