### PR TITLE
Added traffic.istio.io/ingress-public-address annotation

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -784,6 +784,21 @@ Accepted values:
 		},
 	}
 
+	TrafficIngressPublicAddress = Instance {
+		Name:          "traffic.istio.io/ingress-public-address",
+		Description:   "Specifies the public address that can connect to this "+
+                        "service, enabling you to define an address different from "+
+                        "the one provisioned by the load balancer. This is "+
+                        "particularly useful when traffic is DNATed before "+
+                        "reaching a private load balancer.",
+		FeatureStatus: Stable,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Service,
+		},
+	}
+
 	TrafficNodeSelector = Instance {
 		Name:          "traffic.istio.io/nodeSelector",
 		Description:   "This annotation is a set of node-labels "+
@@ -962,6 +977,7 @@ func AllResourceAnnotations() []*Instance {
 		&SidecarUserVolumeMount,
 		&SidecarStatusPort,
 		&TopologyControlPlaneClusters,
+		&TrafficIngressPublicAddress,
 		&TrafficNodeSelector,
 		&SidecarTrafficExcludeInboundPorts,
 		&SidecarTrafficExcludeInterfaces,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -904,6 +904,28 @@ If that backend becomes unhealthy, traffic will sent to <code>us-east</code>.</l
     </tr>
   </tbody>
 </table>
+<h2 id="TrafficIngressPublicAddress">traffic.istio.io/ingress-public-address</h2>
+<table class="annotations">
+  <tbody>
+    <tr>
+      <th>Name</th>
+      <td><code>traffic.istio.io/ingress-public-address</code></td>
+    </tr>
+    <tr>
+      <th>Feature Status</th>
+      <td>Stable</td>
+    </tr>
+    <tr>
+      <th>Resource Types</th>
+      <td>[Service]</td>
+    </tr>
+    <tr>
+      <th>Description</th>
+      <td><p>Specifies the public address that can connect to this service, enabling you to define an address different from the one provisioned by the load balancer. This is particularly useful when traffic is DNATed before reaching a private load balancer.</p>
+</td>
+    </tr>
+  </tbody>
+</table>
 <h2 id="TrafficNodeSelector">traffic.istio.io/nodeSelector</h2>
 <table class="annotations">
   <tbody>

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -297,6 +297,16 @@ annotations:
     resources:
       - Service
 
+  - name: traffic.istio.io/ingress-public-address
+    featureStatus: Stable
+    description: Specifies the public address that can connect to this service, enabling you to
+      define an address different from the one provisioned by the load balancer. This is particularly useful
+      when traffic is DNATed before reaching a private load balancer.
+    deprecated: false
+    hidden: false
+    resources:
+      - Service
+
   - name: traffic.sidecar.istio.io/includeOutboundIPRanges
     featureStatus: Alpha
     description: A comma separated list of IP ranges in CIDR form to redirect to Envoy


### PR DESCRIPTION
Adding a service annotation that allows users to override the IP Istio will use to reach out to gateways.
This enables you to use a private load balancer with a public IP that DNATs to it.