### PR TITLE
Update telemetry docs to reflect GAMMA-style attachment doesn't work

### DIFF
--- a/telemetry/v1alpha1/telemetry.pb.go
+++ b/telemetry/v1alpha1/telemetry.pb.go
@@ -562,9 +562,8 @@ type Telemetry struct {
 	// applied to. The targeted resources specified will determine which workloads
 	// the policy applies to.
 	//
-	// Currently, the following resource attachment types are supported:
+	// Currently, the following resource attachment type is supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
-	// * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/telemetry/v1alpha1/telemetry.pb.html
+++ b/telemetry/v1alpha1/telemetry.pb.html
@@ -224,10 +224,9 @@ No
 <p>Optional. The targetRefs specifies a list of resources the policy should be
 applied to. The targeted resources specified will determine which workloads
 the policy applies to.</p>
-<p>Currently, the following resource attachment types are supported:</p>
+<p>Currently, the following resource attachment type is supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
-<li><code>kind: Service</code> with <code>group: &quot;&quot;</code> or <code>group: &quot;core&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/telemetry/v1alpha1/telemetry.proto
+++ b/telemetry/v1alpha1/telemetry.proto
@@ -274,9 +274,8 @@ message Telemetry {
   // applied to. The targeted resources specified will determine which workloads
   // the policy applies to.
   //
-  // Currently, the following resource attachment types are supported:
+  // Currently, the following resource attachment type is supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
-  // * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.


### PR DESCRIPTION
This works:

```
apiVersion: telemetry.istio.io/v1
kind: Telemetry
metadata:
  name: logs
  namespace: default
spec:
  targetRefs:
  - kind: Gateway
    name: waypoint
    group: gateway.networking.k8s.io
  accessLogging:
  - providers:
    - name: envoy
```

This does not:

``` 
apiVersion: telemetry.istio.io/v1
kind: Telemetry
metadata:
  name: logs
  namespace: default
spec:
  targetRefs:
  - kind: Service
    name: ratings
    group: ""
  accessLogging:
  - providers:
    - name: envoy
```