### PR TITLE
Improve OutboundTrafficPolicy docs

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -8275,7 +8275,8 @@ spec:
                   type: object
                 type: array
               outboundTrafficPolicy:
-                description: Configuration for the outbound traffic policy.
+                description: Set the default behavior of the sidecar for handling
+                  outbound traffic from the application.
                 properties:
                   egressProxy:
                     properties:
@@ -8805,7 +8806,8 @@ spec:
                   type: object
                 type: array
               outboundTrafficPolicy:
-                description: Configuration for the outbound traffic policy.
+                description: Set the default behavior of the sidecar for handling
+                  outbound traffic from the application.
                 properties:
                   egressProxy:
                     properties:
@@ -9335,7 +9337,8 @@ spec:
                   type: object
                 type: array
               outboundTrafficPolicy:
-                description: Configuration for the outbound traffic policy.
+                description: Set the default behavior of the sidecar for handling
+                  outbound traffic from the application.
                 properties:
                   egressProxy:
                     properties:

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -161,13 +161,21 @@ message MeshConfig {
   // On Kubernetes, this can be overridden on individual pods with the `proxy.istio.io/config` annotation.
   ProxyConfig default_config = 14;
 
+  // `OutboundTrafficPolicy` sets the default behavior of the sidecar for
+  // handling unknown outbound traffic from the application.
   message OutboundTrafficPolicy {
     enum Mode {
-      // outbound traffic will be restricted to services defined in the
-      // service registry as well as those defined through ServiceEntries
+      // In `REGISTRY_ONLY` mode, unknown outbound traffic will be dropped.
+      // Traffic destinations must be explicitly declared into the service registry through `ServiceEntry` configurations.
+      //
+      // Note: Istio [does not offer an outbound traffic security policy](https://istio.io/latest/docs/ops/best-practices/security/#understand-traffic-capture-limitations).
+      // This option does not act as one, or as any form of an outbound firewall.
+      // Instead, this option exists primarily to offer users a way to detect missing `ServiceEntry` configurations by explicitly failing.
       REGISTRY_ONLY = 0;
-      // outbound traffic to unknown destinations will be allowed, in case
-      // there are no services or ServiceEntries for the destination port
+      // In `ALLOW_ANY` mode, any traffic to unknown destinations will be allowed.
+      // Unknown destination traffic will have limited functionality, however, such as reduced observability.
+      // This mode allows users that do not have all possible egress destinations registered through `ServiceEntry` configurations to still connect
+      // to arbitrary destinations.
       ALLOW_ANY = 1;
 
       reserved 2;
@@ -177,17 +185,12 @@ message MeshConfig {
   }
 
   // Set the default behavior of the sidecar for handling outbound
-  // traffic from the application.  If your application uses one or
-  // more external services that are not known apriori, setting the
-  // policy to `ALLOW_ANY` will cause the sidecars to route any unknown
-  // traffic originating from the application to its requested
-  // destination. Users are strongly encouraged to use ServiceEntries
-  // to explicitly declare any external dependencies, instead of using
-  // `ALLOW_ANY`, so that traffic to these services can be
-  // monitored. Can be overridden at a Sidecar level by setting the
-  // `OutboundTrafficPolicy` in the [Sidecar
-  // API](https://istio.io/docs/reference/config/networking/sidecar/#OutboundTrafficPolicy).
-  // Default mode is `ALLOW_ANY` which means outbound traffic to unknown destinations will be allowed.
+  // traffic from the application.
+  //
+  // Can be overridden at a Sidecar level by setting the `OutboundTrafficPolicy` in the
+  // [Sidecar API](https://istio.io/docs/reference/config/networking/sidecar/#OutboundTrafficPolicy).
+  //
+  // Default mode is `ALLOW_ANY`, which means outbound traffic to unknown destinations will be allowed.
   OutboundTrafficPolicy outbound_traffic_policy = 17;
 
   message InboundTrafficPolicy {

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -229,17 +229,10 @@ No
 <td><code><a href="#MeshConfig-OutboundTrafficPolicy">OutboundTrafficPolicy</a></code></td>
 <td>
 <p>Set the default behavior of the sidecar for handling outbound
-traffic from the application.  If your application uses one or
-more external services that are not known apriori, setting the
-policy to <code>ALLOW_ANY</code> will cause the sidecars to route any unknown
-traffic originating from the application to its requested
-destination. Users are strongly encouraged to use ServiceEntries
-to explicitly declare any external dependencies, instead of using
-<code>ALLOW_ANY</code>, so that traffic to these services can be
-monitored. Can be overridden at a Sidecar level by setting the
-<code>OutboundTrafficPolicy</code> in the <a href="https://istio.io/docs/reference/config/networking/sidecar/#OutboundTrafficPolicy">Sidecar
-API</a>.
-Default mode is <code>ALLOW_ANY</code> which means outbound traffic to unknown destinations will be allowed.</p>
+traffic from the application.</p>
+<p>Can be overridden at a Sidecar level by setting the <code>OutboundTrafficPolicy</code> in the
+<a href="https://istio.io/docs/reference/config/networking/sidecar/#OutboundTrafficPolicy">Sidecar API</a>.</p>
+<p>Default mode is <code>ALLOW_ANY</code>, which means outbound traffic to unknown destinations will be allowed.</p>
 
 </td>
 <td>
@@ -815,6 +808,9 @@ No
 </section>
 <h2 id="MeshConfig-OutboundTrafficPolicy">MeshConfig.OutboundTrafficPolicy</h2>
 <section>
+<p><code>OutboundTrafficPolicy</code> sets the default behavior of the sidecar for
+handling unknown outbound traffic from the application.</p>
+
 <table class="message-fields">
 <thead>
 <tr>
@@ -4406,16 +4402,21 @@ No
 <tr id="MeshConfig-OutboundTrafficPolicy-Mode-REGISTRY_ONLY">
 <td><code>REGISTRY_ONLY</code></td>
 <td>
-<p>outbound traffic will be restricted to services defined in the
-service registry as well as those defined through ServiceEntries</p>
+<p>In <code>REGISTRY_ONLY</code> mode, unknown outbound traffic will be dropped.
+Traffic destinations must be explicitly declared into the service registry through <code>ServiceEntry</code> configurations.</p>
+<p>Note: Istio <a href="https://istio.io/latest/docs/ops/best-practices/security/#understand-traffic-capture-limitations">does not offer an outbound traffic security policy</a>.
+This option does not act as one, or as any form of an outbound firewall.
+Instead, this option exists primarily to offer users a way to detect missing <code>ServiceEntry</code> configurations by explicitly failing.</p>
 
 </td>
 </tr>
 <tr id="MeshConfig-OutboundTrafficPolicy-Mode-ALLOW_ANY">
 <td><code>ALLOW_ANY</code></td>
 <td>
-<p>outbound traffic to unknown destinations will be allowed, in case
-there are no services or ServiceEntries for the destination port</p>
+<p>In <code>ALLOW_ANY</code> mode, any traffic to unknown destinations will be allowed.
+Unknown destination traffic will have limited functionality, however, such as reduced observability.
+This mode allows users that do not have all possible egress destinations registered through <code>ServiceEntry</code> configurations to still connect
+to arbitrary destinations.</p>
 
 </td>
 </tr>

--- a/networking/v1/sidecar_alias.gen.go
+++ b/networking/v1/sidecar_alias.gen.go
@@ -46,23 +46,22 @@ type IstioEgressListener = v1alpha3.IstioEgressListener
 type WorkloadSelector = v1alpha3.WorkloadSelector
 
 // `OutboundTrafficPolicy` sets the default behavior of the sidecar for
-// handling outbound traffic from the application.
-// If your application uses one or more external
-// services that are not known apriori, setting the policy to `ALLOW_ANY`
-// will cause the sidecars to route any unknown traffic originating from
-// the application to its requested destination.  Users are strongly
-// encouraged to use `ServiceEntry` configurations to explicitly declare any external
-// dependencies, instead of using `ALLOW_ANY`, so that traffic to these
-// services can be monitored.
+// handling unknown outbound traffic from the application.
 type OutboundTrafficPolicy = v1alpha3.OutboundTrafficPolicy
 type OutboundTrafficPolicy_Mode = v1alpha3.OutboundTrafficPolicy_Mode
 
-// Outbound traffic will be restricted to services defined in the
-// service registry as well as those defined through `ServiceEntry` configurations.
+// In `REGISTRY_ONLY` mode, unknown outbound traffic will be dropped.
+// Traffic destinations must be explicitly declared into the service registry through `ServiceEntry` configurations.
+//
+// Note: Istio [does not offer an outbound traffic security policy](https://istio.io/latest/docs/ops/best-practices/security/#understand-traffic-capture-limitations).
+// This option does not act as one, or as any form of an outbound firewall.
+// Instead, this option exists primarily to offer users a way to detect missing `ServiceEntry` configurations by explicitly failing.
 const OutboundTrafficPolicy_REGISTRY_ONLY OutboundTrafficPolicy_Mode = v1alpha3.OutboundTrafficPolicy_REGISTRY_ONLY
 
-// Outbound traffic to unknown destinations will be allowed, in case
-// there are no services or `ServiceEntry` configurations for the destination port.
+// In `ALLOW_ANY` mode, any traffic to unknown destinations will be allowed.
+// Unknown destination traffic will have limited functionality, however, such as reduced observability.
+// This mode allows users that do not have all possible egress destinations registered through `ServiceEntry` configurations to still connect
+// to arbitrary destinations.
 const OutboundTrafficPolicy_ALLOW_ANY OutboundTrafficPolicy_Mode = v1alpha3.OutboundTrafficPolicy_ALLOW_ANY
 
 // Port describes the properties of a specific port of a service.

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -395,13 +395,9 @@ No
 <td><code>outboundTrafficPolicy</code></td>
 <td><code><a href="#OutboundTrafficPolicy">OutboundTrafficPolicy</a></code></td>
 <td>
-<p>Configuration for the outbound traffic policy.  If your
-application uses one or more external services that are not known
-apriori, setting the policy to <code>ALLOW_ANY</code> will cause the
-sidecars to route any unknown traffic originating from the
-application to its requested destination. If not specified,
-inherits the system detected defaults from the namespace-wide or
-the global default Sidecar.</p>
+<p>Set the default behavior of the sidecar for handling outbound
+traffic from the application.</p>
+<p>Default mode is <code>ALLOW_ANY</code>, which means outbound traffic to unknown destinations will be allowed.</p>
 
 </td>
 <td>
@@ -659,14 +655,7 @@ No
 <h2 id="OutboundTrafficPolicy">OutboundTrafficPolicy</h2>
 <section>
 <p><code>OutboundTrafficPolicy</code> sets the default behavior of the sidecar for
-handling outbound traffic from the application.
-If your application uses one or more external
-services that are not known apriori, setting the policy to <code>ALLOW_ANY</code>
-will cause the sidecars to route any unknown traffic originating from
-the application to its requested destination.  Users are strongly
-encouraged to use <code>ServiceEntry</code> configurations to explicitly declare any external
-dependencies, instead of using <code>ALLOW_ANY</code>, so that traffic to these
-services can be monitored.</p>
+handling unknown outbound traffic from the application.</p>
 
 <table class="message-fields">
 <thead>
@@ -756,16 +745,21 @@ No
 <tr id="OutboundTrafficPolicy-Mode-REGISTRY_ONLY">
 <td><code>REGISTRY_ONLY</code></td>
 <td>
-<p>Outbound traffic will be restricted to services defined in the
-service registry as well as those defined through <code>ServiceEntry</code> configurations.</p>
+<p>In <code>REGISTRY_ONLY</code> mode, unknown outbound traffic will be dropped.
+Traffic destinations must be explicitly declared into the service registry through <code>ServiceEntry</code> configurations.</p>
+<p>Note: Istio <a href="https://istio.io/latest/docs/ops/best-practices/security/#understand-traffic-capture-limitations">does not offer an outbound traffic security policy</a>.
+This option does not act as one, or as any form of an outbound firewall.
+Instead, this option exists primarily to offer users a way to detect missing <code>ServiceEntry</code> configurations by explicitly failing.</p>
 
 </td>
 </tr>
 <tr id="OutboundTrafficPolicy-Mode-ALLOW_ANY">
 <td><code>ALLOW_ANY</code></td>
 <td>
-<p>Outbound traffic to unknown destinations will be allowed, in case
-there are no services or <code>ServiceEntry</code> configurations for the destination port.</p>
+<p>In <code>ALLOW_ANY</code> mode, any traffic to unknown destinations will be allowed.
+Unknown destination traffic will have limited functionality, however, such as reduced observability.
+This mode allows users that do not have all possible egress destinations registered through <code>ServiceEntry</code> configurations to still connect
+to arbitrary destinations.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -415,13 +415,10 @@ message Sidecar {
   // In every case, the connection pool settings are overriden, not merged.
   ConnectionPoolSettings inbound_connection_pool = 7;
 
-  // Configuration for the outbound traffic policy.  If your
-  // application uses one or more external services that are not known
-  // apriori, setting the policy to `ALLOW_ANY` will cause the
-  // sidecars to route any unknown traffic originating from the
-  // application to its requested destination. If not specified,
-  // inherits the system detected defaults from the namespace-wide or
-  // the global default Sidecar.
+  // Set the default behavior of the sidecar for handling outbound
+  // traffic from the application.
+  //
+  // Default mode is `ALLOW_ANY`, which means outbound traffic to unknown destinations will be allowed.
   OutboundTrafficPolicy outbound_traffic_policy = 4;
 
   reserved "localhost";
@@ -558,21 +555,20 @@ message WorkloadSelector {
 }
 
 // `OutboundTrafficPolicy` sets the default behavior of the sidecar for
-// handling outbound traffic from the application.
-// If your application uses one or more external
-// services that are not known apriori, setting the policy to `ALLOW_ANY`
-// will cause the sidecars to route any unknown traffic originating from
-// the application to its requested destination.  Users are strongly
-// encouraged to use `ServiceEntry` configurations to explicitly declare any external
-// dependencies, instead of using `ALLOW_ANY`, so that traffic to these
-// services can be monitored.
+// handling unknown outbound traffic from the application.
 message OutboundTrafficPolicy {
   enum Mode {
-    // Outbound traffic will be restricted to services defined in the
-    // service registry as well as those defined through `ServiceEntry` configurations.
+    // In `REGISTRY_ONLY` mode, unknown outbound traffic will be dropped.
+    // Traffic destinations must be explicitly declared into the service registry through `ServiceEntry` configurations.
+    //
+    // Note: Istio [does not offer an outbound traffic security policy](https://istio.io/latest/docs/ops/best-practices/security/#understand-traffic-capture-limitations).
+    // This option does not act as one, or as any form of an outbound firewall.
+    // Instead, this option exists primarily to offer users a way to detect missing `ServiceEntry` configurations by explicitly failing.
     REGISTRY_ONLY = 0;
-    // Outbound traffic to unknown destinations will be allowed, in case
-    // there are no services or `ServiceEntry` configurations for the destination port.
+    // In `ALLOW_ANY` mode, any traffic to unknown destinations will be allowed.
+    // Unknown destination traffic will have limited functionality, however, such as reduced observability.
+    // This mode allows users that do not have all possible egress destinations registered through `ServiceEntry` configurations to still connect
+    // to arbitrary destinations.
     ALLOW_ANY = 1;
   }
   Mode mode = 1;

--- a/networking/v1beta1/sidecar_alias.gen.go
+++ b/networking/v1beta1/sidecar_alias.gen.go
@@ -46,23 +46,22 @@ type IstioEgressListener = v1alpha3.IstioEgressListener
 type WorkloadSelector = v1alpha3.WorkloadSelector
 
 // `OutboundTrafficPolicy` sets the default behavior of the sidecar for
-// handling outbound traffic from the application.
-// If your application uses one or more external
-// services that are not known apriori, setting the policy to `ALLOW_ANY`
-// will cause the sidecars to route any unknown traffic originating from
-// the application to its requested destination.  Users are strongly
-// encouraged to use `ServiceEntry` configurations to explicitly declare any external
-// dependencies, instead of using `ALLOW_ANY`, so that traffic to these
-// services can be monitored.
+// handling unknown outbound traffic from the application.
 type OutboundTrafficPolicy = v1alpha3.OutboundTrafficPolicy
 type OutboundTrafficPolicy_Mode = v1alpha3.OutboundTrafficPolicy_Mode
 
-// Outbound traffic will be restricted to services defined in the
-// service registry as well as those defined through `ServiceEntry` configurations.
+// In `REGISTRY_ONLY` mode, unknown outbound traffic will be dropped.
+// Traffic destinations must be explicitly declared into the service registry through `ServiceEntry` configurations.
+//
+// Note: Istio [does not offer an outbound traffic security policy](https://istio.io/latest/docs/ops/best-practices/security/#understand-traffic-capture-limitations).
+// This option does not act as one, or as any form of an outbound firewall.
+// Instead, this option exists primarily to offer users a way to detect missing `ServiceEntry` configurations by explicitly failing.
 const OutboundTrafficPolicy_REGISTRY_ONLY OutboundTrafficPolicy_Mode = v1alpha3.OutboundTrafficPolicy_REGISTRY_ONLY
 
-// Outbound traffic to unknown destinations will be allowed, in case
-// there are no services or `ServiceEntry` configurations for the destination port.
+// In `ALLOW_ANY` mode, any traffic to unknown destinations will be allowed.
+// Unknown destination traffic will have limited functionality, however, such as reduced observability.
+// This mode allows users that do not have all possible egress destinations registered through `ServiceEntry` configurations to still connect
+// to arbitrary destinations.
 const OutboundTrafficPolicy_ALLOW_ANY OutboundTrafficPolicy_Mode = v1alpha3.OutboundTrafficPolicy_ALLOW_ANY
 
 // Port describes the properties of a specific port of a service.


### PR DESCRIPTION
This is a bit of a mess since its documented in 3 places * 2 resources.

Meaningful changes:
* Explain registry only != security
* Remove recommendation to use registry_only, but explain why someone
  might
