### PR TITLE
Validation: PolicyTargetReference to target GatewayClass

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -179,10 +179,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -215,10 +215,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               type:
@@ -6441,10 +6441,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               workloadSelector:
@@ -14877,10 +14877,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -14913,10 +14913,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -15259,10 +15259,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -15295,10 +15295,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -15934,10 +15934,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -15970,10 +15970,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -16229,10 +16229,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -16265,10 +16265,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -16602,10 +16602,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -16638,10 +16638,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               tracing:
@@ -17062,10 +17062,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -17098,10 +17098,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               tracing:

--- a/releasenotes/notes/3412.yaml
+++ b/releasenotes/notes/3412.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/54696
+releaseNotes:
+- |
+  **Added** GatewayClass.gateway.networking.k8s.io as a valid PolicyTargetReference

--- a/type/v1beta1/selector.pb.go
+++ b/type/v1beta1/selector.pb.go
@@ -248,7 +248,9 @@ func (x *PortSelector) GetNumber() uint32 {
 //	      ports: ["8080"]
 //
 // ```
-// +kubebuilder:validation:XValidation:message="Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",rule="[self.group, self.kind] in [['core','Service'], [”,'Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+//
+// When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.
+// +kubebuilder:validation:XValidation:message="Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass",rule="[self.group, self.kind] in [['core','Service'], [”,'Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry'], ['gateway.networking.k8s.io','GatewayClass']]"
 type PolicyTargetReference struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// group is the group of the target resource.

--- a/type/v1beta1/selector.pb.html
+++ b/type/v1beta1/selector.pb.html
@@ -93,6 +93,7 @@ spec:
         methods: [&quot;POST&quot;]
         ports: [&quot;8080&quot;]
 </code></pre>
+<p>When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.</p>
 
 <table class="message-fields">
 <thead>

--- a/type/v1beta1/selector.proto
+++ b/type/v1beta1/selector.proto
@@ -106,7 +106,9 @@ enum WorkloadMode {
 //         methods: ["POST"]
 //         ports: ["8080"]
 // ```
-// +kubebuilder:validation:XValidation:message="Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",rule="[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+// 
+// When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.
+// +kubebuilder:validation:XValidation:message="Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass",rule="[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry'], ['gateway.networking.k8s.io','GatewayClass']]"
 message PolicyTargetReference {
   // group is the group of the target resource.
   // +kubebuilder:validation:MaxLength=253


### PR DESCRIPTION
Adjusted CEL to allow PolicyTargetReference to target Kubernetes GatewayAPI GatewayClass.

The initial intended use is to allow setting a default policy configuration for all Gateways derived from a GatewayClass by creating a policy in the root namespace (usually istio-system) and targeting the desired GatewayClass. For a more concrete example, this would enable expressing a global default deny posture for all waypoint proxies in Ambient data plane mode. Please reference https://github.com/istio/istio/issues/54696 for further detail on the need for this adjustement.