### PR TITLE
doc: Adds explanation of the '~' character to networking.istio.io/exportTo annotation

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -326,8 +326,8 @@ This takes the format: "<protocol>" or "<protocol>/<port>".
 	NetworkingExportTo = Instance {
 		Name:          "networking.istio.io/exportTo",
 		Description:   "Specifies the namespaces to which this service should be "+
-                        "exported to. A value of '*' indicates it is reachable "+
-                        "within the mesh '.' indicates it is reachable within its "+
+                        "exported to. A value of `*` indicates it is reachable "+
+                        "within the mesh. `.` indicates it is reachable within its "+
                         "namespace. '~' indicates it is hidden and exported to no "+
                         "namespaces. Additionally, a list of comma separated "+
                         "namespace names can be specified.",

--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -328,7 +328,9 @@ This takes the format: "<protocol>" or "<protocol>/<port>".
 		Description:   "Specifies the namespaces to which this service should be "+
                         "exported to. A value of '*' indicates it is reachable "+
                         "within the mesh '.' indicates it is reachable within its "+
-                        "namespace.",
+                        "namespace. '~' indicates it is hidden and exported to no "+
+                        "namespaces. Additionally, a list of comma separated "+
+                        "namespace names can be specified.",
 		FeatureStatus: Alpha,
 		Hidden:        false,
 		Deprecated:    false,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -182,7 +182,7 @@ User should not manually modify this annotation.</p>
     </tr>
     <tr>
       <th>Description</th>
-      <td><p>Specifies the namespaces to which this service should be exported to. A value of &lsquo;*&rsquo; indicates it is reachable within the mesh &lsquo;.&rsquo; indicates it is reachable within its namespace. &lsquo;~&rsquo; indicates it is hidden and exported to no namespaces. Additionally, a list of comma separated namespace names can be specified.</p>
+      <td><p>Specifies the namespaces to which this service should be exported to. A value of <code>*</code> indicates it is reachable within the mesh. <code>.</code> indicates it is reachable within its namespace. &lsquo;~&rsquo; indicates it is hidden and exported to no namespaces. Additionally, a list of comma separated namespace names can be specified.</p>
 </td>
     </tr>
   </tbody>

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -182,7 +182,7 @@ User should not manually modify this annotation.</p>
     </tr>
     <tr>
       <th>Description</th>
-      <td><p>Specifies the namespaces to which this service should be exported to. A value of &lsquo;*&rsquo; indicates it is reachable within the mesh &lsquo;.&rsquo; indicates it is reachable within its namespace.</p>
+      <td><p>Specifies the namespaces to which this service should be exported to. A value of &lsquo;*&rsquo; indicates it is reachable within the mesh &lsquo;.&rsquo; indicates it is reachable within its namespace. &lsquo;~&rsquo; indicates it is hidden and exported to no namespaces. Additionally, a list of comma separated namespace names can be specified.</p>
 </td>
     </tr>
   </tbody>

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -47,7 +47,7 @@ annotations:
     featureStatus: Alpha
     description: Specifies the namespaces to which this service should be exported to.
       A value of '*' indicates it is reachable within the mesh '.' indicates it is
-      reachable within its namespace.
+      reachable within its namespace. '~' indicates it is hidden and exported to no namespaces.
     deprecated: false
     hidden: false
     resources:

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -47,7 +47,7 @@ annotations:
     featureStatus: Alpha
     description: Specifies the namespaces to which this service should be exported to.
       A value of '*' indicates it is reachable within the mesh '.' indicates it is
-      reachable within its namespace. '~' indicates it is hidden and exported to no namespaces.
+      reachable within its namespace. '~' indicates it is hidden and exported to no namespaces. Additionally, a list of comma separated namespace names can be specified.
     deprecated: false
     hidden: false
     resources:


### PR DESCRIPTION
I couldn't see any explanation of what the '~' character does for this annotation , but it seems like it is supposed to set visibility to nothing: 

https://github.com/istio/istio/blob/055e235292052c100688def4bee9c63b3fab830c/pilot/pkg/serviceregistry/kube/conversion_test.go#L305

https://istio.slack.com/archives/C37A4KAAD/p1728324326776739?thread_ts=1728036926.260279&cid=C37A4KAAD