### PR TITLE
Fix minor typo

### DIFF
--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -540,7 +540,7 @@ type Sidecar struct {
 	// - top level `TrafficPolicy.ConnectionPool` from the `DestinationRule`
 	// - default connection pool settings (essentially unlimited)
 	//
-	// In every case, the connection pool settings are overriden, not merged.
+	// In every case, the connection pool settings are overridden, not merged.
 	InboundConnectionPool *ConnectionPoolSettings `protobuf:"bytes,7,opt,name=inbound_connection_pool,json=inboundConnectionPool,proto3" json:"inbound_connection_pool,omitempty"`
 	// Set the default behavior of the sidecar for handling outbound
 	// traffic from the application.

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -384,7 +384,7 @@ following precedence, highest to lowest:</p>
 <li>top level <code>TrafficPolicy.ConnectionPool</code> from the <code>DestinationRule</code></li>
 <li>default connection pool settings (essentially unlimited)</li>
 </ul>
-<p>In every case, the connection pool settings are overriden, not merged.</p>
+<p>In every case, the connection pool settings are overridden, not merged.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -412,7 +412,7 @@ message Sidecar {
   // - top level `TrafficPolicy.ConnectionPool` from the `DestinationRule`
   // - default connection pool settings (essentially unlimited)
   //
-  // In every case, the connection pool settings are overriden, not merged.
+  // In every case, the connection pool settings are overridden, not merged.
   ConnectionPoolSettings inbound_connection_pool = 7;
 
   // Set the default behavior of the sidecar for handling outbound


### PR DESCRIPTION
Correct typo from 'overriden' to 'overridden'.

Fixes https://github.com/istio/istio.io/pull/15562#issuecomment-2290904741