### PR TITLE
networking: add pathTemplate match type to StringMatch

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -10631,14 +10631,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -10854,14 +10863,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -10886,14 +10904,23 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - pathTemplate
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - pathTemplate
                               properties:
                                 exact:
+                                  type: string
+                                pathTemplate:
+                                  description: URI template path match using `{*}`
+                                    (matches one path segment) and `{**}` (matches
+                                    one or more path segments) operators.
                                   type: string
                                 prefix:
                                   type: string
@@ -10922,14 +10949,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -10957,14 +10993,23 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - pathTemplate
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - pathTemplate
                               properties:
                                 exact:
+                                  type: string
+                                pathTemplate:
+                                  description: URI template path match using `{*}`
+                                    (matches one path segment) and `{**}` (matches
+                                    one or more path segments) operators.
                                   type: string
                                 prefix:
                                   type: string
@@ -10988,14 +11033,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -11032,14 +11086,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -11058,14 +11121,23 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - pathTemplate
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - pathTemplate
                               properties:
                                 exact:
+                                  type: string
+                                pathTemplate:
+                                  description: URI template path match using `{*}`
+                                    (matches one path segment) and `{**}` (matches
+                                    one or more path segments) operators.
                                   type: string
                                 prefix:
                                   type: string
@@ -11683,14 +11755,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -11906,14 +11987,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -11938,14 +12028,23 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - pathTemplate
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - pathTemplate
                               properties:
                                 exact:
+                                  type: string
+                                pathTemplate:
+                                  description: URI template path match using `{*}`
+                                    (matches one path segment) and `{**}` (matches
+                                    one or more path segments) operators.
                                   type: string
                                 prefix:
                                   type: string
@@ -11974,14 +12073,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -12009,14 +12117,23 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - pathTemplate
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - pathTemplate
                               properties:
                                 exact:
+                                  type: string
+                                pathTemplate:
+                                  description: URI template path match using `{*}`
+                                    (matches one path segment) and `{**}` (matches
+                                    one or more path segments) operators.
                                   type: string
                                 prefix:
                                   type: string
@@ -12040,14 +12157,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -12084,14 +12210,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -12110,14 +12245,23 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - pathTemplate
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - pathTemplate
                               properties:
                                 exact:
+                                  type: string
+                                pathTemplate:
+                                  description: URI template path match using `{*}`
+                                    (matches one path segment) and `{**}` (matches
+                                    one or more path segments) operators.
                                   type: string
                                 prefix:
                                   type: string
@@ -12735,14 +12879,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -12958,14 +13111,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -12990,14 +13152,23 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - pathTemplate
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - pathTemplate
                               properties:
                                 exact:
+                                  type: string
+                                pathTemplate:
+                                  description: URI template path match using `{*}`
+                                    (matches one path segment) and `{**}` (matches
+                                    one or more path segments) operators.
                                   type: string
                                 prefix:
                                   type: string
@@ -13026,14 +13197,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -13061,14 +13241,23 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - pathTemplate
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - pathTemplate
                               properties:
                                 exact:
+                                  type: string
+                                pathTemplate:
+                                  description: URI template path match using `{*}`
+                                    (matches one path segment) and `{**}` (matches
+                                    one or more path segments) operators.
                                   type: string
                                 prefix:
                                   type: string
@@ -13092,14 +13281,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -13136,14 +13334,23 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - pathTemplate
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - pathTemplate
                             properties:
                               exact:
+                                type: string
+                              pathTemplate:
+                                description: URI template path match using `{*}` (matches
+                                  one path segment) and `{**}` (matches one or more
+                                  path segments) operators.
                                 type: string
                               prefix:
                                 type: string
@@ -13162,14 +13369,23 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - pathTemplate
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - pathTemplate
                               properties:
                                 exact:
+                                  type: string
+                                pathTemplate:
+                                  description: URI template path match using `{*}`
+                                    (matches one path segment) and `{**}` (matches
+                                    one or more path segments) operators.
                                   type: string
                                 prefix:
                                   type: string

--- a/networking/v1/virtual_service_alias.gen.go
+++ b/networking/v1/virtual_service_alias.gen.go
@@ -673,6 +673,17 @@ type StringMatch_Prefix = v1alpha3.StringMatch_Prefix
 // Example: `(?i)^aaa$` can be used to case-insensitive match a string consisting of three a's.
 type StringMatch_Regex = v1alpha3.StringMatch_Regex
 
