### PR TITLE
doc: correct field name in example config

### DIFF
--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -497,7 +497,7 @@ type JWTRule struct {
 	//
 	// ``` yaml
 	//
-	//	from_cookies:
+	//	fromCookies:
 	//	- auth-token
 	//
 	// ```

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -411,7 +411,7 @@ the payload will not be emitted.</p>
 <td>
 <p>List of cookie names from which JWT is expected.	//
 For example, if config is:</p>
-<pre><code class="language-yaml">  from_cookies:
+<pre><code class="language-yaml">  fromCookies:
   - auth-token
 </code></pre>
 <p>Then JWT will be extracted from <code>auth-token</code> cookie in the request.</p>

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -433,7 +433,7 @@ message JWTRule {
   // For example, if config is:
   //
   // ``` yaml
-  //   from_cookies:
+  //   fromCookies:
   //   - auth-token
   // ```
   // Then JWT will be extracted from `auth-token` cookie in the request.


### PR DESCRIPTION
Corrected an error in the config example.

Confirmed that the validation now passes as shown below.
Invalid when we use `from_cookies` as a field name:
```
k apply --dry-run=server -f test-jwt.yaml
Error from server (BadRequest): error when creating "test-jwt.yaml": RequestAuthentication in version "v1" cannot be handled as a RequestAuthentication: strict decoding error: unknown field "spec.jwtRules[0].from_cookies"
```

Valid when we use `fromCookies`:
```
k apply --dry-run=server -f test-jwt.yaml
requestauthentication.security.istio.io/jwt-on-ingress created (server dry run)
```