### PR TITLE
Validation: add documentation and use CEL pre-processor

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -19,6 +19,7 @@ followed for Istio APIs.
 - [Proto Guidelines](#proto-guidelines)
     - [Style](#style)
     - [Basic Proto Versioning](#basic-proto-ersioning)
+- [Validation Guidelines](#validation-guidelines)
 - [CRD Guidelines](#crd-guidelines)
     - [Style](#crd-style)
     - [Basic CRD Versioning](#basic-crd-versioning)
@@ -213,6 +214,75 @@ protos.
       configurations beyond X characters upon upgrade, and would not be permitted.
 
     - Loosening validation is permitted. As a result, it is recommended to err on the side of stricter validation.
+
+## Validation Guidelines
+
+All types should have as strict validation specified on it as possible to rule out invalid states.
+These are ultimately compiled to Kubernetes CustomResourceDefinitions, which use OpenAPI validation with some Kubernetes extras.
+This is handled by our own custom [protoc-gen-crd](https://github.com/istio/tools/tree/master/cmd/protoc-gen-crd) which compiles our
+protobuf definitions down to CRDs.
+
+There are a few types of validations:
+* Automatic ones, based on the protobuf type. For example, a UInt32Value automatically has a validation to check the number between `0` and `MaxUint32`
+* Protobuf `field_behavior`. Currently only `[(google.api.field_behavior) = REQUIRED]` is implemented.
+* Comment driven validations (see below).
+
+Most validation is driven by comments on fields and messages.
+All validations in [KubeBuilder](https://book.kubebuilder.io/reference/markers/crd-validation) are supported, as well as some extras:
+
+* `+protoc-gen-crd:map-value-validation`: apply the validation to each *value* in a map. 
+  Note it's not possible to apply validations to each key. You can, however, validate the entire map together with a CEL rule.
+* `+protoc-gen-crd:list-value-validation`: apply the validation to each value in a list.
+* `+protoc-gen-crd:duration-validation:none`: exclude the default requirement that a duration field is non-zero.
+* `+protoc-gen-crd:validation:XIntOrString`: marks a field as accepting integers or strings.
+* `+protoc-gen-crd:validation:IgnoreSubValidation`: if referencing a message in a field, and that message has some validation on it already, exclude the listed validations.
+  This is uncommon, but can be used when referencing a message in a certain context has different rules than others.
+
+The most common validations are:
+* Sizes: `MaxLength` (strings), `MaxItems` (lists), `MaxProperties` (maps)
+* Regex: `Pattern`
+* CEL: `XValidation`
+
+### CEL
+
+[CEL](https://cel.dev/) is a small language that allows us to write expressions to represent validation logic.
+This comes with a lot of quirks!
+
+Useful tools and references:
+* [CEL playground](https://playcel.undistro.io/) allows an easy way to run CEL expressions against some types.
+* [Kubernetes CEL docs](https://kubernetes.io/docs/reference/using-api/cel/).
+* [CEL language definition](https://github.com/google/cel-spec/blob/master/doc/langdef.md).
+
+The biggest challenge with CEL is the complexity limit imposed by Kubernetes.
+This estimates the cost to run the function, and rejects it if it is too high.
+This takes into account the cost of a function and the cost of *potential* inputs.
+This makes it, typically, required to put maximum size bounds on items.
+
+Kubernetes changes version-to-version on how it estimates cost (usually getting more lenient) and what functions are available.
+We want to target the oldest version for compatibility purposes.
+Our tests do not currently cover this (a prototype of doing so can be found [here](https://github.com/istio/api/pull/3275)).
+A list of what features are in which versions can be found [here](https://kubernetes.io/docs/reference/using-api/cel/#cel-options-language-features-and-libraries).
+
+Istio has some custom macros that are expanded at compile time, driven by the [celpp](https://github.com/howardjohn/celpp) package.
+This extends CEL with these capabilities:
+* **default**. Usage: `default(self.x, 'DEF')`.
+* **oneof**. Usage: `oneof(self.x, self.y, self.z)`. This checks that 0 or 1 of these fields is set.
+* **index**. Usage: `self.index({}, x, z, b)`. This does `self.x.z.b` and returns `{}` if any of these is not set.
+
+Unlike typical Go usage, CEL does not have a concept of zero values for unset fields.
+As a result, an optional field needs special care.
+Do not write `self.fruit == 'apple'`, for instance, write `default(self.fruit, '') == 'apple'.
+
+### Testing
+
+As validation logic is really easy to get wrong, it's useful to write tests.
+This is done by adding YAML files under `tests/testdata`.
+Each type has a `valid` and `invalid` file to do positive and negative cases.
+
+Aside from explicitly testing these, these also form the seed corpus for fuzzing when these are pulled into `istio/istio`.
+This fuzz testing verifies the CRD validation has the same result as the webhook (Golang) validation code.
+Currently, this mostly serves to ensure we do not make something overly strict.
+In the future, it may show us that its safe to disable the webhook entirely, if CRD validation can cover the full validation surface.
 
 ## CRD Guidelines
 

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -230,18 +230,18 @@ There are a few types of validations:
 Most validation is driven by comments on fields and messages.
 All validations in [KubeBuilder](https://book.kubebuilder.io/reference/markers/crd-validation) are supported, as well as some extras:
 
-* `+protoc-gen-crd:map-value-validation`: apply the validation to each *value* in a map. 
+- `+protoc-gen-crd:map-value-validation`: apply the validation to each *value* in a map.
   Note it's not possible to apply validations to each key. You can, however, validate the entire map together with a CEL rule.
-* `+protoc-gen-crd:list-value-validation`: apply the validation to each value in a list.
-* `+protoc-gen-crd:duration-validation:none`: exclude the default requirement that a duration field is non-zero.
-* `+protoc-gen-crd:validation:XIntOrString`: marks a field as accepting integers or strings.
-* `+protoc-gen-crd:validation:IgnoreSubValidation`: if referencing a message in a field, and that message has some validation on it already, exclude the listed validations.
+- `+protoc-gen-crd:list-value-validation`: apply the validation to each value in a list.
+- `+protoc-gen-crd:duration-validation:none`: exclude the default requirement that a duration field is non-zero.
+- `+protoc-gen-crd:validation:XIntOrString`: marks a field as accepting integers or strings.
+- `+protoc-gen-crd:validation:IgnoreSubValidation`: if referencing a message in a field, and that message has some validation on it already, exclude the listed validations.
   This is uncommon, but can be used when referencing a message in a certain context has different rules than others.
 
 The most common validations are:
-* Sizes: `MaxLength` (strings), `MaxItems` (lists), `MaxProperties` (maps)
-* Regex: `Pattern`
-* CEL: `XValidation`
+- Sizes: `MaxLength` (strings), `MaxItems` (lists), `MaxProperties` (maps)
+- Regex: `Pattern`
+- CEL: `XValidation`
 
 ### CEL
 

--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -849,7 +849,7 @@ func (x *VmConfig) GetEnv() []*EnvVar {
 	return nil
 }
 
-// +kubebuilder:validation:XValidation:message="value may only be set when valueFrom is INLINE",rule="(has(self.valueFrom) ? self.valueFrom : ”) != 'HOST' || !has(self.value)"
+// +kubebuilder:validation:XValidation:message="value may only be set when valueFrom is INLINE",rule="default(self.valueFrom, ”) != 'HOST' || !has(self.value)"
 type EnvVar struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -539,7 +539,7 @@ func (FailStrategy) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="oneof(self.selector, self.targetRef, self.targetRefs)"
 type WasmPlugin struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -462,7 +462,7 @@ message VmConfig {
   repeated EnvVar env = 1;
 }
 
-// +kubebuilder:validation:XValidation:message="value may only be set when valueFrom is INLINE",rule="(has(self.valueFrom) ? self.valueFrom : '') != 'HOST' || !has(self.value)"
+// +kubebuilder:validation:XValidation:message="value may only be set when valueFrom is INLINE",rule="default(self.valueFrom, '') != 'HOST' || !has(self.value)"
 message EnvVar {
   // Name of the environment variable.
   // Must be a C_IDENTIFIER.

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -236,7 +236,7 @@ option go_package="istio.io/api/extensions/v1alpha1";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="oneof(self.selector, self.targetRef, self.targetRefs)"
 message WasmPlugin {
   // Criteria used to select the specific set of pods/VMs on which
   // this plugin configuration should be applied. If omitted, this

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -7658,9 +7658,9 @@ spec:
                 1 : 0) <= 1'
             - message: CIDR addresses are allowed only for NONE/STATIC resolution
                 types
-              rule: |-
-                !(has(self.addresses) && self.addresses.exists(k, k.contains("/")) && has(self.resolution) &&
-                self.resolution != "STATIC" && self.resolution != "NONE")
+              rule: '!((has(self.addresses) ? self.addresses : []).exists(k, k.contains("/"))
+                && !((has(self.resolution) ? self.resolution : "NONE") in ["STATIC",
+                "NONE"]))'
             - message: NONE mode cannot set endpoints
               rule: '(!has(self.resolution) || self.resolution == "NONE") ? !has(self.endpoints)
                 : true'
@@ -7957,9 +7957,9 @@ spec:
                 1 : 0) <= 1'
             - message: CIDR addresses are allowed only for NONE/STATIC resolution
                 types
-              rule: |-
-                !(has(self.addresses) && self.addresses.exists(k, k.contains("/")) && has(self.resolution) &&
-                self.resolution != "STATIC" && self.resolution != "NONE")
+              rule: '!((has(self.addresses) ? self.addresses : []).exists(k, k.contains("/"))
+                && !((has(self.resolution) ? self.resolution : "NONE") in ["STATIC",
+                "NONE"]))'
             - message: NONE mode cannot set endpoints
               rule: '(!has(self.resolution) || self.resolution == "NONE") ? !has(self.endpoints)
                 : true'
@@ -8256,9 +8256,9 @@ spec:
                 1 : 0) <= 1'
             - message: CIDR addresses are allowed only for NONE/STATIC resolution
                 types
-              rule: |-
-                !(has(self.addresses) && self.addresses.exists(k, k.contains("/")) && has(self.resolution) &&
-                self.resolution != "STATIC" && self.resolution != "NONE")
+              rule: '!((has(self.addresses) ? self.addresses : []).exists(k, k.contains("/"))
+                && !((has(self.resolution) ? self.resolution : "NONE") in ["STATIC",
+                "NONE"]))'
             - message: NONE mode cannot set endpoints
               rule: '(!has(self.resolution) || self.resolution == "NONE") ? !has(self.endpoints)
                 : true'

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -7548,7 +7548,7 @@ spec:
                   - message: Address is required
                     rule: has(self.address) || has(self.network)
                   - message: UDS may not include ports
-                    rule: '(has(self.address) && self.address.startsWith("unix://"))
+                    rule: '(has(self.address) ? self.address : "").startsWith("unix://")
                       ? !has(self.ports) : true'
                 maxItems: 4096
                 type: array
@@ -7662,12 +7662,11 @@ spec:
                 && !((has(self.resolution) ? self.resolution : "NONE") in ["STATIC",
                 "NONE"]))'
             - message: NONE mode cannot set endpoints
-              rule: '(!has(self.resolution) || self.resolution == "NONE") ? !has(self.endpoints)
-                : true'
+              rule: '((has(self.resolution) ? self.resolution : "NONE") == "NONE")
+                ? !has(self.endpoints) : true'
             - message: DNS_ROUND_ROBIN mode cannot have multiple endpoints
-              rule: |-
-                (has(self.resolution) && self.resolution == "DNS_ROUND_ROBIN") ? (!has(self.endpoints) ||
-                size(self.endpoints) == 1) : true
+              rule: '((has(self.resolution) ? self.resolution : "") == "DNS_ROUND_ROBIN")
+                ? ((has(self.endpoints) ? self.endpoints : []).size() <= 1) : true'
           status:
             properties:
               conditions:
@@ -7847,7 +7846,7 @@ spec:
                   - message: Address is required
                     rule: has(self.address) || has(self.network)
                   - message: UDS may not include ports
-                    rule: '(has(self.address) && self.address.startsWith("unix://"))
+                    rule: '(has(self.address) ? self.address : "").startsWith("unix://")
                       ? !has(self.ports) : true'
                 maxItems: 4096
                 type: array
@@ -7961,12 +7960,11 @@ spec:
                 && !((has(self.resolution) ? self.resolution : "NONE") in ["STATIC",
                 "NONE"]))'
             - message: NONE mode cannot set endpoints
-              rule: '(!has(self.resolution) || self.resolution == "NONE") ? !has(self.endpoints)
-                : true'
+              rule: '((has(self.resolution) ? self.resolution : "NONE") == "NONE")
+                ? !has(self.endpoints) : true'
             - message: DNS_ROUND_ROBIN mode cannot have multiple endpoints
-              rule: |-
-                (has(self.resolution) && self.resolution == "DNS_ROUND_ROBIN") ? (!has(self.endpoints) ||
-                size(self.endpoints) == 1) : true
+              rule: '((has(self.resolution) ? self.resolution : "") == "DNS_ROUND_ROBIN")
+                ? ((has(self.endpoints) ? self.endpoints : []).size() <= 1) : true'
           status:
             properties:
               conditions:
@@ -8146,7 +8144,7 @@ spec:
                   - message: Address is required
                     rule: has(self.address) || has(self.network)
                   - message: UDS may not include ports
-                    rule: '(has(self.address) && self.address.startsWith("unix://"))
+                    rule: '(has(self.address) ? self.address : "").startsWith("unix://")
                       ? !has(self.ports) : true'
                 maxItems: 4096
                 type: array
@@ -8260,12 +8258,11 @@ spec:
                 && !((has(self.resolution) ? self.resolution : "NONE") in ["STATIC",
                 "NONE"]))'
             - message: NONE mode cannot set endpoints
-              rule: '(!has(self.resolution) || self.resolution == "NONE") ? !has(self.endpoints)
-                : true'
+              rule: '((has(self.resolution) ? self.resolution : "NONE") == "NONE")
+                ? !has(self.endpoints) : true'
             - message: DNS_ROUND_ROBIN mode cannot have multiple endpoints
-              rule: |-
-                (has(self.resolution) && self.resolution == "DNS_ROUND_ROBIN") ? (!has(self.endpoints) ||
-                size(self.endpoints) == 1) : true
+              rule: '((has(self.resolution) ? self.resolution : "") == "DNS_ROUND_ROBIN")
+                ? ((has(self.endpoints) ? self.endpoints : []).size() <= 1) : true'
           status:
             properties:
               conditions:
@@ -13246,8 +13243,8 @@ spec:
             - message: Address is required
               rule: has(self.address) || has(self.network)
             - message: UDS may not include ports
-              rule: '(has(self.address) && self.address.startsWith("unix://")) ? !has(self.ports)
-                : true'
+              rule: '(has(self.address) ? self.address : "").startsWith("unix://")
+                ? !has(self.ports) : true'
           status:
             properties:
               conditions:
@@ -13406,8 +13403,8 @@ spec:
             - message: Address is required
               rule: has(self.address) || has(self.network)
             - message: UDS may not include ports
-              rule: '(has(self.address) && self.address.startsWith("unix://")) ? !has(self.ports)
-                : true'
+              rule: '(has(self.address) ? self.address : "").startsWith("unix://")
+                ? !has(self.ports) : true'
           status:
             properties:
               conditions:
@@ -13566,8 +13563,8 @@ spec:
             - message: Address is required
               rule: has(self.address) || has(self.network)
             - message: UDS may not include ports
-              rule: '(has(self.address) && self.address.startsWith("unix://")) ? !has(self.ports)
-                : true'
+              rule: '(has(self.address) ? self.address : "").startsWith("unix://")
+                ? !has(self.ports) : true'
           status:
             properties:
               conditions:
@@ -13895,7 +13892,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: UDS may not include ports
-                  rule: '(has(self.address) && self.address.startsWith("unix://"))
+                  rule: '(has(self.address) ? self.address : "").startsWith("unix://")
                     ? !has(self.ports) : true'
             required:
             - template
@@ -14203,7 +14200,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: UDS may not include ports
-                  rule: '(has(self.address) && self.address.startsWith("unix://"))
+                  rule: '(has(self.address) ? self.address : "").startsWith("unix://")
                     ? !has(self.ports) : true'
             required:
             - template
@@ -14511,7 +14508,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: UDS may not include ports
-                  rule: '(has(self.address) && self.address.startsWith("unix://"))
+                  rule: '(has(self.address) ? self.address : "").startsWith("unix://")
                     ? !has(self.ports) : true'
             required:
             - template
@@ -15497,9 +15494,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: portLevelMtls requires selector
-              rule: |-
-                has(self.selector) && has(self.selector.matchLabels) && self.selector.matchLabels.size() > 0 ||
-                !has(self.portLevelMtls)
+              rule: 'has(self.portLevelMtls) ? (((has(self.selector) && has(self.selector.matchLabels))
+                ? self.selector.matchLabels : {}).size() > 0) : true'
           status:
             properties:
               conditions:
@@ -15661,9 +15657,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: portLevelMtls requires selector
-              rule: |-
-                has(self.selector) && has(self.selector.matchLabels) && self.selector.matchLabels.size() > 0 ||
-                !has(self.portLevelMtls)
+              rule: 'has(self.portLevelMtls) ? (((has(self.selector) && has(self.selector.matchLabels))
+                ? self.selector.matchLabels : {}).size() > 0) : true'
           status:
             properties:
               conditions:

--- a/networking/v1/destination_rule_alias.gen.go
+++ b/networking/v1/destination_rule_alias.gen.go
@@ -179,7 +179,7 @@ type LoadBalancerSettings_ConsistentHashLB_RingHash_ = v1alpha3.LoadBalancerSett
 // The Maglev load balancer implements consistent hashing to backend hosts.
 type LoadBalancerSettings_ConsistentHashLB_Maglev = v1alpha3.LoadBalancerSettings_ConsistentHashLB_Maglev
 
-// +kubebuilder:validation:XValidation:message="only one of warmupDurationSecs or warmup can be set",rule="(has(self.warmupDurationSecs)?1:0)+(has(self.warmup)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of warmupDurationSecs or warmup can be set",rule="oneof(self.warmupDurationSecs, self.warmup)"
 // Standard load balancing algorithms that require no tuning.
 type LoadBalancerSettings_SimpleLB = v1alpha3.LoadBalancerSettings_SimpleLB
 

--- a/networking/v1/service_entry_alias.gen.go
+++ b/networking/v1/service_entry_alias.gen.go
@@ -35,7 +35,7 @@ import "istio.io/api/networking/v1alpha3"
 // istiostatus-override: ServiceEntryStatus: istio.io/api/networking/v1alpha3
 // -->
 // +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
-// +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(has(self.addresses) && self.addresses.exists(k, k.contains('/')) && (has(self.resolution) && self.resolution != 'STATIC' && self.resolution != 'NONE'))"
+// +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(default(self.addresses, []).exists(k, k.contains('/')) && !(default(self.resolution, 'NONE') in ['STATIC', 'NONE']))"
 // +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
 // +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"
 type ServiceEntry = v1alpha3.ServiceEntry

--- a/networking/v1/service_entry_alias.gen.go
+++ b/networking/v1/service_entry_alias.gen.go
@@ -36,8 +36,8 @@ import "istio.io/api/networking/v1alpha3"
 // -->
 // +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
 // +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(default(self.addresses, []).exists(k, k.contains('/')) && !(default(self.resolution, 'NONE') in ['STATIC', 'NONE']))"
-// +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
-// +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"
+// +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="default(self.resolution, 'NONE') == 'NONE' ? !has(self.endpoints) : true"
+// +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="default(self.resolution, ”) == 'DNS_ROUND_ROBIN' ? default(self.endpoints, []).size() <= 1 : true"
 type ServiceEntry = v1alpha3.ServiceEntry
 
 // Location specifies whether the service is part of Istio mesh or

--- a/networking/v1/service_entry_alias.gen.go
+++ b/networking/v1/service_entry_alias.gen.go
@@ -34,7 +34,7 @@ import "istio.io/api/networking/v1alpha3"
 // +k8s:deepcopy-gen=true
 // istiostatus-override: ServiceEntryStatus: istio.io/api/networking/v1alpha3
 // -->
-// +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="(has(self.workloadSelector)?1:0)+(has(self.endpoints)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
 // +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(has(self.addresses) && self.addresses.exists(k, k.contains('/')) && (has(self.resolution) && self.resolution != 'STATIC' && self.resolution != 'NONE'))"
 // +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
 // +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"

--- a/networking/v1/workload_entry_alias.gen.go
+++ b/networking/v1/workload_entry_alias.gen.go
@@ -29,5 +29,5 @@ import "istio.io/api/networking/v1alpha3"
 // +k8s:deepcopy-gen=true
 // -->
 // +kubebuilder:validation:XValidation:message="Address is required",rule="has(self.address) || has(self.network)"
-// +kubebuilder:validation:XValidation:message="UDS may not include ports",rule="(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+// +kubebuilder:validation:XValidation:message="UDS may not include ports",rule="(default(self.address, "").startsWith('unix://')) ? !has(self.ports) : true"
 type WorkloadEntry = v1alpha3.WorkloadEntry

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -188,7 +188,7 @@ func (TrafficPolicy_ProxyProtocol_VERSION) EnumDescriptor() ([]byte, []int) {
 	return file_networking_v1alpha3_destination_rule_proto_rawDescGZIP(), []int{1, 2, 0}
 }
 
-// +kubebuilder:validation:XValidation:message="only one of warmupDurationSecs or warmup can be set",rule="(has(self.warmupDurationSecs)?1:0)+(has(self.warmup)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of warmupDurationSecs or warmup can be set",rule="oneof(self.warmupDurationSecs, self.warmup)"
 // Standard load balancing algorithms that require no tuning.
 type LoadBalancerSettings_SimpleLB int32
 

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -379,7 +379,7 @@ message Subset {
 // ```
 //
 message LoadBalancerSettings {
-  // +kubebuilder:validation:XValidation:message="only one of warmupDurationSecs or warmup can be set",rule="(has(self.warmupDurationSecs)?1:0)+(has(self.warmup)?1:0)<=1"
+  // +kubebuilder:validation:XValidation:message="only one of warmupDurationSecs or warmup can be set",rule="oneof(self.warmupDurationSecs, self.warmup)"
   // Standard load balancing algorithms that require no tuning.
   enum SimpleLB {
     // No load balancing algorithm has been specified by the user. Istio

--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -822,7 +822,7 @@ func (EnvoyFilter_Patch_FilterClass) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or workloadSelector can be set",rule="(has(self.workloadSelector)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or workloadSelector can be set",rule="oneof(self.workloadSelector, self.targetRefs)"
 type EnvoyFilter struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -421,7 +421,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or workloadSelector can be set",rule="(has(self.workloadSelector)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or workloadSelector can be set",rule="oneof(self.workloadSelector, self.targetRefs)"
 message EnvoyFilter {
   // `ApplyTo` specifies where in the Envoy configuration, the given patch should be applied.
   enum ApplyTo {

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -592,7 +592,7 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // +k8s:deepcopy-gen=true
 // istiostatus-override: ServiceEntryStatus: istio.io/api/networking/v1alpha3
 // -->
-// +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="(has(self.workloadSelector)?1:0)+(has(self.endpoints)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
 // +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(has(self.addresses) && self.addresses.exists(k, k.contains('/')) && (has(self.resolution) && self.resolution != 'STATIC' && self.resolution != 'NONE'))"
 // +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
 // +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -594,8 +594,8 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // -->
 // +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
 // +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(default(self.addresses, []).exists(k, k.contains('/')) && !(default(self.resolution, 'NONE') in ['STATIC', 'NONE']))"
-// +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
-// +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"
+// +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="default(self.resolution, 'NONE') == 'NONE' ? !has(self.endpoints) : true"
+// +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="default(self.resolution, ”) == 'DNS_ROUND_ROBIN' ? default(self.endpoints, []).size() <= 1 : true"
 type ServiceEntry struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/networking/v1alpha3/service_entry.pb.go
+++ b/networking/v1alpha3/service_entry.pb.go
@@ -593,7 +593,7 @@ func (ServiceEntry_Resolution) EnumDescriptor() ([]byte, []int) {
 // istiostatus-override: ServiceEntryStatus: istio.io/api/networking/v1alpha3
 // -->
 // +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
-// +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(has(self.addresses) && self.addresses.exists(k, k.contains('/')) && (has(self.resolution) && self.resolution != 'STATIC' && self.resolution != 'NONE'))"
+// +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(default(self.addresses, []).exists(k, k.contains('/')) && !(default(self.resolution, 'NONE') in ['STATIC', 'NONE']))"
 // +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
 // +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"
 type ServiceEntry struct {

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -437,7 +437,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +k8s:deepcopy-gen=true
 // istiostatus-override: ServiceEntryStatus: istio.io/api/networking/v1alpha3
 // -->
-// +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="(has(self.workloadSelector)?1:0)+(has(self.endpoints)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
 // +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(has(self.addresses) && self.addresses.exists(k, k.contains('/')) && (has(self.resolution) && self.resolution != 'STATIC' && self.resolution != 'NONE'))"
 // +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
 // +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -438,7 +438,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // istiostatus-override: ServiceEntryStatus: istio.io/api/networking/v1alpha3
 // -->
 // +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
-// +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(has(self.addresses) && self.addresses.exists(k, k.contains('/')) && (has(self.resolution) && self.resolution != 'STATIC' && self.resolution != 'NONE'))"
+// +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(default(self.addresses, []).exists(k, k.contains('/')) && !(default(self.resolution, 'NONE') in ['STATIC', 'NONE']))"
 // +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
 // +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"
 message ServiceEntry {

--- a/networking/v1alpha3/service_entry.proto
+++ b/networking/v1alpha3/service_entry.proto
@@ -439,8 +439,8 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // -->
 // +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
 // +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(default(self.addresses, []).exists(k, k.contains('/')) && !(default(self.resolution, 'NONE') in ['STATIC', 'NONE']))"
-// +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
-// +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"
+// +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="default(self.resolution, 'NONE') == 'NONE' ? !has(self.endpoints) : true"
+// +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="default(self.resolution, '') == 'DNS_ROUND_ROBIN' ? default(self.endpoints, []).size() <= 1 : true"
 message ServiceEntry {
   // The hosts associated with the ServiceEntry. Could be a DNS
   // name with wildcard prefix.

--- a/networking/v1alpha3/workload_entry.pb.go
+++ b/networking/v1alpha3/workload_entry.pb.go
@@ -193,7 +193,7 @@ const (
 // +k8s:deepcopy-gen=true
 // -->
 // +kubebuilder:validation:XValidation:message="Address is required",rule="has(self.address) || has(self.network)"
-// +kubebuilder:validation:XValidation:message="UDS may not include ports",rule="(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+// +kubebuilder:validation:XValidation:message="UDS may not include ports",rule="(default(self.address, "").startsWith('unix://')) ? !has(self.ports) : true"
 type WorkloadEntry struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/networking/v1alpha3/workload_entry.proto
+++ b/networking/v1alpha3/workload_entry.proto
@@ -176,7 +176,7 @@ option go_package = "istio.io/api/networking/v1alpha3";
 // +k8s:deepcopy-gen=true
 // -->
 // +kubebuilder:validation:XValidation:message="Address is required",rule="has(self.address) || has(self.network)"
-// +kubebuilder:validation:XValidation:message="UDS may not include ports",rule="(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+// +kubebuilder:validation:XValidation:message="UDS may not include ports",rule="(default(self.address, "").startsWith('unix://')) ? !has(self.ports) : true"
 message WorkloadEntry {
   // Address associated with the network endpoint without the
   // port.  Domain names can be used if and only if the resolution is set

--- a/networking/v1beta1/destination_rule_alias.gen.go
+++ b/networking/v1beta1/destination_rule_alias.gen.go
@@ -179,7 +179,7 @@ type LoadBalancerSettings_ConsistentHashLB_RingHash_ = v1alpha3.LoadBalancerSett
 // The Maglev load balancer implements consistent hashing to backend hosts.
 type LoadBalancerSettings_ConsistentHashLB_Maglev = v1alpha3.LoadBalancerSettings_ConsistentHashLB_Maglev
 
-// +kubebuilder:validation:XValidation:message="only one of warmupDurationSecs or warmup can be set",rule="(has(self.warmupDurationSecs)?1:0)+(has(self.warmup)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of warmupDurationSecs or warmup can be set",rule="oneof(self.warmupDurationSecs, self.warmup)"
 // Standard load balancing algorithms that require no tuning.
 type LoadBalancerSettings_SimpleLB = v1alpha3.LoadBalancerSettings_SimpleLB
 

--- a/networking/v1beta1/service_entry_alias.gen.go
+++ b/networking/v1beta1/service_entry_alias.gen.go
@@ -35,7 +35,7 @@ import "istio.io/api/networking/v1alpha3"
 // istiostatus-override: ServiceEntryStatus: istio.io/api/networking/v1alpha3
 // -->
 // +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
-// +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(has(self.addresses) && self.addresses.exists(k, k.contains('/')) && (has(self.resolution) && self.resolution != 'STATIC' && self.resolution != 'NONE'))"
+// +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(default(self.addresses, []).exists(k, k.contains('/')) && !(default(self.resolution, 'NONE') in ['STATIC', 'NONE']))"
 // +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
 // +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"
 type ServiceEntry = v1alpha3.ServiceEntry

--- a/networking/v1beta1/service_entry_alias.gen.go
+++ b/networking/v1beta1/service_entry_alias.gen.go
@@ -36,8 +36,8 @@ import "istio.io/api/networking/v1alpha3"
 // -->
 // +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
 // +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(default(self.addresses, []).exists(k, k.contains('/')) && !(default(self.resolution, 'NONE') in ['STATIC', 'NONE']))"
-// +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
-// +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"
+// +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="default(self.resolution, 'NONE') == 'NONE' ? !has(self.endpoints) : true"
+// +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="default(self.resolution, ”) == 'DNS_ROUND_ROBIN' ? default(self.endpoints, []).size() <= 1 : true"
 type ServiceEntry = v1alpha3.ServiceEntry
 
 // Location specifies whether the service is part of Istio mesh or

--- a/networking/v1beta1/service_entry_alias.gen.go
+++ b/networking/v1beta1/service_entry_alias.gen.go
@@ -34,7 +34,7 @@ import "istio.io/api/networking/v1alpha3"
 // +k8s:deepcopy-gen=true
 // istiostatus-override: ServiceEntryStatus: istio.io/api/networking/v1alpha3
 // -->
-// +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="(has(self.workloadSelector)?1:0)+(has(self.endpoints)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of WorkloadSelector or Endpoints can be set",rule="oneof(self.workloadSelector, self.endpoints)"
 // +kubebuilder:validation:XValidation:message="CIDR addresses are allowed only for NONE/STATIC resolution types",rule="!(has(self.addresses) && self.addresses.exists(k, k.contains('/')) && (has(self.resolution) && self.resolution != 'STATIC' && self.resolution != 'NONE'))"
 // +kubebuilder:validation:XValidation:message="NONE mode cannot set endpoints",rule="(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
 // +kubebuilder:validation:XValidation:message="DNS_ROUND_ROBIN mode cannot have multiple endpoints",rule="(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"

--- a/networking/v1beta1/workload_entry_alias.gen.go
+++ b/networking/v1beta1/workload_entry_alias.gen.go
@@ -29,5 +29,5 @@ import "istio.io/api/networking/v1alpha3"
 // +k8s:deepcopy-gen=true
 // -->
 // +kubebuilder:validation:XValidation:message="Address is required",rule="has(self.address) || has(self.network)"
-// +kubebuilder:validation:XValidation:message="UDS may not include ports",rule="(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+// +kubebuilder:validation:XValidation:message="UDS may not include ports",rule="(default(self.address, "").startsWith('unix://')) ? !has(self.ports) : true"
 type WorkloadEntry = v1alpha3.WorkloadEntry

--- a/security/v1/authorization_policy_alias.gen.go
+++ b/security/v1/authorization_policy_alias.gen.go
@@ -28,7 +28,7 @@ import "istio.io/api/security/v1beta1"
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="oneof(self.selector, self.targetRef, self.targetRefs)"
 type AuthorizationPolicy = v1beta1.AuthorizationPolicy
 type AuthorizationPolicy_ExtensionProvider = v1beta1.AuthorizationPolicy_ExtensionProvider
 

--- a/security/v1/peer_authentication_alias.gen.go
+++ b/security/v1/peer_authentication_alias.gen.go
@@ -26,7 +26,7 @@ import "istio.io/api/security/v1beta1"
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="portLevelMtls requires selector",rule="(has(self.selector) && has(self.selector.matchLabels) && self.selector.matchLabels.size() > 0) || !has(self.portLevelMtls)"
+// +kubebuilder:validation:XValidation:message="portLevelMtls requires selector",rule="has(self.portLevelMtls) ? self.index({}, selector, matchLabels).size() > 0 : true"
 type PeerAuthentication = v1beta1.PeerAuthentication
 
 // Mutual TLS settings.

--- a/security/v1/request_authentication_alias.gen.go
+++ b/security/v1/request_authentication_alias.gen.go
@@ -21,7 +21,7 @@ import "istio.io/api/security/v1beta1"
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="oneof(self.selector, self.targetRef, self.targetRefs)"
 type RequestAuthentication = v1beta1.RequestAuthentication
 
 // JSON Web Token (JWT) token format for authentication as defined by

--- a/security/v1/request_authentication_alias.gen.go
+++ b/security/v1/request_authentication_alias.gen.go
@@ -53,7 +53,7 @@ type RequestAuthentication = v1beta1.RequestAuthentication
 // fromHeaders:
 // - "x-goog-iap-jwt-assertion"
 // ```
-// +kubebuilder:validation:XValidation:message="only one of jwks or jwksUri can be set",rule="(has(self.jwksUri)?1:0)+(has(self.jwks_uri)?1:0)+(has(self.jwks)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of jwks or jwksUri can be set",rule="oneof(self.jwksUri, self.jwks_uri, self.jwks)"
 type JWTRule = v1beta1.JWTRule
 
 // This message specifies a header location to extract JWT token.

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -377,7 +377,7 @@ func (AuthorizationPolicy_Action) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="oneof(self.selector, self.targetRef, self.targetRefs)"
 type AuthorizationPolicy struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -270,7 +270,7 @@ option go_package="istio.io/api/security/v1beta1";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="oneof(self.selector, self.targetRef, self.targetRefs)"
 message AuthorizationPolicy {
   // Optional. The selector decides where to apply the authorization policy. The selector will match with workloads
   // in the same namespace as the authorization policy. If the authorization policy is in the root namespace, the selector

--- a/security/v1beta1/peer_authentication.pb.go
+++ b/security/v1beta1/peer_authentication.pb.go
@@ -207,7 +207,7 @@ func (PeerAuthentication_MutualTLS_Mode) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="portLevelMtls requires selector",rule="(has(self.selector) && has(self.selector.matchLabels) && self.selector.matchLabels.size() > 0) || !has(self.portLevelMtls)"
+// +kubebuilder:validation:XValidation:message="portLevelMtls requires selector",rule="has(self.portLevelMtls) ? self.index({}, selector, matchLabels).size() > 0 : true"
 type PeerAuthentication struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/security/v1beta1/peer_authentication.proto
+++ b/security/v1beta1/peer_authentication.proto
@@ -134,7 +134,7 @@ option go_package="istio.io/api/security/v1beta1";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="portLevelMtls requires selector",rule="(has(self.selector) && has(self.selector.matchLabels) && self.selector.matchLabels.size() > 0) || !has(self.portLevelMtls)"
+// +kubebuilder:validation:XValidation:message="portLevelMtls requires selector",rule="has(self.portLevelMtls) ? self.index({}, selector, matchLabels).size() > 0 : true"
 message PeerAuthentication {
   // The selector determines the workloads to apply the PeerAuthentication on. The selector will match with workloads in the
   // same namespace as the policy. If the policy is in the root namespace, the selector will additionally match with workloads in all namespace.

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -393,7 +393,7 @@ func (x *RequestAuthentication) GetJwtRules() []*JWTRule {
 // fromHeaders:
 // - "x-goog-iap-jwt-assertion"
 // ```
-// +kubebuilder:validation:XValidation:message="only one of jwks or jwksUri can be set",rule="(has(self.jwksUri)?1:0)+(has(self.jwks_uri)?1:0)+(has(self.jwks)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of jwks or jwksUri can be set",rule="oneof(self.jwksUri, self.jwks_uri, self.jwks)"
 type JWTRule struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -260,7 +260,7 @@ const (
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="oneof(self.selector, self.targetRef, self.targetRefs)"
 type RequestAuthentication struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -316,7 +316,7 @@ message RequestAuthentication {
 // fromHeaders:
 // - "x-goog-iap-jwt-assertion"
 // ```
-// +kubebuilder:validation:XValidation:message="only one of jwks or jwksUri can be set",rule="(has(self.jwksUri)?1:0)+(has(self.jwks_uri)?1:0)+(has(self.jwks)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of jwks or jwksUri can be set",rule="oneof(self.jwksUri, self.jwks_uri, self.jwks)"
 message JWTRule {
   // Identifies the issuer that issued the JWT. See
   // [issuer](https://tools.ietf.org/html/rfc7519#section-4.1.1)

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -244,7 +244,7 @@ option go_package="istio.io/api/security/v1beta1";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="oneof(self.selector, self.targetRef, self.targetRefs)"
 message RequestAuthentication {
   // Optional. The selector decides where to apply the request authentication policy. The selector will match with workloads
   // in the same namespace as the request authentication policy. If the request authentication policy is in the root namespace,

--- a/telemetry/v1/telemetry_alias.gen.go
+++ b/telemetry/v1/telemetry_alias.gen.go
@@ -205,8 +205,8 @@ type MetricsOverrides = v1alpha1.MetricsOverrides
 // TagOverride specifies an operation to perform on a metric dimension (also
 // known as a `label`). Tags may be added, removed, or have their default
 // values overridden.
-// +kubebuilder:validation:XValidation:message="value must be set when operation is UPSERT",rule="((has(self.operation) ? self.operation : ”) == 'UPSERT') ? self.value != ” : true"
-// +kubebuilder:validation:XValidation:message="value must not be set when operation is REMOVE",rule="((has(self.operation) ? self.operation : ”) == 'REMOVE') ? !has(self.value) : true"
+// +kubebuilder:validation:XValidation:message="value must be set when operation is UPSERT",rule="default(self.operation, ”) == 'UPSERT' ? self.value != ” : true"
+// +kubebuilder:validation:XValidation:message="value must not be set when operation is REMOVE",rule="default(self.operation, ”) == 'REMOVE' ? !has(self.value) : true"
 type MetricsOverrides_TagOverride = v1alpha1.MetricsOverrides_TagOverride
 type MetricsOverrides_TagOverride_Operation = v1alpha1.MetricsOverrides_TagOverride_Operation
 

--- a/telemetry/v1/telemetry_alias.gen.go
+++ b/telemetry/v1/telemetry_alias.gen.go
@@ -27,7 +27,7 @@ import "istio.io/api/telemetry/v1alpha1"
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="oneof(self.selector, self.targetRef, self.targetRefs)"
 type Telemetry = v1alpha1.Telemetry
 
 // Tracing configures tracing behavior for workloads within a mesh.

--- a/telemetry/v1alpha1/telemetry.pb.go
+++ b/telemetry/v1alpha1/telemetry.pb.go
@@ -550,7 +550,7 @@ func (MetricsOverrides_TagOverride_Operation) EnumDescriptor() ([]byte, []int) {
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="oneof(self.selector, self.targetRef, self.targetRefs)"
 type Telemetry struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/telemetry/v1alpha1/telemetry.pb.go
+++ b/telemetry/v1alpha1/telemetry.pb.go
@@ -1514,8 +1514,8 @@ func (x *Tracing_RequestHeader) GetDefaultValue() string {
 // TagOverride specifies an operation to perform on a metric dimension (also
 // known as a `label`). Tags may be added, removed, or have their default
 // values overridden.
-// +kubebuilder:validation:XValidation:message="value must be set when operation is UPSERT",rule="((has(self.operation) ? self.operation : ”) == 'UPSERT') ? self.value != ” : true"
-// +kubebuilder:validation:XValidation:message="value must not be set when operation is REMOVE",rule="((has(self.operation) ? self.operation : ”) == 'REMOVE') ? !has(self.value) : true"
+// +kubebuilder:validation:XValidation:message="value must be set when operation is UPSERT",rule="default(self.operation, ”) == 'UPSERT' ? self.value != ” : true"
+// +kubebuilder:validation:XValidation:message="value must not be set when operation is REMOVE",rule="default(self.operation, ”) == 'REMOVE' ? !has(self.value) : true"
 type MetricsOverrides_TagOverride struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/telemetry/v1alpha1/telemetry.proto
+++ b/telemetry/v1alpha1/telemetry.proto
@@ -635,8 +635,8 @@ message MetricsOverrides {
   // TagOverride specifies an operation to perform on a metric dimension (also
   // known as a `label`). Tags may be added, removed, or have their default
   // values overridden.
-  // +kubebuilder:validation:XValidation:message="value must be set when operation is UPSERT",rule="((has(self.operation) ? self.operation : '') == 'UPSERT') ? self.value != '' : true"
-  // +kubebuilder:validation:XValidation:message="value must not be set when operation is REMOVE",rule="((has(self.operation) ? self.operation : '') == 'REMOVE') ? !has(self.value) : true"
+  // +kubebuilder:validation:XValidation:message="value must be set when operation is UPSERT",rule="default(self.operation, '') == 'UPSERT' ? self.value != '' : true"
+  // +kubebuilder:validation:XValidation:message="value must not be set when operation is REMOVE",rule="default(self.operation, '') == 'REMOVE' ? !has(self.value) : true"
   message TagOverride {
     enum Operation {
       // Insert or Update the tag with the provided value expression. The

--- a/telemetry/v1alpha1/telemetry.proto
+++ b/telemetry/v1alpha1/telemetry.proto
@@ -264,7 +264,7 @@ option go_package = "istio.io/api/telemetry/v1alpha1";
 // +genclient
 // +k8s:deepcopy-gen=true
 // -->
-// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+// +kubebuilder:validation:XValidation:message="only one of targetRefs or selector can be set",rule="oneof(self.selector, self.targetRef, self.targetRefs)"
 message Telemetry {
   // Optional. The selector decides where to apply the policy.
   // If not set, the policy will be applied to all workloads in the


### PR DESCRIPTION
Depends on https://github.com/istio/tools/pull/3050.

This PR adds support for a new cel pre-processor: https://github.com/howardjohn/celpp.

This avoids the need to write incredibly verbose and error prone boilerplate to workaround limitations in the CEL language.

----

This PR has a few commits:
* Run with no changes. The pre-processor formats the CEL expression, so this has some trivial changes
* Incrementally migrate things to the new CEL macros where it makes sense to simplify
* Add documentation for validation (includes more than just the new stuff)