### PR TITLE
Clarify ForwardClientCertDetails comments

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -4737,7 +4737,7 @@ header handling for more details.</p>
 <tr id="ForwardClientCertDetails-SANITIZE">
 <td><code>SANITIZE</code></td>
 <td>
-<p>Do not send the XFCC header to the next hop. This is the default value.</p>
+<p>Do not send the XFCC header to the next hop. This is the default value. This is the default value for gateway proxies.</p>
 
 </td>
 </tr>
@@ -4753,7 +4753,7 @@ in the request.</p>
 <td><code>APPEND_FORWARD</code></td>
 <td>
 <p>When the client connection is mTLS, append the client certificate
-information to the request’s XFCC header and forward it.</p>
+information to the request’s XFCC header and forward it. This is the default value for sidecar proxies.</p>
 
 </td>
 </tr>

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -4737,7 +4737,7 @@ header handling for more details.</p>
 <tr id="ForwardClientCertDetails-SANITIZE">
 <td><code>SANITIZE</code></td>
 <td>
-<p>Do not send the XFCC header to the next hop. This is the default value. This is the default value for gateway proxies.</p>
+<p>Do not send the XFCC header to the next hop. This is the default value for gateway proxies.</p>
 
 </td>
 </tr>

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -4737,7 +4737,7 @@ header handling for more details.</p>
 <tr id="ForwardClientCertDetails-SANITIZE">
 <td><code>SANITIZE</code></td>
 <td>
-<p>Do not send the XFCC header to the next hop. This is the default value for gateway proxies.</p>
+<p>Do not send the XFCC header to the next hop.</p>
 
 </td>
 </tr>
@@ -4761,7 +4761,7 @@ information to the request’s XFCC header and forward it. This is the default v
 <td><code>SANITIZE_SET</code></td>
 <td>
 <p>When the client connection is mTLS, reset the XFCC header with the client
-certificate information and send it to the next hop.</p>
+certificate information and send it to the next hop. This is the default value for gateway proxies.</p>
 
 </td>
 </tr>

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -4715,7 +4715,7 @@ policy.</p>
 <h2 id="ForwardClientCertDetails">ForwardClientCertDetails</h2>
 <section>
 <p>ForwardClientCertDetails controls how the x-forwarded-client-cert (XFCC)
