### PR TITLE
Validation: remove CEL for PolicyTargetRef to allow vendor extensions

### DIFF
--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -559,7 +559,9 @@ type WasmPlugin struct {
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace.
 	// * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
+	// * `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/extensions/v1alpha1/wasm.pb.html
+++ b/extensions/v1alpha1/wasm.pb.html
@@ -206,7 +206,9 @@ the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
+<li><code>kind: GatewayClass</code> with <code>group: gateway.networking.k8s.io</code> in the root namespace.</li>
 <li><code>kind: Service</code> with <code>group: &quot;&quot;</code> or <code>group: &quot;core&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
+<li><code>kind: ServiceEntry</code> with <code>group: networking.istio.io</code> in the same namespace.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -257,7 +257,9 @@ message WasmPlugin {
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace.
   // * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
+  // * `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -179,10 +179,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -215,10 +215,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               type:
@@ -6441,10 +6441,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               workloadSelector:
@@ -14877,10 +14877,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -14913,10 +14913,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -15259,10 +15259,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -15295,10 +15295,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -15934,10 +15934,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -15970,10 +15970,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -16229,10 +16229,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -16265,10 +16265,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -16602,10 +16602,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -16638,10 +16638,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               tracing:
@@ -17062,10 +17062,10 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway
+                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                   rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                     ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"]]'
+                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -17098,10 +17098,10 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway
+                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
                     rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
                       ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"]]'
+                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               tracing:

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -177,12 +177,6 @@ spec:
                 - kind
                 - name
                 type: object
-                x-kubernetes-validations:
-                - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                  rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                    ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -213,12 +207,6 @@ spec:
                   - kind
                   - name
                   type: object
-                  x-kubernetes-validations:
-                  - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                    rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                      ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               type:
@@ -6439,12 +6427,6 @@ spec:
                   - kind
                   - name
                   type: object
-                  x-kubernetes-validations:
-                  - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                    rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                      ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               workloadSelector:
@@ -14875,12 +14857,6 @@ spec:
                 - kind
                 - name
                 type: object
-                x-kubernetes-validations:
-                - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                  rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                    ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -14911,12 +14887,6 @@ spec:
                   - kind
                   - name
                   type: object
-                  x-kubernetes-validations:
-                  - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                    rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                      ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -15257,12 +15227,6 @@ spec:
                 - kind
                 - name
                 type: object
-                x-kubernetes-validations:
-                - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                  rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                    ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -15293,12 +15257,6 @@ spec:
                   - kind
                   - name
                   type: object
-                  x-kubernetes-validations:
-                  - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                    rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                      ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -15932,12 +15890,6 @@ spec:
                 - kind
                 - name
                 type: object
-                x-kubernetes-validations:
-                - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                  rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                    ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -15968,12 +15920,6 @@ spec:
                   - kind
                   - name
                   type: object
-                  x-kubernetes-validations:
-                  - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                    rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                      ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -16227,12 +16173,6 @@ spec:
                 - kind
                 - name
                 type: object
-                x-kubernetes-validations:
-                - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                  rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                    ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -16263,12 +16203,6 @@ spec:
                   - kind
                   - name
                   type: object
-                  x-kubernetes-validations:
-                  - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                    rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                      ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
             type: object
@@ -16600,12 +16534,6 @@ spec:
                 - kind
                 - name
                 type: object
-                x-kubernetes-validations:
-                - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                  rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                    ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -16636,12 +16564,6 @@ spec:
                   - kind
                   - name
                   type: object
-                  x-kubernetes-validations:
-                  - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                    rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                      ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               tracing:
@@ -17060,12 +16982,6 @@ spec:
                 - kind
                 - name
                 type: object
-                x-kubernetes-validations:
-                - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                    gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                  rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                    ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                    "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
               targetRefs:
                 description: Optional.
                 items:
@@ -17096,12 +17012,6 @@ spec:
                   - kind
                   - name
                   type: object
-                  x-kubernetes-validations:
-                  - message: Support kinds are core/Service, networking.istio.io/ServiceEntry,
-                      gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass
-                    rule: '[self.group, self.kind] in [["core", "Service"], ["", "Service"],
-                      ["gateway.networking.k8s.io", "Gateway"], ["networking.istio.io",
-                      "ServiceEntry"], ["gateway.networking.k8s.io", "GatewayClass"]]'
                 maxItems: 16
                 type: array
               tracing:

--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -838,7 +838,9 @@ type EnvoyFilter struct {
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace.
 	// * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
+	// * `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/networking/v1alpha3/envoy_filter.pb.html
+++ b/networking/v1alpha3/envoy_filter.pb.html
@@ -391,7 +391,9 @@ the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
+<li><code>kind: GatewayClass</code> with <code>group: gateway.networking.k8s.io</code> in the root namespace.</li>
 <li><code>kind: Service</code> with <code>&quot;&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
+<li><code>kind: ServiceEntry</code> with <code>group: networking.istio.io</code> in the same namespace.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -856,7 +856,9 @@ message EnvoyFilter {
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace.
   // * `kind: Service` with `""` in the same namespace. This type is only supported for waypoints.
+  // * `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/releasenotes/notes/3412.yaml
+++ b/releasenotes/notes/3412.yaml
@@ -5,4 +5,4 @@ issue:
   - https://github.com/istio/istio/issues/54696
 releaseNotes:
 - |
-  **Added** GatewayClass.gateway.networking.k8s.io as a valid PolicyTargetReference
+  **Removed** CEL validation of group/kind for PolicyTargetReference to enable vendor extensions

--- a/releasenotes/notes/3412.yaml
+++ b/releasenotes/notes/3412.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/54696
+releaseNotes:
+- |
+  **Added** GatewayClass.gateway.networking.k8s.io as a valid PolicyTargetReference

--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -396,7 +396,9 @@ type AuthorizationPolicy struct {
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace.
 	// * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
+	// * `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -230,7 +230,9 @@ the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
+<li><code>kind: GatewayClass</code> with <code>group: gateway.networking.k8s.io</code> in the root namespace.</li>
 <li><code>kind: Service</code> with <code>group: &quot;&quot;</code> or <code>group: &quot;core&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
+<li><code>kind: ServiceEntry</code> with <code>group: networking.istio.io</code> in the same namespace.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -290,7 +290,9 @@ message AuthorizationPolicy {
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace.
   // * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
+  // * `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -279,7 +279,9 @@ type RequestAuthentication struct {
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace.
 	// * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
+	// * `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -228,7 +228,9 @@ the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
+<li><code>kind: GatewayClass</code> with <code>group: gateway.networking.k8s.io</code> in the root namespace.</li>
 <li><code>kind: Service</code> with <code>group: &quot;&quot;</code> or <code>group: &quot;core&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
+<li><code>kind: ServiceEntry</code> with <code>group: networking.istio.io</code> in the same namespace.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -264,7 +264,9 @@ message RequestAuthentication {
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace.
   // * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
+  // * `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/telemetry/v1alpha1/telemetry.pb.go
+++ b/telemetry/v1alpha1/telemetry.pb.go
@@ -567,7 +567,9 @@ type Telemetry struct {
 	//
 	// Currently, the following resource attachment types are supported:
 	// * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+	// * `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace.
 	// * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
+	// * `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.
 	//
 	// If not set, the policy is applied as defined by the selector.
 	// At most one of the selector and targetRefs can be set.

--- a/telemetry/v1alpha1/telemetry.pb.html
+++ b/telemetry/v1alpha1/telemetry.pb.html
@@ -228,7 +228,9 @@ the policy applies to.</p>
 <p>Currently, the following resource attachment types are supported:</p>
 <ul>
 <li><code>kind: Gateway</code> with <code>group: gateway.networking.k8s.io</code> in the same namespace.</li>
+<li><code>kind: GatewayClass</code> with <code>group: gateway.networking.k8s.io</code> in the root namespace.</li>
 <li><code>kind: Service</code> with <code>group: &quot;&quot;</code> or <code>group: &quot;core&quot;</code> in the same namespace. This type is only supported for waypoints.</li>
+<li><code>kind: ServiceEntry</code> with <code>group: networking.istio.io</code> in the same namespace.</li>
 </ul>
 <p>If not set, the policy is applied as defined by the selector.
 At most one of the selector and targetRefs can be set.</p>

--- a/telemetry/v1alpha1/telemetry.proto
+++ b/telemetry/v1alpha1/telemetry.proto
@@ -282,7 +282,9 @@ message Telemetry {
   //
   // Currently, the following resource attachment types are supported:
   // * `kind: Gateway` with `group: gateway.networking.k8s.io` in the same namespace.
+  // * `kind: GatewayClass` with `group: gateway.networking.k8s.io` in the root namespace.
   // * `kind: Service` with `group: ""` or `group: "core"` in the same namespace. This type is only supported for waypoints.
+  // * `kind: ServiceEntry` with `group: networking.istio.io` in the same namespace.
   //
   // If not set, the policy is applied as defined by the selector.
   // At most one of the selector and targetRefs can be set.

--- a/type/v1beta1/selector.pb.go
+++ b/type/v1beta1/selector.pb.go
@@ -250,7 +250,8 @@ func (x *PortSelector) GetNumber() uint32 {
 // ```
 //
 // When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.
-// +kubebuilder:validation:XValidation:message="Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass",rule="[self.group, self.kind] in [['core','Service'], [”,'Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry'], ['gateway.networking.k8s.io','GatewayClass']]"
+//
+// Supported kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, and gateway.networking.k8s.io/GatewayClass
 type PolicyTargetReference struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// group is the group of the target resource.

--- a/type/v1beta1/selector.pb.go
+++ b/type/v1beta1/selector.pb.go
@@ -248,7 +248,9 @@ func (x *PortSelector) GetNumber() uint32 {
 //	      ports: ["8080"]
 //
 // ```
-// +kubebuilder:validation:XValidation:message="Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",rule="[self.group, self.kind] in [['core','Service'], [”,'Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+//
+// When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.
+// +kubebuilder:validation:XValidation:message="Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass",rule="[self.group, self.kind] in [['core','Service'], [”,'Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry'], ['gateway.networking.k8s.io','GatewayClass']]"
 type PolicyTargetReference struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// group is the group of the target resource.

--- a/type/v1beta1/selector.pb.go
+++ b/type/v1beta1/selector.pb.go
@@ -250,8 +250,6 @@ func (x *PortSelector) GetNumber() uint32 {
 // ```
 //
 // When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.
-//
-// Supported kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, and gateway.networking.k8s.io/GatewayClass
 type PolicyTargetReference struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// group is the group of the target resource.

--- a/type/v1beta1/selector.pb.html
+++ b/type/v1beta1/selector.pb.html
@@ -93,6 +93,7 @@ spec:
         methods: [&quot;POST&quot;]
         ports: [&quot;8080&quot;]
 </code></pre>
+<p>When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.</p>
 
 <table class="message-fields">
 <thead>

--- a/type/v1beta1/selector.pb.html
+++ b/type/v1beta1/selector.pb.html
@@ -94,7 +94,6 @@ spec:
         ports: [&quot;8080&quot;]
 </code></pre>
 <p>When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.</p>
-<p>Supported kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, and gateway.networking.k8s.io/GatewayClass</p>
 
 <table class="message-fields">
 <thead>

--- a/type/v1beta1/selector.pb.html
+++ b/type/v1beta1/selector.pb.html
@@ -94,6 +94,7 @@ spec:
         ports: [&quot;8080&quot;]
 </code></pre>
 <p>When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.</p>
+<p>Supported kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, and gateway.networking.k8s.io/GatewayClass</p>
 
 <table class="message-fields">
 <thead>

--- a/type/v1beta1/selector.proto
+++ b/type/v1beta1/selector.proto
@@ -106,7 +106,9 @@ enum WorkloadMode {
 //         methods: ["POST"]
 //         ports: ["8080"]
 // ```
-// +kubebuilder:validation:XValidation:message="Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",rule="[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+// 
+// When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.
+// +kubebuilder:validation:XValidation:message="Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass",rule="[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry'], ['gateway.networking.k8s.io','GatewayClass']]"
 message PolicyTargetReference {
   // group is the group of the target resource.
   // +kubebuilder:validation:MaxLength=253

--- a/type/v1beta1/selector.proto
+++ b/type/v1beta1/selector.proto
@@ -108,8 +108,6 @@ enum WorkloadMode {
 // ```
 // 
 // When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.
-//
-// Supported kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, and gateway.networking.k8s.io/GatewayClass
 message PolicyTargetReference {
   // group is the group of the target resource.
   // +kubebuilder:validation:MaxLength=253

--- a/type/v1beta1/selector.proto
+++ b/type/v1beta1/selector.proto
@@ -108,7 +108,8 @@ enum WorkloadMode {
 // ```
 // 
 // When binding to a GatewayClass resource using PolicyTargetReference, your policy must be in the root namespace.
-// +kubebuilder:validation:XValidation:message="Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, gateway.networking.k8s.io/GatewayClass",rule="[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry'], ['gateway.networking.k8s.io','GatewayClass']]"
+//
+// Supported kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway, and gateway.networking.k8s.io/GatewayClass
 message PolicyTargetReference {
   // group is the group of the target resource.
   // +kubebuilder:validation:MaxLength=253


### PR DESCRIPTION
This PR removes CEL validation from PolicyTargetRef for two primary reasons:

1. Allow vendor extensions by allowing Istio policy to target non-Istio references
2. Allow Istio policy to target a GatewayClass