### PR TITLE
Make observedGeneration intOrStr

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -316,6 +316,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -2158,6 +2159,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -3972,6 +3974,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -5786,6 +5789,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -6178,6 +6182,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -6431,6 +6436,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -6658,6 +6664,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -6885,6 +6892,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -7031,6 +7039,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -7305,6 +7314,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -7553,6 +7563,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -7801,6 +7812,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -8355,6 +8367,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -8885,6 +8898,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -9415,6 +9429,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -10475,6 +10490,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -11509,6 +11525,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -12543,6 +12560,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -12721,6 +12739,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -12877,6 +12896,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -13033,6 +13053,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -13325,6 +13346,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -13589,6 +13611,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -13853,6 +13876,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -14225,6 +14249,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -14570,6 +14595,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -14754,6 +14780,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -14911,6 +14938,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -15220,6 +15248,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -15502,6 +15531,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -15969,6 +15999,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:
@@ -16409,6 +16440,7 @@ spec:
                   refers.
                 format: int64
                 type: integer
+                x-kubernetes-int-or-string: true
               validationMessages:
                 description: Includes any errors or warnings detected by Istio's analyzers.
                 items:

--- a/meta/v1alpha1/status.pb.go
+++ b/meta/v1alpha1/status.pb.go
@@ -60,6 +60,7 @@ type IstioStatus struct {
 	// When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current
 	// generation is still in progress.  See https://istio.io/latest/docs/reference/config/config-status/ for more info.
 	// +optional
+	// +kubebuilder:validation:XIntOrString
 	ObservedGeneration int64 `protobuf:"varint,3,opt,name=observed_generation,json=observedGeneration,proto3" json:"observed_generation,omitempty"`
 }
 

--- a/meta/v1alpha1/status.proto
+++ b/meta/v1alpha1/status.proto
@@ -43,6 +43,7 @@ message IstioStatus {
   // When this value is not equal to the object's metadata generation, reconciled condition  calculation for the current
   // generation is still in progress.  See https://istio.io/latest/docs/reference/config/config-status/ for more info.
   // +optional
+  // +kubebuilder:validation:XIntOrString
   int64 observed_generation = 3;
 }
 


### PR DESCRIPTION
int64 in proto is encoded to json as a string. To support this, we make
it accept either form.

Without this, istio fails to write the status. See
https://github.com/istio/istio/pull/52159.

Note: this is only an issue now since we just added schema validation
for status.