+// URI template path match using `{*}` (matches one path segment) and `{**}` (matches one or more
+// path segments) operators. This leverages Envoy's
+// [UriTemplateMatchConfig](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/path/match/uri_template/v3/uri_template_match.proto)
+// and is more readable and performant than equivalent regex patterns.
+//
+// Example: `/users/{*}/orders/{**}` matches `/users/alice/orders` and `/users/alice/orders/123/items`.
+//
+// Note: `{**}` must be the last operator in the path template. Only valid for `uri` matches
+// in HTTPMatchRequest.
+type StringMatch_PathTemplate = v1alpha3.StringMatch_PathTemplate
+
 // Describes the retry policy to use when a HTTP request fails. For
 // example, the following rule sets the maximum number of retries to 3 when
 // calling ratings:v1 service, with a 2s timeout per retry attempt.

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -2539,6 +2539,7 @@ type StringMatch struct {
 	//	*StringMatch_Exact
 	//	*StringMatch_Prefix
 	//	*StringMatch_Regex
+	//	*StringMatch_PathTemplate
 	MatchType     isStringMatch_MatchType `protobuf_oneof:"match_type"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2608,6 +2609,15 @@ func (x *StringMatch) GetRegex() string {
 	return ""
 }
 
+func (x *StringMatch) GetPathTemplate() string {
+	if x != nil {
+		if x, ok := x.MatchType.(*StringMatch_PathTemplate); ok {
+			return x.PathTemplate
+		}
+	}
+	return ""
+}
+
 type isStringMatch_MatchType interface {
 	isStringMatch_MatchType()
 }
@@ -2629,11 +2639,26 @@ type StringMatch_Regex struct {
 	Regex string `protobuf:"bytes,3,opt,name=regex,proto3,oneof"`
 }
 
+type StringMatch_PathTemplate struct {
+	// URI template path match using `{*}` (matches one path segment) and `{**}` (matches one or more
+	// path segments) operators. This leverages Envoy's
+	// [UriTemplateMatchConfig](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/path/match/uri_template/v3/uri_template_match.proto)
+	// and is more readable and performant than equivalent regex patterns.
+	//
+	// Example: `/users/{*}/orders/{**}` matches `/users/alice/orders` and `/users/alice/orders/123/items`.
+	//
+	// Note: `{**}` must be the last operator in the path template. Only valid for `uri` matches
+	// in HTTPMatchRequest.
+	PathTemplate string `protobuf:"bytes,4,opt,name=path_template,json=pathTemplate,proto3,oneof"`
+}
+
 func (*StringMatch_Exact) isStringMatch_MatchType() {}
 
 func (*StringMatch_Prefix) isStringMatch_MatchType() {}
 
 func (*StringMatch_Regex) isStringMatch_MatchType() {}
+
+func (*StringMatch_PathTemplate) isStringMatch_MatchType() {}
 
 // Describes the retry policy to use when a HTTP request fails. For
 // example, the following rule sets the maximum number of retries to 3 when
@@ -3648,11 +3673,12 @@ const file_networking_v1alpha3_virtual_service_proto_rawDesc = "" +
 	"\x11uri_regex_rewrite\x18\x03 \x01(\v2'.istio.networking.v1alpha3.RegexRewriteR\x0furiRegexRewrite\">\n" +
 	"\fRegexRewrite\x12\x14\n" +
 	"\x05match\x18\x01 \x01(\tR\x05match\x12\x18\n" +
-	"\arewrite\x18\x02 \x01(\tR\arewrite\"e\n" +
+	"\arewrite\x18\x02 \x01(\tR\arewrite\"\x8c\x01\n" +
 	"\vStringMatch\x12\x16\n" +
 	"\x05exact\x18\x01 \x01(\tH\x00R\x05exact\x12\x18\n" +
 	"\x06prefix\x18\x02 \x01(\tH\x00R\x06prefix\x12\x16\n" +
-	"\x05regex\x18\x03 \x01(\tH\x00R\x05regexB\f\n" +
+	"\x05regex\x18\x03 \x01(\tH\x00R\x05regex\x12%\n" +
+	"\rpath_template\x18\x04 \x01(\tH\x00R\fpathTemplateB\f\n" +
 	"\n" +
 	"match_type\"\xe9\x02\n" +
 	"\tHTTPRetry\x12\x1a\n" +
@@ -3854,6 +3880,7 @@ func file_networking_v1alpha3_virtual_service_proto_init() {
 		(*StringMatch_Exact)(nil),
 		(*StringMatch_Prefix)(nil),
 		(*StringMatch_Regex)(nil),
+		(*StringMatch_PathTemplate)(nil),
 	}
 	file_networking_v1alpha3_virtual_service_proto_msgTypes[33].OneofWrappers = []any{
 		(*HTTPFaultInjection_Delay_FixedDelay)(nil),

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -1882,6 +1882,21 @@ case-sensitive. <code>regex</code> matching supports case-insensitive matches.</
 
 </td>
 </tr>
+<tr id="StringMatch-path_template" class="oneof">
+<td><div class="field"><div class="name"><code><a href="#StringMatch-path_template">pathTemplate</a></code></div>
+<div class="type">string (oneof)</div>
+</div></td>
+<td>
+<p>URI template path match using <code>{*}</code> (matches one path segment) and <code>{**}</code> (matches one or more
+path segments) operators. This leverages Envoy&rsquo;s
+<a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/path/match/uri_template/v3/uri_template_match.proto">UriTemplateMatchConfig</a>
+and is more readable and performant than equivalent regex patterns.</p>
+<p>Example: <code>/users/{*}/orders/{**}</code> matches <code>/users/alice/orders</code> and <code>/users/alice/orders/123/items</code>.</p>
+<p>Note: <code>{**}</code> must be the last operator in the path template. Only valid for <code>uri</code> matches
+in HTTPMatchRequest.</p>
+
+</td>
+</tr>
 </tbody>
 </table>
 </section>

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -1270,6 +1270,17 @@ message StringMatch {
     //
     // Example: `(?i)^aaa$` can be used to case-insensitive match a string consisting of three a's.
     string regex = 3;
+
+    // URI template path match using `{*}` (matches one path segment) and `{**}` (matches one or more
+    // path segments) operators. This leverages Envoy's
+    // [UriTemplateMatchConfig](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/path/match/uri_template/v3/uri_template_match.proto)
+    // and is more readable and performant than equivalent regex patterns.
+    //
+    // Example: `/users/{*}/orders/{**}` matches `/users/alice/orders` and `/users/alice/orders/123/items`.
+    //
+    // Note: `{**}` must be the last operator in the path template. Only valid for `uri` matches
+    // in HTTPMatchRequest.
+    string path_template = 4;
   }
 }
 

--- a/networking/v1beta1/virtual_service_alias.gen.go
+++ b/networking/v1beta1/virtual_service_alias.gen.go
@@ -673,6 +673,17 @@ type StringMatch_Prefix = v1alpha3.StringMatch_Prefix
 // Example: `(?i)^aaa$` can be used to case-insensitive match a string consisting of three a's.
 type StringMatch_Regex = v1alpha3.StringMatch_Regex
 
+// URI template path match using `{*}` (matches one path segment) and `{**}` (matches one or more
+// path segments) operators. This leverages Envoy's
+// [UriTemplateMatchConfig](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/path/match/uri_template/v3/uri_template_match.proto)
+// and is more readable and performant than equivalent regex patterns.
+//
+// Example: `/users/{*}/orders/{**}` matches `/users/alice/orders` and `/users/alice/orders/123/items`.
+//
+// Note: `{**}` must be the last operator in the path template. Only valid for `uri` matches
+// in HTTPMatchRequest.
+type StringMatch_PathTemplate = v1alpha3.StringMatch_PathTemplate
+
 // Describes the retry policy to use when a HTTP request fails. For
 // example, the following rule sets the maximum number of retries to 3 when
 // calling ratings:v1 service, with a 2s timeout per retry attempt.


### PR DESCRIPTION
## Description

Add a new `pathTemplate` oneof variant to `StringMatch` to support URI template path matching in VirtualService `HTTPMatchRequest.uri`.

This allows matching patterns like `/users/{*}/orders` without resorting to regex:

```yaml
apiVersion: networking.istio.io/v1
kind: VirtualService
metadata:
  name: example
spec:
  hosts:
  - example.com
  http:
  - match:
    - uri:
        pathTemplate: "/users/{*}/orders"
    route:
    - destination:
        host: orders-service
```

- `{*}` matches exactly one path segment
- `{**}` matches one or more path segments (must be the last operator)

Backed by Envoy's [`UriTemplateMatchConfig`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/path/match/uri_template/v3/uri_template_match.proto) extension, the same mechanism already used for `AuthorizationPolicy` path matching.

## Motivation

- **Consistency**: `AuthorizationPolicy` already supports `{*}`/`{**}` path templates (#47306); `VirtualService` should too
- **Simplicity**: more readable and less error-prone than equivalent regex for REST API patterns
- **Performance**: avoids regex evaluation overhead

## Related

- Fixes https://github.com/istio/istio/issues/59533
- #47306 — added `{*}`/`{**}` to `AuthorizationPolicy`

The implementation in `istio/istio` is submitted as a dependent PR and will be linked once this merges.