### PR TITLE
docs: clarify target ref to service

### DIFF
--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -561,7 +561,7 @@ type WasmPlugin struct {
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
-	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
+	// * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/extensions/v1alpha1/wasm.pb.html
+++ b/extensions/v1alpha1/wasm.pb.html
@@ -209,7 +209,7 @@ the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
-<li><code>kind: Service</code> with <code>&quot;&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
+<li><code>kind: Service</code> with <code>group: &quot;&quot;</code> or <code>group: &quot;core&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -256,7 +256,7 @@ message WasmPlugin {
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
-  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
+  // * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -398,7 +398,7 @@ type AuthorizationPolicy struct {
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
-	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
+	// * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -233,7 +233,7 @@ the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
-<li><code>kind: Service</code> with <code>&quot;&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
+<li><code>kind: Service</code> with <code>group: &quot;&quot;</code> or <code>group: &quot;core&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -289,7 +289,7 @@ message AuthorizationPolicy {
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
-  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
+  // * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -322,7 +322,7 @@ type RequestAuthentication struct {
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
-	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
+	// * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -238,7 +238,7 @@ the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
-<li><code>kind: Service</code> with <code>&quot;&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
+<li><code>kind: Service</code> with <code>group: &quot;&quot;</code> or <code>group: &quot;core&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -264,7 +264,7 @@ message RequestAuthentication {
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
-  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
+  // * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/telemetry/v1alpha1/telemetry.pb.go
+++ b/telemetry/v1alpha1/telemetry.pb.go
@@ -563,7 +563,7 @@ type Telemetry struct {
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
-	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
+	// * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/telemetry/v1alpha1/telemetry.pb.html
+++ b/telemetry/v1alpha1/telemetry.pb.html
@@ -227,7 +227,7 @@ the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
-<li><code>kind: Service</code> with <code>&quot;&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
+<li><code>kind: Service</code> with <code>group: &quot;&quot;</code> or <code>group: &quot;core&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/telemetry/v1alpha1/telemetry.proto
+++ b/telemetry/v1alpha1/telemetry.proto
@@ -275,7 +275,7 @@ message Telemetry {
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
-  // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
+  // * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.


### PR DESCRIPTION
> Service  with `""`

The wording doesn't explicitly mention that it's `group: ""`. This makes it very clear, as well as mentions you can write `"core"` as well. 

https://github.com/istio/istio/blob/d7a9700d5eaa4e9728274b408623670f48deadb5/pilot/pkg/model/policyattachment.go#L133-L140