### PR TITLE
hide ca cert from tls certificates

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -6656,13 +6656,12 @@ spec:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`, `private_key`,
-                            `ca_certificates` or `credential_name` or `credential_names`
-                            or `tls_certificates` should be specified.
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
                           items:
                             properties:
                               caCertificates:
-                                description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                 type: string
                               privateKey:
                                 description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -6928,13 +6927,12 @@ spec:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`, `private_key`,
-                            `ca_certificates` or `credential_name` or `credential_names`
-                            or `tls_certificates` should be specified.
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
                           items:
                             properties:
                               caCertificates:
-                                description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                 type: string
                               privateKey:
                                 description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -7200,13 +7198,12 @@ spec:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`, `private_key`,
-                            `ca_certificates` or `credential_name` or `credential_names`
-                            or `tls_certificates` should be specified.
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
                           items:
                             properties:
                               caCertificates:
-                                description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                 type: string
                               privateKey:
                                 description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -8822,13 +8819,12 @@ spec:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`, `private_key`,
-                            `ca_certificates` or `credential_name` or `credential_names`
-                            or `tls_certificates` should be specified.
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
                           items:
                             properties:
                               caCertificates:
-                                description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                 type: string
                               privateKey:
                                 description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -9397,13 +9393,12 @@ spec:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`, `private_key`,
-                            `ca_certificates` or `credential_name` or `credential_names`
-                            or `tls_certificates` should be specified.
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
                           items:
                             properties:
                               caCertificates:
-                                description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                 type: string
                               privateKey:
                                 description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -9972,13 +9967,12 @@ spec:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`, `private_key`,
-                            `ca_certificates` or `credential_name` or `credential_names`
-                            or `tls_certificates` should be specified.
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
                           items:
                             properties:
                               caCertificates:
-                                description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                                 type: string
                               privateKey:
                                 description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -988,6 +988,7 @@ type ServerTLSSettings_TLSCertificate struct {
 	// REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`. The path to a file
 	// containing certificate authority certificates to use in verifying a presented
 	// client side certificate.
+	// $hide_from_docs
 	CaCertificates string `protobuf:"bytes,3,opt,name=ca_certificates,json=caCertificates,proto3" json:"ca_certificates,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -783,7 +783,7 @@ type ServerTLSSettings struct {
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:MinItems=1
 	CredentialNames []string `protobuf:"bytes,14,rep,name=credential_names,json=credentialNames,proto3" json:"credential_names,omitempty"`
-	// Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name`
+	// Only one of `server_certificate`, `private_key` or `credential_name`
 	// or `credential_names` or `tls_certificates` should be specified.
 	// This is mainly used for specifying RSA and ECDSA certificates for the same server.
 	// +kubebuilder:validation:MaxItems=2
@@ -984,6 +984,7 @@ type ServerTLSSettings_TLSCertificate struct {
 	// REQUIRED if mode is `SIMPLE` or `MUTUAL`. The path to the file
 	// holding the server's private key.
 	PrivateKey string `protobuf:"bytes,2,opt,name=private_key,json=privateKey,proto3" json:"private_key,omitempty"`
+	// $hide_from_docs
 	// REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`. The path to a file
 	// containing certificate authority certificates to use in verifying a presented
 	// client side certificate.

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -518,7 +518,7 @@ RSA and ECDSA certificates for the same server.</p>
 <div class="type"><a href="#ServerTLSSettings-TLSCertificate">TLSCertificate[]</a></div>
 </div></td>
 <td>
-<p>Only one of <code>server_certificate</code>, <code>private_key</code>, <code>ca_certificates</code> or <code>credential_name</code>
+<p>Only one of <code>server_certificate</code>, <code>private_key</code> or <code>credential_name</code>
 or <code>credential_names</code> or <code>tls_certificates</code> should be specified.
 This is mainly used for specifying RSA and ECDSA certificates for the same server.</p>
 
@@ -646,17 +646,6 @@ holding the server-side TLS certificate to use.</p>
 <td>
 <p>REQUIRED if mode is <code>SIMPLE</code> or <code>MUTUAL</code>. The path to the file
 holding the server&rsquo;s private key.</p>
-
-</td>
-</tr>
-<tr id="ServerTLSSettings-TLSCertificate-ca_certificates">
-<td><div class="field"><div class="name"><code><a href="#ServerTLSSettings-TLSCertificate-ca_certificates">caCertificates</a></code></div>
-<div class="type">string</div>
-</div></td>
-<td>
-<p>REQUIRED if mode is <code>MUTUAL</code> or <code>OPTIONAL_MUTUAL</code>. The path to a file
-containing certificate authority certificates to use in verifying a presented
-client side certificate.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -490,13 +490,14 @@ message ServerTLSSettings {
     // holding the server's private key.
     string private_key = 2;
 
+    // $hide_from_docs
     // REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`. The path to a file
     // containing certificate authority certificates to use in verifying a presented
     // client side certificate.
     string ca_certificates = 3;
   }
 
-  // Only one of `server_certificate`, `private_key`, `ca_certificates` or `credential_name`
+  // Only one of `server_certificate`, `private_key` or `credential_name`
   // or `credential_names` or `tls_certificates` should be specified.
   // This is mainly used for specifying RSA and ECDSA certificates for the same server.
   // +kubebuilder:validation:MaxItems=2

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -494,6 +494,7 @@ message ServerTLSSettings {
     // REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`. The path to a file
     // containing certificate authority certificates to use in verifying a presented
     // client side certificate.
+    // $hide_from_docs
     string ca_certificates = 3;
   }
 


### PR DESCRIPTION
Added for dual cert support but realized later that envoy supports single cert for validation. So decided to uses ca_cert in ServerTLSSettings. Hiding this for now

Ref
#3466  https://github.com/istio/istio/pull/55760