### PR TITLE
Add spaceDelimitedClaims field to RequestAuthentication API

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -16174,6 +16174,14 @@ spec:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
                       type: string
+                    spaceDelimitedClaims:
+                      description: List of JWT claim names that should be treated
+                        as space-delimited strings.
+                      items:
+                        minLength: 1
+                        type: string
+                      maxItems: 64
+                      type: array
                     timeout:
                       description: The maximum amount of time that the resolver, determined
                         by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable,
@@ -16455,6 +16463,14 @@ spec:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
                       type: string
+                    spaceDelimitedClaims:
+                      description: List of JWT claim names that should be treated
+                        as space-delimited strings.
+                      items:
+                        minLength: 1
+                        type: string
+                      maxItems: 64
+                      type: array
                     timeout:
                       description: The maximum amount of time that the resolver, determined
                         by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable,

--- a/releasenotes/notes/space-delimited-jwt-claims.yaml
+++ b/releasenotes/notes/space-delimited-jwt-claims.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - https://github.com/istio/istio/issues/56873
+
+releaseNotes:
+  - |
+    **Added** `spaceDelimitedClaims` field in `RequestAuthentication` under `spec.jwtRules.` to configure custom JWT claims
+    that should be treated as space-delimited strings.
+    This allows authorization policies to match individual values within space-separated claim strings,
+    extending beyond the default `scope` and `permission` claims.
+    This addresses compatibility issues when upgrading from older Istio versions with custom space-delimited JWT claim fields.

--- a/security/v1/request_authentication_alias.gen.go
+++ b/security/v1/request_authentication_alias.gen.go
@@ -53,6 +53,21 @@ type RequestAuthentication = v1beta1.RequestAuthentication
 // fromHeaders:
 // - "x-goog-iap-jwt-assertion"
 // ```
+//
+// This example shows how to configure custom claims to be treated as space-delimited strings.
+// This is useful when JWT tokens contain custom claims with multiple space-separated values
+// that should be available for individual matching in authorization policies.
+//
+// ```yaml
+// issuer: https://example.com
+// spaceDelimitedClaims:
+// - "custom_scope"
+// - "provider.login.scope"
+// - "roles"
+// ```
+//
+// With this configuration, a JWT containing `"custom_scope": "read write admin"` will allow
+// authorization policies to match against individual values like "read", "write", or "admin".
 // +kubebuilder:validation:XValidation:message="only one of jwks or jwksUri can be set",rule="oneof(self.jwksUri, self.jwks_uri, self.jwks)"
 type JWTRule = v1beta1.JWTRule
 

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -283,6 +283,17 @@ jwksUri: https://example.com/.secret/jwks.json
 fromHeaders:
 - &quot;x-goog-iap-jwt-assertion&quot;
 </code></pre>
+<p>This example shows how to configure custom claims to be treated as space-delimited strings.
+This is useful when JWT tokens contain custom claims with multiple space-separated values
+that should be available for individual matching in authorization policies.</p>
+<pre><code class="language-yaml">issuer: https://example.com
+spaceDelimitedClaims:
+- &quot;custom_scope&quot;
+- &quot;provider.login.scope&quot;
+- &quot;roles&quot;
+</code></pre>
+<p>With this configuration, a JWT containing <code>&quot;custom_scope&quot;: &quot;read write admin&quot;</code> will allow
+authorization policies to match against individual values like &ldquo;read&rdquo;, &ldquo;write&rdquo;, or &ldquo;admin&rdquo;.</p>
 
 <table class="message-fields">
 <thead>
@@ -445,6 +456,28 @@ The header specified in each operation in the list must be unique. Nested claims
 <td>
 <p>The maximum amount of time that the resolver, determined by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable,
 will spend waiting for the JWKS to be fetched. Default is 5s.</p>
