### PR TITLE
wasm: add wasm plugin fail strategy reload

### DIFF
--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -472,6 +472,10 @@ const (
 	// binary, an exception, or abort() on the VM. This flag is not recommended
 	// for the authentication or the authorization plugins.
 	FailStrategy_FAIL_OPEN FailStrategy = 1
+	// New plugin instance will be created for the new request if the Wasm plugin
+	// has failed. This only applies for “proxy_wasm::FailState::RuntimeError“.
+	// For all other error types this will fallback to “FAIL_CLOSED“.
+	FailStrategy_FAIL_RELOAD FailStrategy = 2
 )
 
 // Enum value maps for FailStrategy.
@@ -479,10 +483,12 @@ var (
 	FailStrategy_name = map[int32]string{
 		0: "FAIL_CLOSE",
 		1: "FAIL_OPEN",
+		2: "FAIL_RELOAD",
 	}
 	FailStrategy_value = map[string]int32{
-		"FAIL_CLOSE": 0,
-		"FAIL_OPEN":  1,
+		"FAIL_CLOSE":  0,
+		"FAIL_OPEN":   1,
+		"FAIL_RELOAD": 2,
 	}
 )
 
@@ -1046,11 +1052,12 @@ const file_extensions_v1alpha1_wasm_proto_rawDesc = "" +
 	"\x0eEnvValueSource\x12\n" +
 	"\n" +
 	"\x06INLINE\x10\x00\x12\b\n" +
-	"\x04HOST\x10\x01*-\n" +
+	"\x04HOST\x10\x01*>\n" +
 	"\fFailStrategy\x12\x0e\n" +
 	"\n" +
 	"FAIL_CLOSE\x10\x00\x12\r\n" +
-	"\tFAIL_OPEN\x10\x01B\"Z istio.io/api/extensions/v1alpha1b\x06proto3"
+	"\tFAIL_OPEN\x10\x01\x12\x0f\n" +
+	"\vFAIL_RELOAD\x10\x02B\"Z istio.io/api/extensions/v1alpha1b\x06proto3"
 
 var (
 	file_extensions_v1alpha1_wasm_proto_rawDescOnce sync.Once

--- a/extensions/v1alpha1/wasm.pb.html
+++ b/extensions/v1alpha1/wasm.pb.html
@@ -665,6 +665,15 @@ for the authentication or the authorization plugins.</p>
 
 </td>
 </tr>
+<tr id="FailStrategy-FAIL_RELOAD">
+<td><code><a href="#FailStrategy-FAIL_RELOAD">FAIL_RELOAD</a></code></td>
+<td>
+<p>New plugin instance will be created for the new request if the Wasm plugin
+has failed. This only applies for <code>proxy_wasm::FailState::RuntimeError</code>.
+For all other error types this will fallback to <code>FAIL_CLOSED</code>.</p>
+
+</td>
+</tr>
 </tbody>
 </table>
 </section>

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -500,4 +500,9 @@ enum FailStrategy {
   // binary, an exception, or abort() on the VM. This flag is not recommended
   // for the authentication or the authorization plugins.
   FAIL_OPEN = 1;
+
+  // New plugin instance will be created for the new request if the Wasm plugin
+  // has failed. This only applies for ``proxy_wasm::FailState::RuntimeError``.
+  // For all other error types this will fallback to ``FAIL_CLOSED``.
+  FAIL_RELOAD = 2;
 }

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -43,10 +43,11 @@ spec:
                 description: |-
                   Specifies the failure behavior for the plugin due to fatal errors.
 
-                  Valid Options: FAIL_CLOSE, FAIL_OPEN
+                  Valid Options: FAIL_CLOSE, FAIL_OPEN, FAIL_RELOAD
                 enum:
                 - FAIL_CLOSE
                 - FAIL_OPEN
+                - FAIL_RELOAD
                 type: string
               imagePullPolicy:
                 description: |-


### PR DESCRIPTION
Add support for envoy's [FailurePolicy](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#enum-extensions-wasm-v3-failurepolicy) `FAIL_RELOAD` 

Resolves #3470 