### PR TITLE
Clarify relationship btw MeshNetworks and ENABLE_HCM_INTERNAL_NET

### DIFF
--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -4422,7 +4422,19 @@ inside a mesh and how to route to endpoints in each network. For example</p>
       locality: us-east-1a
 </code></pre>
 <p>If <code>ENABLE_HCM_INTERNAL_NETWORKS</code> is set to true, MeshNetworks can be used to
-to explicitly define the networks in Envoy&rsquo;s internal address configuration.</p>
+to explicitly define the networks in Envoy&rsquo;s internal address configuration.
+Envoy uses the IPs in the <code>internalAddressConfig</code> to decide whether or not to sanitize
+Envoy headers. If the IP address is listed an internal, the Envoy headers are not
+sanitized. As of Envoy 1.33, the default value for <code>internalAddressConfig</code> is set to
+an empty set. Previously, the default value was the set of all private IPs. Setting
+the <code>internalAddressConfig</code> to all private IPs (via Envoy&rsquo;s previous default behavior
+or via the MeshNetworks) will leave users with an Istio Ingress Gateway potentially
+vulnerable to <code>x-envoy</code> header manipulation by external sources. More information about
+this vulnerability can be found here:
+<a href="https://github.com/envoyproxy/envoy/security/advisories/GHSA-ffhv-fvxq-r6mf">https://github.com/envoyproxy/envoy/security/advisories/GHSA-ffhv-fvxq-r6mf</a>
+To preserve headers, you must explicitly configure MeshNetworks and set
+<code>ENABLE_HCM_INTERNAL_NETWORKS</code> to true. Envoy&rsquo;s <code>internalAddressConfig</code> will be set to
+the endpointed specified by <code>fromCidr</code>.</p>
 
 <table class="message-fields">
 <thead>

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -3746,8 +3746,6 @@ Note: currently all headers are enabled by default.</p>
   metadataExchangeHeaders:
     mode: IN_MESH
 </code></pre>
-<p>If <code>ENABLE_HCM_INTERNAL_NETWORKS</code> is set to true, MeshNetworks can be used to
-to explicitly define the networks in Envoy&rsquo;s internal address configuration.</p>
 
 </td>
 </tr>
@@ -4423,6 +4421,8 @@ inside a mesh and how to route to endpoints in each network. For example</p>
       port: 15443
       locality: us-east-1a
 </code></pre>
+<p>If <code>ENABLE_HCM_INTERNAL_NETWORKS</code> is set to true, MeshNetworks can be used to
+to explicitly define the networks in Envoy&rsquo;s internal address configuration.</p>
 
 <table class="message-fields">
 <thead>

--- a/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
+++ b/mesh/v1alpha1/istio.mesh.v1alpha1.pb.html
@@ -3746,6 +3746,8 @@ Note: currently all headers are enabled by default.</p>
   metadataExchangeHeaders:
     mode: IN_MESH
 </code></pre>
+<p>If <code>ENABLE_HCM_INTERNAL_NETWORKS</code> is set to true, MeshNetworks can be used to
+to explicitly define the networks in Envoy&rsquo;s internal address configuration.</p>
 
 </td>
 </tr>

