### PR TITLE
noticed typo in labels gen proto link in description note

### DIFF
--- a/label/labels.gen.go
+++ b/label/labels.gen.go
@@ -172,7 +172,7 @@ The waypoint is assumed to be in the same namespace; for cross-namespace, see "i
 When set or a "Pod" or a "Service", this binds that specific resource to the waypoint.
 When set on a "Namespace", this applies to all "Pod"/"Service" in the namespace.
 
-Note: the waypoint must allow the type, see "stio.io/waypoint-for".
+Note: the waypoint must allow the type, see "istio.io/waypoint-for".
 `,
 		FeatureStatus: Beta,
 		Hidden:        false,

--- a/label/labels.pb.html
+++ b/label/labels.pb.html
@@ -144,7 +144,7 @@ The waypoint is assumed to be in the same namespace; for cross-namespace, see <c
 <p>When set or a <code>Pod</code> or a <code>Service</code>, this binds that specific resource to the waypoint.
 When set on a <code>Namespace</code>, this applies to all <code>Pod</code>/<code>Service</code> in the namespace.</p>
 
-<p>Note: the waypoint must allow the type, see <code>stio.io/waypoint-for</code>.</p>
+<p>Note: the waypoint must allow the type, see <code>istio.io/waypoint-for</code>.</p>
 </td>
     </tr>
   </tbody>

--- a/label/labels.yaml
+++ b/label/labels.yaml
@@ -203,7 +203,7 @@ labels:
       When set or a `Pod` or a `Service`, this binds that specific resource to the waypoint.
       When set on a `Namespace`, this applies to all `Pod`/`Service` in the namespace.
 
-      Note: the waypoint must allow the type, see `stio.io/waypoint-for`.
+      Note: the waypoint must allow the type, see `istio.io/waypoint-for`.
     deprecated: false
     hidden: false
     resources:


### PR DESCRIPTION
There was a typo in the generated files for labels that I noticed when working on istio/istio. Came here to fix the typo and regenerate the files.