### PR TITLE
Remove required validation for JWTRule issuer field

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -16038,8 +16038,6 @@ spec:
                       x-kubernetes-validations:
                       - message: must be a valid duration greater than 1ms
                         rule: duration(self) >= duration('1ms')
-                  required:
-                  - issuer
                   type: object
                   x-kubernetes-validations:
                   - message: only one of jwks or jwksUri can be set
@@ -16321,8 +16319,6 @@ spec:
                       x-kubernetes-validations:
                       - message: must be a valid duration greater than 1ms
                         rule: duration(self) >= duration('1ms')
-                  required:
-                  - issuer
                   type: object
                   x-kubernetes-validations:
                   - message: only one of jwks or jwksUri can be set

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -752,9 +752,9 @@ const file_security_v1beta1_request_authentication_proto_rawDesc = "" +
 	"\n" +
 	"targetRefs\x18\x04 \x03(\v2).istio.type.v1beta1.PolicyTargetReferenceR\n" +
 	"targetRefs\x12<\n" +
-	"\tjwt_rules\x18\x02 \x03(\v2\x1f.istio.security.v1beta1.JWTRuleR\bjwtRules\"\x80\x04\n" +
-	"\aJWTRule\x12\x1c\n" +
-	"\x06issuer\x18\x01 \x01(\tB\x04\xe2A\x01\x02R\x06issuer\x12\x1c\n" +
+	"\tjwt_rules\x18\x02 \x03(\v2\x1f.istio.security.v1beta1.JWTRuleR\bjwtRules\"\xfa\x03\n" +
+	"\aJWTRule\x12\x16\n" +
+	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1c\n" +
 	"\taudiences\x18\x02 \x03(\tR\taudiences\x12\x19\n" +
 	"\bjwks_uri\x18\x03 \x01(\tR\ajwksUri\x12\x12\n" +
 	"\x04jwks\x18\n" +

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -295,7 +295,6 @@ fromHeaders:
 <tr id="JWTRule-issuer">
 <td><div class="field"><div class="name"><code><a href="#JWTRule-issuer">issuer</a></code></div>
 <div class="type">string</div>
-<div class="required">Required</div>
 </div></td>
 <td>
 <p>Identifies the issuer that issued the JWT. See

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -327,7 +327,7 @@ message JWTRule {
   // Example: `https://foobar.auth0.com`
   // Example: `1234567-compute@developer.gserviceaccount.com`
   // +kubebuilder:validation:MinLength=1
-  string issuer = 1 [(google.api.field_behavior) = REQUIRED];
+  string issuer = 1;
 
   // The list of JWT
   // [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3)


### PR DESCRIPTION
To support JWTRules without checking that the `iss` claim matches a specific value, the existing validation to require the `issuer` field to be set in each `JWTRule` needs to be removed.

cc @zirain 

Implementation PR here: https://github.com/istio/istio/pull/56158