--- a/mesh/v1alpha1/network.pb.go
+++ b/mesh/v1alpha1/network.pb.go
@@ -120,6 +120,18 @@ func (x *Network) GetGateways() []*Network_IstioNetworkGateway {
 //
 // If `ENABLE_HCM_INTERNAL_NETWORKS` is set to true, MeshNetworks can be used to
 // to explicitly define the networks in Envoy's internal address configuration.
+// Envoy uses the IPs in the `internalAddressConfig` to decide whether or not to sanitize
+// Envoy headers. If the IP address is listed an internal, the Envoy headers are not
+// sanitized. As of Envoy 1.33, the default value for `internalAddressConfig` is set to
+// an empty set. Previously, the default value was the set of all private IPs. Setting
+// the `internalAddressConfig` to all private IPs (via Envoy's previous default behavior
+// or via the MeshNetworks) will leave users with an Istio Ingress Gateway potentially
+// vulnerable to `x-envoy` header manipulation by external sources. More information about
+// this vulnerability can be found here:
+// https://github.com/envoyproxy/envoy/security/advisories/GHSA-ffhv-fvxq-r6mf
+// To preserve headers, you must explicitly configure MeshNetworks and set
+// `ENABLE_HCM_INTERNAL_NETWORKS` to true. Envoy's `internalAddressConfig` will be set to
+// the endpointed specified by `fromCidr`.
 type MeshNetworks struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The set of networks inside this mesh. Each network should

--- a/mesh/v1alpha1/network.pb.go
+++ b/mesh/v1alpha1/network.pb.go
@@ -117,6 +117,9 @@ func (x *Network) GetGateways() []*Network_IstioNetworkGateway {
 //	    locality: us-east-1a
 //
 // ```
+//
+// If `ENABLE_HCM_INTERNAL_NETWORKS` is set to true, MeshNetworks can be used to
+// to explicitly define the networks in Envoy's internal address configuration.
 type MeshNetworks struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The set of networks inside this mesh. Each network should

--- a/mesh/v1alpha1/network.proto
+++ b/mesh/v1alpha1/network.proto
@@ -116,6 +116,18 @@ message Network {
 //
 // If `ENABLE_HCM_INTERNAL_NETWORKS` is set to true, MeshNetworks can be used to
 // to explicitly define the networks in Envoy's internal address configuration.
+// Envoy uses the IPs in the `internalAddressConfig` to decide whether or not to sanitize
+// Envoy headers. If the IP address is listed an internal, the Envoy headers are not
+// sanitized. As of Envoy 1.33, the default value for `internalAddressConfig` is set to
+// an empty set. Previously, the default value was the set of all private IPs. Setting
+// the `internalAddressConfig` to all private IPs (via Envoy's previous default behavior
+// or via the MeshNetworks) will leave users with an Istio Ingress Gateway potentially
+// vulnerable to `x-envoy` header manipulation by external sources. More information about
+// this vulnerability can be found here:
+// https://github.com/envoyproxy/envoy/security/advisories/GHSA-ffhv-fvxq-r6mf
+// To preserve headers, you must explicitly configure MeshNetworks and set
+// `ENABLE_HCM_INTERNAL_NETWORKS` to true. Envoy's `internalAddressConfig` will be set to
+// the endpointed specified by `fromCidr`.
 //
 message MeshNetworks {
   // The set of networks inside this mesh. Each network should

--- a/mesh/v1alpha1/network.proto
+++ b/mesh/v1alpha1/network.proto
@@ -114,6 +114,9 @@ message Network {
 //       locality: us-east-1a
 // ```
 //
+// If `ENABLE_HCM_INTERNAL_NETWORKS` is set to true, MeshNetworks can be used to
+// to explicitly define the networks in Envoy's internal address configuration.
+//
 message MeshNetworks {
   // The set of networks inside this mesh. Each network should
   // have a unique name and information about how to infer the endpoints in

--- a/releasenotes/notes/mesh-network-internal-addr-config.yaml
+++ b/releasenotes/notes/mesh-network-internal-addr-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: documentation
+issue:
+  - https://github.com/istio/istio/issues/53402
+
+releaseNotes:
+  - |
+    **Fixed** documentation for using MeshNetworks to configure envoy internal address configuration
+    when ENABLE_HCM_INTERNAL_NETWORKS is set to true.

--- a/releasenotes/notes/mesh-network-internal-addr-config.yaml
+++ b/releasenotes/notes/mesh-network-internal-addr-config.yaml
@@ -7,4 +7,10 @@ issue:
 releaseNotes:
   - |
     **Fixed** documentation for using MeshNetworks to configure envoy internal address configuration
-    when ENABLE_HCM_INTERNAL_NETWORKS is set to true.
+    when ENABLE_HCM_INTERNAL_NETWORKS is set to true. As of Envoy 1.33, the default value for
+    internalAddressConfig is set to an empty set. Previously, the default value was the set of all
+    private IPs. To preserve Envoy headers, you must explicitly configure MeshNetworks
+    or revert to Envoy's prior behavior by setting envoy.reloadable_features.explicit_internal_address_config
+    to false. Setting MeshNetworks to all private IPs or reverting to Envoy's previous behavior will leave
+    users with an Istio Ingress Gateway potentially vulnerable to x-envoy header manipulation by external
+    sources. More information about this vulnerability can be found here: https://github.com/envoyproxy/envoy/security/advisories/GHSA-ffhv-fvxq-r6mf


### PR DESCRIPTION
Add comments explaining the ability to use MeshNetworks to configure Envoy's internal_address_config via
ENABLE_HCM_INTERNAL_NETWORK

https://github.com/istio/istio/issues/53402

Related: https://github.com/istio/istio/issues/52037