### PR TITLE
add missing slash to fix docs path/lint

### DIFF
--- a/networking/v1alpha3/sidecar.pb.go
+++ b/networking/v1alpha3/sidecar.pb.go
@@ -38,7 +38,7 @@
 // out unneeded configuration, to improve scalability of the mesh.
 // A common misunderstanding is that restricting the configuration amounts to *blocking* the traffic.
 // If requests are sent to destinations not included in the scoping, the traffic will be treated as
-// [unmatched traffic](docs/ops/configuration/traffic-management/traffic-routing/#unmatched-traffic), which is often still allowed.
+// [unmatched traffic](/docs/ops/configuration/traffic-management/traffic-routing/#unmatched-traffic), which is often still allowed.
 // The sidecar is not able to enforce an outbound traffic restriction (see [Egress Gateways](/docs/tasks/traffic-management/egress/egress-gateway/) for how to achieve this).
 //
 // Services and configuration in a mesh are organized into one or more

--- a/networking/v1alpha3/sidecar.pb.html
+++ b/networking/v1alpha3/sidecar.pb.html
@@ -21,7 +21,7 @@ This configuration scoping, among <a href="/docs/ops/configuration/mesh/configur
 out unneeded configuration, to improve scalability of the mesh.
 A common misunderstanding is that restricting the configuration amounts to <em>blocking</em> the traffic.
 If requests are sent to destinations not included in the scoping, the traffic will be treated as
-<a href="docs/ops/configuration/traffic-management/traffic-routing/#unmatched-traffic">unmatched traffic</a>, which is often still allowed.
+<a href="/docs/ops/configuration/traffic-management/traffic-routing/#unmatched-traffic">unmatched traffic</a>, which is often still allowed.
 The sidecar is not able to enforce an outbound traffic restriction (see <a href="/docs/tasks/traffic-management/egress/egress-gateway/">Egress Gateways</a> for how to achieve this).</p>
 <p>Services and configuration in a mesh are organized into one or more
 namespaces (e.g., a Kubernetes namespace or a CF org/space). A <code>Sidecar</code>

--- a/networking/v1alpha3/sidecar.proto
+++ b/networking/v1alpha3/sidecar.proto
@@ -39,7 +39,7 @@ import "networking/v1alpha3/virtual_service.proto";
 // out unneeded configuration, to improve scalability of the mesh.
 // A common misunderstanding is that restricting the configuration amounts to *blocking* the traffic.
 // If requests are sent to destinations not included in the scoping, the traffic will be treated as
-// [unmatched traffic](docs/ops/configuration/traffic-management/traffic-routing/#unmatched-traffic), which is often still allowed.
+// [unmatched traffic](/docs/ops/configuration/traffic-management/traffic-routing/#unmatched-traffic), which is often still allowed.
 // The sidecar is not able to enforce an outbound traffic restriction (see [Egress Gateways](/docs/tasks/traffic-management/egress/egress-gateway/) for how to achieve this).
 //
 // Services and configuration in a mesh are organized into one or more


### PR DESCRIPTION
Now the refdocs builder is running again, it has uncovered a missing / introduced in #3308 which is now breaking lint of istio docs.