### PR TITLE
Fix incorrect annotation in kubevirtInterfaces docs

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -909,7 +909,7 @@ Supported values are "brotli", "gzip", and "zstd".
 		Description:   "A comma separated list of virtual interfaces whose "+
                         "inbound traffic (from VM) will be treated as outbound. "+
                         "Deprecated in favor of "+
-                        "`istio.io/redirect-virtual-interfaces`",
+                        "`istio.io/reroute-virtual-interfaces`",
 		FeatureStatus: Alpha,
 		Hidden:        false,
 		Deprecated:    true,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -1144,7 +1144,7 @@ Supported values are <code>brotli</code>, <code>gzip</code>, and <code>zstd</cod
     </tr>
     <tr>
       <th>Description</th>
-      <td><p>A comma separated list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound. Deprecated in favor of <code>istio.io/redirect-virtual-interfaces</code></p>
+      <td><p>A comma separated list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound. Deprecated in favor of <code>istio.io/reroute-virtual-interfaces</code></p>
 </td>
     </tr>
   </tbody>

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -363,7 +363,7 @@ annotations:
   - name: traffic.sidecar.istio.io/kubevirtInterfaces
     featureStatus: Alpha
     description: A comma separated list of virtual interfaces whose inbound traffic
-      (from VM) will be treated as outbound. Deprecated in favor of `istio.io/redirect-virtual-interfaces`
+      (from VM) will be treated as outbound. Deprecated in favor of `istio.io/reroute-virtual-interfaces`
     deprecated: true
     hidden: false
     resources:


### PR DESCRIPTION
As mentioned in the [deprecation notes](https://istio.io/latest/news/releases/1.25.x/announcing-1.25/change-notes/#deprecation-notices), it should be `istio.io/reroute-virtual-interfaces`

Related to: https://github.com/istio/istio/issues/57662