### PR TITLE
add requireJwt field in RequestAuthentication

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -16410,6 +16410,12 @@ spec:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
                       type: string
+                    requireJwt:
+                      description: If set to true, requests without a valid JWT token
+                        will be rejected with a 401 Unauthorized status code along
+                        with a `WWW-Authenticate` header indicating the Bearer authentication
+                        scheme is required.
+                      type: boolean
                     spaceDelimitedClaims:
                       description: List of JWT claim names that should be treated
                         as space-delimited strings.
@@ -16699,6 +16705,12 @@ spec:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
                       type: string
+                    requireJwt:
+                      description: If set to true, requests without a valid JWT token
+                        will be rejected with a 401 Unauthorized status code along
+                        with a `WWW-Authenticate` header indicating the Bearer authentication
+                        scheme is required.
+                      type: boolean
                     spaceDelimitedClaims:
                       description: List of JWT claim names that should be treated
                         as space-delimited strings.

--- a/security/v1/request_authentication_alias.gen.go
+++ b/security/v1/request_authentication_alias.gen.go
@@ -68,6 +68,18 @@ type RequestAuthentication = v1beta1.RequestAuthentication
 //
 // With this configuration, a JWT containing `"custom_scope": "read write admin"` will allow
 // authorization policies to match against individual values like "read", "write", or "admin".
+//
+// This example shows how to require JWT tokens and return 401 for missing tokens:
+//
+// ```yaml
+// issuer: https://example.com
+// jwksUri: https://example.com/.well-known/jwks.json
+// requireJwt: true
+// ```
+//
+// With `requireJwt: true`, requests without a JWT will receive a 401 Unauthorized response with a
+// `WWW-Authenticate: Bearer` header directly from the authentication filter, eliminating the need
+// for a separate AuthorizationPolicy when you simply want to require authentication.
 // +kubebuilder:validation:XValidation:message="only one of jwks or jwksUri can be set",rule="oneof(self.jwksUri, self.jwks_uri, self.jwks)"
 type JWTRule = v1beta1.JWTRule
 

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -125,6 +125,26 @@ spec:
     - operation:
         paths: [&quot;/healthz&quot;]
 </code></pre>
+<p>Alternatively, you can use <code>requireJwt: true</code> to enforce JWT requirement directly in the RequestAuthentication
+policy without needing a separate AuthorizationPolicy. This approach returns 401 Unauthorized with a
+<code>WWW-Authenticate: Bearer</code> header for missing JWTs instead of 403 Forbidden:</p>
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: httpbin
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  jwtRules:
+  - issuer: &quot;issuer-foo&quot;
+    jwksUri: https://example.com/.well-known/jwks.json
+    requireJwt: true
+</code></pre>
+<p>With <code>requireJwt: true</code>, requests without a JWT will be rejected with 401 Unauthorized and a
+<code>WWW-Authenticate: Bearer</code> header, making it clearer that authentication is required. This is semantically
+more accurate than the 403 Forbidden returned by AuthorizationPolicy and complies with RFC 7235.</p>
 <p>[Experimental] Routing based on derived <a href="https://istio.io/latest/docs/reference/config/security/conditions/">metadata</a>
 is now supported. A prefix &lsquo;@&rsquo; is used to denote a match against internal metadata instead of the headers in the request.
 Currently this feature is only supported for the following metadata:</p>
@@ -294,6 +314,14 @@ spaceDelimitedClaims:
 </code></pre>
 <p>With this configuration, a JWT containing <code>&quot;custom_scope&quot;: &quot;read write admin&quot;</code> will allow
 authorization policies to match against individual values like &ldquo;read&rdquo;, &ldquo;write&rdquo;, or &ldquo;admin&rdquo;.</p>
