### PR TITLE
Clarify that while this annotation has been deprecated, the label of the same name is still available.

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -521,8 +521,10 @@ Accepted values:
 	SidecarInject = Instance {
 		Name:          "sidecar.istio.io/inject",
 		Description:   "Specifies whether or not an Envoy sidecar should be "+
-                        "automatically injected into the workload. Deprecated in "+
-                        "favor of `sidecar.istio.io/inject` label.",
+                        "automatically injected into the workload. This annotation "+
+                        "has been deprecated in favor of the "+
+                        "`sidecar.istio.io/inject` label documented "+
+                        "[here](/docs/reference/config/labels/#SidecarInject).",
 		FeatureStatus: Beta,
 		Hidden:        false,
 		Deprecated:    true,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -481,7 +481,7 @@ If that backend becomes unhealthy, traffic will sent to <code>us-east</code>.</l
     </tr>
     <tr>
       <th>Description</th>
-      <td><p>Specifies whether or not an Envoy sidecar should be automatically injected into the workload. Deprecated in favor of <code>sidecar.istio.io/inject</code> label.</p>
+      <td><p>Specifies whether or not an Envoy sidecar should be automatically injected into the workload. This annotation has been deprecated in favor of the <code>sidecar.istio.io/inject</code> label documented <a href="/docs/reference/config/labels/#SidecarInject">here</a>.</p>
 </td>
     </tr>
   </tbody>

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -56,7 +56,8 @@ annotations:
   - name: sidecar.istio.io/inject
     featureStatus: Beta
     description: Specifies whether or not an Envoy sidecar should be automatically
-      injected into the workload. Deprecated in favor of `sidecar.istio.io/inject` label.
+      injected into the workload. This annotation has been deprecated in favor of the
+      `sidecar.istio.io/inject` label documented [here](/docs/reference/config/labels/#SidecarInject).
     deprecated: true
     hidden: false
     resources:


### PR DESCRIPTION
The existing wording made it appear (to me at least) that the annotation was deprecated in favour of itself.