### PR TITLE
AuthorizationPolicy serviceAccount: allow same namespace

### DIFF
--- a/security/v1beta1/authorization_policy.pb.go
+++ b/security/v1beta1/authorization_policy.pb.go
@@ -640,6 +640,7 @@ type Source struct {
 	// This field requires mTLS enabled and is the same as the `source.serviceaccount` attribute.
 	//
 	// This takes the format `<namespace>/<serviceaccount>`.
+	// `<serviceaccount>` may also be used to use the same namespace as the `AuthorizationPolicy`.
 	//
 	// If not set, any service account is allowed.
 	//
@@ -652,6 +653,7 @@ type Source struct {
 	// Optional. A list of negative match of Kubernetes service accounts.
 	//
 	// This takes the format `<namespace>/<serviceaccount>`.
+	// `<serviceaccount>` may also be used to use the same namespace as the `AuthorizationPolicy`.
 	//
 	// No form of wildcard (`*`) is allowed.
 	// +protoc-gen-crd:list-value-validation:MaxLength=320

--- a/security/v1beta1/authorization_policy.pb.html
+++ b/security/v1beta1/authorization_policy.pb.html
@@ -557,7 +557,8 @@ This field requires mTLS enabled and is the same as the <code>source.namespace</
 <td>
 <p>A list of Kubernetes service accounts derived from the peer certificate.
 This field requires mTLS enabled and is the same as the <code>source.serviceaccount</code> attribute.</p>
-<p>This takes the format <code>&lt;namespace&gt;/&lt;serviceaccount&gt;</code>.</p>
+<p>This takes the format <code>&lt;namespace&gt;/&lt;serviceaccount&gt;</code>.
+<code>&lt;serviceaccount&gt;</code> may also be used to use the same namespace as the <code>AuthorizationPolicy</code>.</p>
 <p>If not set, any service account is allowed.</p>
 <p>No form of wildcard (<code>*</code>) is allowed.
 Cannot be set with <code>principals</code> or <code>namespaces</code>.</p>
@@ -570,7 +571,8 @@ Cannot be set with <code>principals</code> or <code>namespaces</code>.</p>
 </div></td>
 <td>
 <p>A list of negative match of Kubernetes service accounts.</p>
-<p>This takes the format <code>&lt;namespace&gt;/&lt;serviceaccount&gt;</code>.</p>
+<p>This takes the format <code>&lt;namespace&gt;/&lt;serviceaccount&gt;</code>.
+<code>&lt;serviceaccount&gt;</code> may also be used to use the same namespace as the <code>AuthorizationPolicy</code>.</p>
 <p>No form of wildcard (<code>*</code>) is allowed.</p>
 
 </td>

--- a/security/v1beta1/authorization_policy.proto
+++ b/security/v1beta1/authorization_policy.proto
@@ -462,6 +462,7 @@ message Source {
   // This field requires mTLS enabled and is the same as the `source.serviceaccount` attribute.
   //
   // This takes the format `<namespace>/<serviceaccount>`.
+  // `<serviceaccount>` may also be used to use the same namespace as the `AuthorizationPolicy`.
   //
   // If not set, any service account is allowed.
   //
@@ -475,6 +476,7 @@ message Source {
   // Optional. A list of negative match of Kubernetes service accounts.
   //
   // This takes the format `<namespace>/<serviceaccount>`.
+  // `<serviceaccount>` may also be used to use the same namespace as the `AuthorizationPolicy`.
   //
   // No form of wildcard (`*`) is allowed.
   // +protoc-gen-crd:list-value-validation:MaxLength=320

--- a/tests/testdata/authz-valid.yaml
+++ b/tests/testdata/authz-valid.yaml
@@ -81,7 +81,7 @@ spec:
   rules:
     - from:
         - source:
-            serviceAccounts: ["baz/sa"]
+            serviceAccounts: ["baz/sa", "sa"]
         - source:
             principals: ["bar"]
         - source:


### PR DESCRIPTION
This allows applying a policy like

```yaml
apiVersion: security.istio.io/v1
kind: AuthorizationPolicy
metadata:
 name: allow-waypoint
spec:
  selector:
    matchLabels:
      app: echo
  action: ALLOW
  rules:
  - from:
    - source:
        serviceAccounts: ["waypoint"]
```

To get the semantics of "allow the waypoint in the same namespace". 

It is common in k8s to allow configurations to be written without a namespace specified and have the namespace of references implied by the namespace it is eventually written to. This allows taking the same policy and applying it to many places without the need for modification/templating. As far as I know, this is allowed with virtually every k8s core type and Istio type today.

Note this just changes docs to match the implementation in https://github.com/istio/istio/pull/54745 (which has a "hold" until this is approved)

Note: a release note is skipped since we have not shipped this feature