+
+</td>
+</tr>
+<tr id="JWTRule-space_delimited_claims">
+<td><div class="field"><div class="name"><code><a href="#JWTRule-space_delimited_claims">spaceDelimitedClaims</a></code></div>
+<div class="type">string[]</div>
+</div></td>
+<td>
+<p>List of JWT claim names that should be treated as space-delimited strings.
+These claims will be split on whitespace and each individual value will be available
+for matching in authorization policies. This extends the default behavior that only
+treats &lsquo;scope&rsquo; and &lsquo;permission&rsquo; claims as space-delimited.</p>
+<p>Example usage for custom claims:</p>
+<pre><code class="language-yaml">spaceDelimitedClaims:
+- &quot;custom_scope&quot;
+- &quot;provider.login.scope&quot;
+- &quot;roles&quot;
+</code></pre>
+<p>This allows authorization policies to match individual values within space-separated
+claim strings, maintaining compatibility with existing JWT token formats.</p>
+<p>Note: The default claims &lsquo;scope&rsquo; and &lsquo;permission&rsquo; are always treated as space-delimited
+regardless of this setting.</p>
 
 </td>
 </tr>

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -318,6 +318,21 @@ message RequestAuthentication {
 // fromHeaders:
 // - "x-goog-iap-jwt-assertion"
 // ```
+//
+// This example shows how to configure custom claims to be treated as space-delimited strings.
+// This is useful when JWT tokens contain custom claims with multiple space-separated values
+// that should be available for individual matching in authorization policies.
+//
+// ```yaml
+// issuer: https://example.com
+// spaceDelimitedClaims:
+// - "custom_scope"
+// - "provider.login.scope"
+// - "roles"
+// ```
+//
+// With this configuration, a JWT containing `"custom_scope": "read write admin"` will allow
+// authorization policies to match against individual values like "read", "write", or "admin".
 // +kubebuilder:validation:XValidation:message="only one of jwks or jwksUri can be set",rule="oneof(self.jwksUri, self.jwks_uri, self.jwks)"
 message JWTRule {
   // Identifies the issuer that issued the JWT. See
@@ -450,8 +465,30 @@ message JWTRule {
   // will spend waiting for the JWKS to be fetched. Default is 5s.
   google.protobuf.Duration timeout = 13;
 
+  // List of JWT claim names that should be treated as space-delimited strings.
+  // These claims will be split on whitespace and each individual value will be available
+  // for matching in authorization policies. This extends the default behavior that only
+  // treats 'scope' and 'permission' claims as space-delimited.
+  //
+  // Example usage for custom claims:
+  // ```yaml
+  // spaceDelimitedClaims:
+  // - "custom_scope"
+  // - "provider.login.scope"
+  // - "roles"
+  // ```
+  //
+  // This allows authorization policies to match individual values within space-separated
+  // claim strings, maintaining compatibility with existing JWT token formats.
+  //
+  // Note: The default claims 'scope' and 'permission' are always treated as space-delimited
+  // regardless of this setting.
+  // +protoc-gen-crd:list-value-validation:MinLength=1
+  // +kubebuilder:validation:MaxItems=64
+  repeated string space_delimited_claims = 14;
+
   // $hide_from_docs
-  // Next available field number: 14
+  // Next available field number: 15
 }
 
 // This message specifies a header location to extract JWT token.

--- a/tests/testdata/reqauth-invalid.yaml
+++ b/tests/testdata/reqauth-invalid.yaml
@@ -210,3 +210,14 @@ spec:
   - issuer: example
     timeout: "apple"
 ---
+_err: 'spaceDelimitedClaims[0] in body should be at least 1 chars long'
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: invalid-space-delimited-claims
+spec:
+  jwtRules:
+  - issuer: example
+    spaceDelimitedClaims:
+    - ""
+---

--- a/tests/testdata/reqauth-valid.yaml
+++ b/tests/testdata/reqauth-valid.yaml
@@ -20,3 +20,6 @@ spec:
       header: def
     timeout: 5s
     outputPayloadToHeader: header
+    spaceDelimitedClaims:
+    - "custom_scope"
+    - "provider.login.scope"


### PR DESCRIPTION
 Related Issues
#[56873](https://github.com/istio/istio/issues/56873)

Following a change in Istio 1.21, JWT claims other than `scope` and `permissions` are treated as exact string values. This created an issue for users with custom, space-delimited claims (for example: a roles claim with the value "editor admin"), as they could no longer match individual values like editor or admin in their Authorization Policies.

This PR introduces a new field, `spaceDelimitedClaims`, to the `RequestAuthentication` API. This field allows users to explicitly specify a list of custom claims that Istio should parse as space-delimited strings. This restores the previous, more flexible behavior for users who depend on it, without changing the new default for other claims.

  ### API Changes

  ```yaml
  apiVersion: security.istio.io/v1beta1
  kind: RequestAuthentication
  spec:
    jwtRules:
    - issuer: "https://example.com"
      jwksUri: "https://example.com/.well-known/jwks.json"
      spaceDelimitedClaims:
      - "custom_scope"
      - "provider.login.scope"
      - "roles"
```

This change is fully backward compatible. The default behavior for the standard scope and permissions claims remains unchanged; they will always be treated as space-delimited lists, regardless of whether they are included in the new field.