### PR TITLE
[fixes #56772] Fix WasmPlugin .spec.url validation

### DIFF
--- a/extensions/v1alpha1/wasm.pb.go
+++ b/extensions/v1alpha1/wasm.pb.go
@@ -587,7 +587,7 @@ type WasmPlugin struct {
 	// within the proxy container, and `http[s]://` for `.wasm` module files
 	// hosted remotely.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:XValidation:message="url must have schema one of [http, https, file, oci]",rule="isURL(self) ? (url(self).getScheme() in [”, 'http', 'https', 'oci', 'file']) : (isURL('http://' + self) && url('http://' +self).getScheme() in [”, 'http', 'https', 'oci', 'file'])"
+	// +kubebuilder:validation:XValidation:message="url must have schema one of [http, https, file, oci] or be a valid OCI image reference",rule="(isURL(self) && url(self).getScheme() in ['http','https','file','oci']) || matches(self,'^([A-Za-z0-9.-]+(?::[0-9]+)?)?(/[A-Za-z0-9][A-Za-z0-9._-]*)*(?::[\\w][\\w.-]{0,127})?$')"
 	Url string `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
 	// SHA256 checksum that will be used to verify Wasm module or OCI container.
 	// If the `url` field already references a SHA256 (using the `@sha256:`

--- a/extensions/v1alpha1/wasm.proto
+++ b/extensions/v1alpha1/wasm.proto
@@ -279,7 +279,7 @@ message WasmPlugin {
   // within the proxy container, and `http[s]://` for `.wasm` module files
   // hosted remotely.
   // +kubebuilder:validation:MinLength=1
-  // +kubebuilder:validation:XValidation:message="url must have schema one of [http, https, file, oci]",rule="isURL(self) ? (url(self).getScheme() in ['', 'http', 'https', 'oci', 'file']) : (isURL('http://' + self) && url('http://' +self).getScheme() in ['', 'http', 'https', 'oci', 'file'])"
+  // +kubebuilder:validation:XValidation:message="url must have schema one of [http, https, file, oci] or be a valid OCI image reference",rule="(isURL(self) && url(self).getScheme() in ['http','https','file','oci']) || matches(self,'^([A-Za-z0-9.-]+(?::[0-9]+)?)?(/[A-Za-z0-9][A-Za-z0-9._-]*)*(?::[\\w][\\w.-]{0,127})?$')"
   string url = 2 [(google.api.field_behavior) = REQUIRED];
 
   // SHA256 checksum that will be used to verify Wasm module or OCI container.

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -225,10 +225,10 @@ spec:
                 minLength: 1
                 type: string
                 x-kubernetes-validations:
-                - message: url must have schema one of [http, https, file, oci]
-                  rule: |-
-                    isURL(self) ? (url(self).getScheme() in ["", "http", "https", "oci", "file"]) : (isURL("http://" + self) &&
-                    url("http://" + self).getScheme() in ["", "http", "https", "oci", "file"])
+                - message: url must have schema one of [http, https, file, oci] or
+                    be a valid OCI image reference
+                  rule: isURL(self) && url(self).getScheme() in ["http", "https",
+                    "file", "oci"] || matches(self, "^([A-Za-z0-9.-]+(?::[0-9]+)?)?(/[A-Za-z0-9][A-Za-z0-9._-]*)*(?::[\\w][\\w.-]{0,127})?$")
               verificationKey:
                 type: string
               vmConfig:

--- a/tests/testdata/wasm-valid.yaml
+++ b/tests/testdata/wasm-valid.yaml
@@ -23,13 +23,6 @@ spec:
 apiVersion: extensions.istio.io/v1alpha1
 kind: WasmPlugin
 metadata:
-  name: url-without-schema
-spec:
-  url: "test"
----
-apiVersion: extensions.istio.io/v1alpha1
-kind: WasmPlugin
-metadata:
   name: env
 spec:
   url: "http://test"
@@ -42,3 +35,73 @@ spec:
         value: "test"
       - name: "test3"
         value: "test"
+---
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: noprefix-image-default-lib-and-tag
+spec:
+  url: "bar"
+---
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: noprefix-image-default-lib-with-tag
+spec:
+  url: "bar:latest"
+---
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: noprefix-image-explicit-lib-default-tag
+spec:
+  url: "library/bar"
+---
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: noprefix-image-explicit-lib-and-tag
+spec:
+  url: "library/bar:latest"
+---
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: noprefix-image-with-explicit-repo-and-tag
+spec:
+  url: "foo.bar/foo/bar:1.21.4"
+---
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: noprefix-image-with-explicit-repo-and-tag-and-port
+spec:
+  url: "foo.bar:5000/client_id_matches_cert:latest"
+---
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: oci-image-explicit-lib-default-tag
+spec:
+  url: "oci://library/bar"
+---
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: oci-image-explicit-lib-and-tag
+spec:
+  url: "oci://library/bar:latest"
+---
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: oci-image-with-explicit-repo-and-tag
+spec:
+  url: "oci://foo.bar/foo/bar:1.21.4"
+---
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: oci-image-with-explicit-repo-and-tag-and-port
+spec:
+  url: "oci://foo.bar:5000/client_id_matches_cert:latest"


### PR DESCRIPTION
## What does this PR do?
- Per the Istio documentation, if the `oci://` prefix is missing in `.spec.url`, it is assumed that the URL is a `oci://` image reference[^1].
- Things like `foo.bar:5000/baz:latest` are valid image references, but do not pass validation, because this treats `foo.bar` as the schema.
- I added an extensive set of test cases, then modified the validation logic to support each.

[^1]: https://istio.io/latest/docs/reference/config/proxy_extensions/wasm-plugin/#WasmPlugin-url.