-header is handled by the gateway proxy.
+header is handled by a proxy.
 See <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto.html#enum-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-forwardclientcertdetails">Envoy XFCC</a>
 header handling for more details.</p>
 

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -103,7 +103,7 @@ type ForwardClientCertDetails int32
 const (
 	// Field is not set
 	ForwardClientCertDetails_UNDEFINED ForwardClientCertDetails = 0
-	// Do not send the XFCC header to the next hop. This is the default value for gateway proxies.
+	// Do not send the XFCC header to the next hop.
 	ForwardClientCertDetails_SANITIZE ForwardClientCertDetails = 1
 	// When the client connection is mTLS (Mutual TLS), forward the XFCC header
 	// in the request.
@@ -112,7 +112,7 @@ const (
 	// information to the request’s XFCC header and forward it. This is the default value for sidecar proxies.
 	ForwardClientCertDetails_APPEND_FORWARD ForwardClientCertDetails = 3
 	// When the client connection is mTLS, reset the XFCC header with the client
-	// certificate information and send it to the next hop.
+	// certificate information and send it to the next hop. This is the default value for gateway proxies.
 	ForwardClientCertDetails_SANITIZE_SET ForwardClientCertDetails = 4
 	// Always forward the XFCC header in the request, regardless of whether the
 	// client connection is mTLS.

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -103,7 +103,7 @@ type ForwardClientCertDetails int32
 const (
 	// Field is not set
 	ForwardClientCertDetails_UNDEFINED ForwardClientCertDetails = 0
-	// Do not send the XFCC header to the next hop. This is the default value. This is the default value for gateway proxies.
+	// Do not send the XFCC header to the next hop. This is the default value for gateway proxies.
 	ForwardClientCertDetails_SANITIZE ForwardClientCertDetails = 1
 	// When the client connection is mTLS (Mutual TLS), forward the XFCC header
 	// in the request.

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -95,7 +95,7 @@ func (AuthenticationPolicy) EnumDescriptor() ([]byte, []int) {
 }
 
 // ForwardClientCertDetails controls how the x-forwarded-client-cert (XFCC)
-// header is handled by the gateway proxy.
+// header is handled by the proxies.
 // See [Envoy XFCC](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto.html#enum-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-forwardclientcertdetails)
 // header handling for more details.
 type ForwardClientCertDetails int32
@@ -103,13 +103,13 @@ type ForwardClientCertDetails int32
 const (
 	// Field is not set
 	ForwardClientCertDetails_UNDEFINED ForwardClientCertDetails = 0
-	// Do not send the XFCC header to the next hop. This is the default value.
+	// Do not send the XFCC header to the next hop. This is the default value for gateway proxies.
 	ForwardClientCertDetails_SANITIZE ForwardClientCertDetails = 1
 	// When the client connection is mTLS (Mutual TLS), forward the XFCC header
 	// in the request.
 	ForwardClientCertDetails_FORWARD_ONLY ForwardClientCertDetails = 2
 	// When the client connection is mTLS, append the client certificate
-	// information to the request’s XFCC header and forward it.
+	// information to the request’s XFCC header and forward it. This is the default value for sidecar proxies.
 	ForwardClientCertDetails_APPEND_FORWARD ForwardClientCertDetails = 3
 	// When the client connection is mTLS, reset the XFCC header with the client
 	// certificate information and send it to the next hop.

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -95,7 +95,7 @@ func (AuthenticationPolicy) EnumDescriptor() ([]byte, []int) {
 }
 
 // ForwardClientCertDetails controls how the x-forwarded-client-cert (XFCC)
-// header is handled by the gateway proxy.
+// header is handled by a proxy.
 // See [Envoy XFCC](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto.html#enum-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-forwardclientcertdetails)
 // header handling for more details.
 type ForwardClientCertDetails int32

--- a/mesh/v1alpha1/proxy.pb.go
+++ b/mesh/v1alpha1/proxy.pb.go
@@ -95,7 +95,7 @@ func (AuthenticationPolicy) EnumDescriptor() ([]byte, []int) {
 }
 
 // ForwardClientCertDetails controls how the x-forwarded-client-cert (XFCC)
-// header is handled by the proxies.
+// header is handled by the gateway proxy.
 // See [Envoy XFCC](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto.html#enum-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-forwardclientcertdetails)
 // header handling for more details.
 type ForwardClientCertDetails int32
@@ -103,7 +103,7 @@ type ForwardClientCertDetails int32
 const (
 	// Field is not set
 	ForwardClientCertDetails_UNDEFINED ForwardClientCertDetails = 0
-	// Do not send the XFCC header to the next hop. This is the default value for gateway proxies.
+	// Do not send the XFCC header to the next hop. This is the default value. This is the default value for gateway proxies.
 	ForwardClientCertDetails_SANITIZE ForwardClientCertDetails = 1
 	// When the client connection is mTLS (Mutual TLS), forward the XFCC header
 	// in the request.

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -280,7 +280,7 @@ enum ForwardClientCertDetails {
   // Field is not set
   UNDEFINED = 0;
 
-  // Do not send the XFCC header to the next hop. This is the default value. This is the default value for gateway proxies.
+  // Do not send the XFCC header to the next hop. This is the default value for gateway proxies.
   SANITIZE = 1;
 
   // When the client connection is mTLS (Mutual TLS), forward the XFCC header

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -280,7 +280,7 @@ enum ForwardClientCertDetails {
   // Field is not set
   UNDEFINED = 0;
 
-  // Do not send the XFCC header to the next hop. This is the default value for gateway proxies.
+  // Do not send the XFCC header to the next hop.
   SANITIZE = 1;
 
   // When the client connection is mTLS (Mutual TLS), forward the XFCC header
@@ -292,7 +292,7 @@ enum ForwardClientCertDetails {
   APPEND_FORWARD = 3;
 
   // When the client connection is mTLS, reset the XFCC header with the client
-  // certificate information and send it to the next hop.
+  // certificate information and send it to the next hop. This is the default value for gateway proxies.
   SANITIZE_SET = 4;
 
   // Always forward the XFCC header in the request, regardless of whether the

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -273,7 +273,7 @@ message Topology {
 }
 
 // ForwardClientCertDetails controls how the x-forwarded-client-cert (XFCC)
-// header is handled by the gateway proxy.
+// header is handled by a proxy.
 // See [Envoy XFCC](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto.html#enum-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-forwardclientcertdetails)
 // header handling for more details.
 enum ForwardClientCertDetails {

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -280,7 +280,7 @@ enum ForwardClientCertDetails {
   // Field is not set
   UNDEFINED = 0;
 
-  // Do not send the XFCC header to the next hop. This is the default value.
+  // Do not send the XFCC header to the next hop. This is the default value. This is the default value for gateway proxies.
   SANITIZE = 1;
 
   // When the client connection is mTLS (Mutual TLS), forward the XFCC header
@@ -288,7 +288,7 @@ enum ForwardClientCertDetails {
   FORWARD_ONLY = 2;
 
   // When the client connection is mTLS, append the client certificate
-  // information to the request’s XFCC header and forward it.
+  // information to the request’s XFCC header and forward it. This is the default value for sidecar proxies.
   APPEND_FORWARD = 3;
 
   // When the client connection is mTLS, reset the XFCC header with the client


### PR DESCRIPTION
This PR is clarifying the default value of ForwardClientCertDetails which is SANITIZE_SET for GW (and not SANITIZE as previously stated) and APPEND_FORWARD for sidecar proxies (as written here https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig-ProxyHeaders).