### PR TITLE
Add a pod-level opt-out for ambient DNS proxying, in preparation for enabling that by default globally

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -112,10 +112,10 @@ var (
 		},
 	}
 
-	AmbientBypassDnsCapture = Instance {
-		Name:          "ambient.istio.io/bypass-dns-capture",
-		Description:   `When specified on a "Pod" enrolled in ambient mesh, DNS traffic (TCP and UDP on port 53) will not be captured or proxied.
-This will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.
+	AmbientBypassInboundCapture = Instance {
+		Name:          "ambient.istio.io/bypass-inbound-capture",
+		Description:   `When specified on a "Pod" enrolled in ambient mesh, only outbound traffic will be captured.
+This is intended to be used when enrolling a workload that only receives traffic from out-of-the-mesh clients, such as third party ingress controllers.
 `,
 		FeatureStatus: Alpha,
 		Hidden:        true,
@@ -125,10 +125,10 @@ This will break some Istio features, such as ServiceEntries and egress waypoints
 		},
 	}
 
-	AmbientBypassInboundCapture = Instance {
-		Name:          "ambient.istio.io/bypass-inbound-capture",
-		Description:   `When specified on a "Pod" enrolled in ambient mesh, only outbound traffic will be captured.
-This is intended to be used when enrolling a workload that only receives traffic from out-of-the-mesh clients, such as third party ingress controllers.
+	AmbientDnsCapture = Instance {
+		Name:          "ambient.istio.io/dns-capture",
+		Description:   `When specified on a "Pod" enrolled in ambient mesh, controls whether DNS traffic (TCP and UDP on port 53) will be captured or proxied in ambient.
+Note that setting this to "false" will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.
 `,
 		FeatureStatus: Alpha,
 		Hidden:        true,
@@ -908,8 +908,8 @@ func AllResourceAnnotations() []*Instance {
 	return []*Instance {
 		&AlphaCanonicalServiceAccounts,
 		&AlphaKubernetesServiceAccounts,
-		&AmbientBypassDnsCapture,
 		&AmbientBypassInboundCapture,
+		&AmbientDnsCapture,
 		&AmbientRedirection,
 		&AmbientWaypointInboundBinding,
 		&GalleyAnalyzeSuppress,

--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -127,7 +127,7 @@ This is intended to be used when enrolling a workload that only receives traffic
 
 	AmbientDnsCapture = Instance {
 		Name:          "ambient.istio.io/dns-capture",
-		Description:   `When specified on a "Pod" enrolled in ambient mesh, controls whether DNS traffic (TCP and UDP on port 53) will be captured or proxied in ambient.
+		Description:   `When specified on a "Pod" enrolled in ambient mesh, controls whether DNS traffic (TCP and UDP on port 53) will be captured and proxied in ambient.
 Note that setting this to "false" will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.
 `,
 		FeatureStatus: Alpha,

--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -112,6 +112,19 @@ var (
 		},
 	}
 
+	AmbientBypassDnsCapture = Instance {
+		Name:          "ambient.istio.io/bypass-dns-capture",
+		Description:   `When specified on a "Pod" enrolled in ambient mesh, DNS traffic (TCP and UDP on port 53) will not be captured or proxied.
+This will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.
+`,
+		FeatureStatus: Alpha,
+		Hidden:        true,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Pod,
+		},
+	}
+
 	AmbientBypassInboundCapture = Instance {
 		Name:          "ambient.istio.io/bypass-inbound-capture",
 		Description:   `When specified on a "Pod" enrolled in ambient mesh, only outbound traffic will be captured.
@@ -895,6 +908,7 @@ func AllResourceAnnotations() []*Instance {
 	return []*Instance {
 		&AlphaCanonicalServiceAccounts,
 		&AlphaKubernetesServiceAccounts,
+		&AmbientBypassDnsCapture,
 		&AmbientBypassInboundCapture,
 		&AmbientRedirection,
 		&AmbientWaypointInboundBinding,

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -586,7 +586,7 @@ annotations:
   - name: ambient.istio.io/dns-capture
     featureStatus: Alpha
     description: |
-      When specified on a `Pod` enrolled in ambient mesh, controls whether DNS traffic (TCP and UDP on port 53) will be captured or proxied in ambient.
+      When specified on a `Pod` enrolled in ambient mesh, controls whether DNS traffic (TCP and UDP on port 53) will be captured and proxied in ambient.
       Note that setting this to `false` will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.
     deprecated: false
     hidden: true

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -582,3 +582,13 @@ annotations:
     hidden: false
     resources:
       - Pod
+
+  - name: ambient.istio.io/bypass-dns-capture
+    featureStatus: Alpha
+    description: |
+      When specified on a `Pod` enrolled in ambient mesh, DNS traffic (TCP and UDP on port 53) will not be captured or proxied.
+      This will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.
+    deprecated: false
+    hidden: true
+    resources:
+      - Pod

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -583,11 +583,11 @@ annotations:
     resources:
       - Pod
 
-  - name: ambient.istio.io/bypass-dns-capture
+  - name: ambient.istio.io/dns-capture
     featureStatus: Alpha
     description: |
-      When specified on a `Pod` enrolled in ambient mesh, DNS traffic (TCP and UDP on port 53) will not be captured or proxied.
-      This will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.
+      When specified on a `Pod` enrolled in ambient mesh, controls whether DNS traffic (TCP and UDP on port 53) will be captured or proxied in ambient.
+      Note that setting this to `false` will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.
     deprecated: false
     hidden: true
     resources:

--- a/releasenotes/notes/3361.yaml
+++ b/releasenotes/notes/3361.yaml
@@ -5,4 +5,4 @@ issue:
 - 49829
 releaseNotes:
 - |
-    **Added** `ambient.istio.io/bypass-dns-capture` annotation. When specified on a `Pod` enrolled in ambient mesh, DNS traffic (TCP and UDP on port 53) will not be captured or proxied. This will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.
+    **Added** `ambient.istio.io/dns-capture` annotation. When specified on a `Pod` enrolled in ambient mesh, DNS traffic (TCP and UDP on port 53) will not be captured or proxied. This will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.

--- a/releasenotes/notes/3361.yaml
+++ b/releasenotes/notes/3361.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 49829
+releaseNotes:
+- |
+    **Added** `ambient.istio.io/bypass-dns-capture` annotation. When specified on a `Pod` enrolled in ambient mesh, DNS traffic (TCP and UDP on port 53) will not be captured or proxied. This will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.


### PR DESCRIPTION
Relates to https://github.com/istio/istio/issues/49829

This is the API side, putting it up for comment/TOC approval with a hold, impl pending.