+<p>This example shows how to require JWT tokens and return 401 for missing tokens:</p>
+<pre><code class="language-yaml">issuer: https://example.com
+jwksUri: https://example.com/.well-known/jwks.json
+requireJwt: true
+</code></pre>
+<p>With <code>requireJwt: true</code>, requests without a JWT will receive a 401 Unauthorized response with a
+<code>WWW-Authenticate: Bearer</code> header directly from the authentication filter, eliminating the need
+for a separate AuthorizationPolicy when you simply want to require authentication.</p>
 
 <table class="message-fields">
 <thead>
@@ -478,6 +506,40 @@ treats &lsquo;scope&rsquo; and &lsquo;permission&rsquo; claims as space-delimite
 claim strings, maintaining compatibility with existing JWT token formats.</p>
 <p>Note: The default claims &lsquo;scope&rsquo; and &lsquo;permission&rsquo; are always treated as space-delimited
 regardless of this setting.</p>
+
+</td>
+</tr>
+<tr id="JWTRule-require_jwt">
+<td><div class="field"><div class="name"><code><a href="#JWTRule-require_jwt">requireJwt</a></code></div>
+<div class="type">bool</div>
+</div></td>
+<td>
+<p>If set to true, requests without a valid JWT token will be rejected with a 401 Unauthorized status code
+along with a <code>WWW-Authenticate</code> header indicating the Bearer authentication scheme is required.
+If set to false or unset (default), requests without a JWT token are allowed to pass through but will not have
+an authenticated identity. In the default case, to enforce that requests must have authentication,
+you should use an AuthorizationPolicy with requestPrincipals.</p>
+<p>Note: Setting this to true changes the HTTP status code for missing JWT from 403 (via AuthorizationPolicy)
+to 401 (via RequestAuthentication), which is semantically more accurate for authentication failures and
+includes the proper <code>WWW-Authenticate</code> header as required by RFC 7235.</p>
+<p>Example usage:</p>
+<pre><code class="language-yaml">jwtRules:
+- issuer: &quot;https://example.com&quot;
+  jwksUri: https://example.com/.well-known/jwks.json
+  requireJwt: true
+</code></pre>
+<p>With <code>requireJwt: true</code>:</p>
+<ul>
+<li>Request with missing JWT -&gt; 401 Unauthorized (with WWW-Authenticate: Bearer header)</li>
+<li>Request with invalid/expired JWT -&gt; 401 Unauthorized (with WWW-Authenticate: Bearer header)</li>
+<li>Request with valid JWT -&gt; Accepted</li>
+</ul>
+<p>With <code>requireJwt: false</code> (default):</p>
+<ul>
+<li>Request with missing JWT -&gt; Accepted (no authenticated identity)</li>
+<li>Request with invalid/expired JWT -&gt; 401 Unauthorized (with WWW-Authenticate: Bearer header)</li>
+<li>Request with valid JWT -&gt; Accepted (with authenticated identity)</li>
+</ul>
 
 </td>
 </tr>

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -149,6 +149,30 @@ syntax = "proto3";
 //         paths: ["/healthz"]
 // ```
 //
+// Alternatively, you can use `requireJwt: true` to enforce JWT requirement directly in the RequestAuthentication
+// policy without needing a separate AuthorizationPolicy. This approach returns 401 Unauthorized with a
+// `WWW-Authenticate: Bearer` header for missing JWTs instead of 403 Forbidden:
+//
+// ```yaml
+// apiVersion: security.istio.io/v1
+// kind: RequestAuthentication
+// metadata:
+//   name: httpbin
+//   namespace: foo
+// spec:
+//   selector:
+//     matchLabels:
+//       app: httpbin
+//   jwtRules:
+//   - issuer: "issuer-foo"
+//     jwksUri: https://example.com/.well-known/jwks.json
+//     requireJwt: true
+// ```
+//
+// With `requireJwt: true`, requests without a JWT will be rejected with 401 Unauthorized and a
+// `WWW-Authenticate: Bearer` header, making it clearer that authentication is required. This is semantically
+// more accurate than the 403 Forbidden returned by AuthorizationPolicy and complies with RFC 7235.
+//
 // [Experimental] Routing based on derived [metadata](https://istio.io/latest/docs/reference/config/security/conditions/)
 // is now supported. A prefix '@' is used to denote a match against internal metadata instead of the headers in the request.
 // Currently this feature is only supported for the following metadata:
