### PR TITLE
Add DNSDomain as a proxyConfig option, used to be values.yaml only

### DIFF
--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -691,6 +691,26 @@ message ProxyConfig {
     // If IN_MESH, these headers will not be appended to outbound requests from sidecars to services not in-mesh.
     MetadataExchangeHeaders metadata_exchange_headers = 6;
   }
+
+  // dnsDomain is the DNS domain used by Kubernetes Services. Defaults to "cluster.local"
+  //
+  // Must match the 'dnsDomain' setting in kubeadm config and clusterDomain setting in kubelet.
+  // Must match the custom domain set in the external DNS server, if CoreDNS is not used.
+  //
+  // Do not set unless you are using a custom DNS domain for your K8S cluster and K8S
+  // is already set to use this value.
+  //
+  // The helm charts use "default.global.proxy.clusterDomain".
+  //
+  // Istiod uses this value to generate FQDNs for services. Agent uses this value
+  // in setting its node ID.
+  //
+  // See:
+  // https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
+  // https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-DNS
+  //
+  //  $hide_from_docs
+  string DNSDomain = 40;
 }
 
 message RemoteService {


### PR DESCRIPTION
See the comments - most of our configuration is now in MeshConfig/ProxyConfig or env variables - this currently is configurable via values.yaml and gets set via '--domain' flag in Istiod and agent. 

This is called 'clusterDomain' in kubelet and dnsDomain in kubeadmin - I used the later as name, don't mind using the first but it would be best to be one of the 2 to reduce confusion. 

It is a very old setting - only existing comment is "# CAUTION: It is important to ensure that all Istio helm charts specify the same clusterDomain value"

Use of K8S with a different suffix is rare, but some vendors and kubeadmin allows this to be set.
Despite the age - in Istio 1.0 was called proxyDomain, 1.1 changed it to clusterDomain - this is a rarely used option and test coverage is limited, but it is required if K8S is set to use a custom domain instead of cluster.local, or the generated config will break FQDNs.  

The goal is to improve documentation/testing and allow setting this via MeshConfig for consistency (and simplify a bit the related code) 
