### PR TITLE
clarify documentation around stringMatch and case-sensitivity

### DIFF
--- a/networking/v1/virtual_service_alias.gen.go
+++ b/networking/v1/virtual_service_alias.gen.go
@@ -658,8 +658,8 @@ type HTTPBody_Bytes = v1alpha3.HTTPBody_Bytes
 type HTTPRewrite = v1alpha3.HTTPRewrite
 type RegexRewrite = v1alpha3.RegexRewrite
 
-// Describes how to match a given string in HTTP headers. Match is
-// case-sensitive.
+// Describes how to match a given string in HTTP headers. `exact` and `prefix` matching is
+// case-sensitive. `regex` matching supports case-insensitive matches.
 type StringMatch = v1alpha3.StringMatch
 
 // exact string match
@@ -669,6 +669,8 @@ type StringMatch_Exact = v1alpha3.StringMatch_Exact
 type StringMatch_Prefix = v1alpha3.StringMatch_Prefix
 
 // [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
+//
+// Example: `(?i)^aaa$` can be used to case-insensitive match a string consisting of three a's.
 type StringMatch_Regex = v1alpha3.StringMatch_Regex
 
 // Describes the retry policy to use when a HTTP request fails. For

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -2554,8 +2554,8 @@ func (x *RegexRewrite) GetRewrite() string {
 	return ""
 }
 
-// Describes how to match a given string in HTTP headers. Match is
-// case-sensitive.
+// Describes how to match a given string in HTTP headers. `exact` and `prefix` matching is
+// case-sensitive. `regex` matching supports case-insensitive matches.
 type StringMatch struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2645,6 +2645,8 @@ type StringMatch_Prefix struct {
 
 type StringMatch_Regex struct {
 	// [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
+	//
+	// Example: `(?i)^aaa$` can be used to case-insensitive match a string consisting of three a's.
 	Regex string `protobuf:"bytes,3,opt,name=regex,proto3,oneof"`
 }
 

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -1947,8 +1947,8 @@ No
 </section>
 <h2 id="StringMatch">StringMatch</h2>
 <section>
-<p>Describes how to match a given string in HTTP headers. Match is
-case-sensitive.</p>
+<p>Describes how to match a given string in HTTP headers. <code>exact</code> and <code>prefix</code> matching is
+case-sensitive. <code>regex</code> matching supports case-insensitive matches.</p>
 
 <table class="message-fields">
 <thead>
@@ -1987,6 +1987,7 @@ No
 <td><code>string (oneof)</code></td>
 <td>
 <p><a href="https://github.com/google/re2/wiki/Syntax">RE2 style regex-based match</a>.</p>
+<p>Example: <code>(?i)^aaa$</code> can be used to case-insensitive match a string consisting of three a&rsquo;s.</p>
 
 </td>
 <td>

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -1240,8 +1240,8 @@ message RegexRewrite {
   string rewrite = 2;
 }
 
-// Describes how to match a given string in HTTP headers. Match is
-// case-sensitive.
+// Describes how to match a given string in HTTP headers. `exact` and `prefix` matching is
+// case-sensitive. `regex` matching supports case-insensitive matches.
 message StringMatch {
   oneof match_type {
 
@@ -1252,6 +1252,8 @@ message StringMatch {
     string prefix = 2;
 
     // [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
+    //
+    // Example: `(?i)^aaa$` can be used to case-insensitive match a string consisting of three a's.
     string regex = 3;
   }
 }

--- a/networking/v1beta1/virtual_service_alias.gen.go
+++ b/networking/v1beta1/virtual_service_alias.gen.go
@@ -658,8 +658,8 @@ type HTTPBody_Bytes = v1alpha3.HTTPBody_Bytes
 type HTTPRewrite = v1alpha3.HTTPRewrite
 type RegexRewrite = v1alpha3.RegexRewrite
 
-// Describes how to match a given string in HTTP headers. Match is
-// case-sensitive.
+// Describes how to match a given string in HTTP headers. `exact` and `prefix` matching is
+// case-sensitive. `regex` matching supports case-insensitive matches.
 type StringMatch = v1alpha3.StringMatch
 
 // exact string match
@@ -669,6 +669,8 @@ type StringMatch_Exact = v1alpha3.StringMatch_Exact
 type StringMatch_Prefix = v1alpha3.StringMatch_Prefix
 
 // [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
+//
+// Example: `(?i)^aaa$` can be used to case-insensitive match a string consisting of three a's.
 type StringMatch_Regex = v1alpha3.StringMatch_Regex
 
 // Describes the retry policy to use when a HTTP request fails. For


### PR DESCRIPTION
seeks to add clarification around case-sensitive vs case-insensitive options for stringMatch in the VirtualService API