@@ -333,6 +357,18 @@ message RequestAuthentication {
 //
 // With this configuration, a JWT containing `"custom_scope": "read write admin"` will allow
 // authorization policies to match against individual values like "read", "write", or "admin".
+//
+// This example shows how to require JWT tokens and return 401 for missing tokens:
+//
+// ```yaml
+// issuer: https://example.com
+// jwksUri: https://example.com/.well-known/jwks.json
+// requireJwt: true
+// ```
+//
+// With `requireJwt: true`, requests without a JWT will receive a 401 Unauthorized response with a
+// `WWW-Authenticate: Bearer` header directly from the authentication filter, eliminating the need
+// for a separate AuthorizationPolicy when you simply want to require authentication.
 // +kubebuilder:validation:XValidation:message="only one of jwks or jwksUri can be set",rule="oneof(self.jwksUri, self.jwks_uri, self.jwks)"
 message JWTRule {
   // Identifies the issuer that issued the JWT. See
@@ -487,8 +523,37 @@ message JWTRule {
   // +kubebuilder:validation:MaxItems=64
   repeated string space_delimited_claims = 14;
 
+  // If set to true, requests without a valid JWT token will be rejected with a 401 Unauthorized status code
+  // along with a `WWW-Authenticate` header indicating the Bearer authentication scheme is required.
+  // If set to false or unset (default), requests without a JWT token are allowed to pass through but will not have
+  // an authenticated identity. In the default case, to enforce that requests must have authentication,
+  // you should use an AuthorizationPolicy with requestPrincipals.
+  //
+  // Note: Setting this to true changes the HTTP status code for missing JWT from 403 (via AuthorizationPolicy)
+  // to 401 (via RequestAuthentication), which is semantically more accurate for authentication failures and
+  // includes the proper `WWW-Authenticate` header as required by RFC 7235.
+  //
+  // Example usage:
+  // ```yaml
+  // jwtRules:
+  // - issuer: "https://example.com"
+  //   jwksUri: https://example.com/.well-known/jwks.json
+  //   requireJwt: true
+  // ```
+  //
+  // With `requireJwt: true`:
+  // - Request with missing JWT -> 401 Unauthorized (with WWW-Authenticate: Bearer header)
+  // - Request with invalid/expired JWT -> 401 Unauthorized (with WWW-Authenticate: Bearer header)
+  // - Request with valid JWT -> Accepted
+  //
+  // With `requireJwt: false` (default):
+  // - Request with missing JWT -> Accepted (no authenticated identity)
+  // - Request with invalid/expired JWT -> 401 Unauthorized (with WWW-Authenticate: Bearer header)
+  // - Request with valid JWT -> Accepted (with authenticated identity)
+  bool require_jwt = 15;
+
   // $hide_from_docs
-  // Next available field number: 15
+  // Next available field number: 16
 }
 
 // This message specifies a header location to extract JWT token.


### PR DESCRIPTION
Problem:
Istio's RequestAuthentication has hardcoded allowMissing behavior, requiring users to combine it with AuthorizationPolicy to enforce JWT presence. This results in:
- HTTP status 403 Forbidden instead of 401 Unauthorized for missing JWT which could be a requirement.
- Missing WWW-Authenticate header ([RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235)).

Solution:
- Add bool require_jwt = 15; field to JWTRule message.
- When true: Missing JWT → 401 Unauthorized + WWW-Authenticate: Bearer header from envoy proxy.
- When false (default): Current behavior (JWT optional).

Istio PR will be taken up if this is acceptable.