### PR TITLE
Fix EnvoyFilter port validation

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -7011,7 +7011,7 @@ spec:
                               type: integer
                               x-kubernetes-validations:
                               - message: port must be between 1-65535
-                                rule: 0 < self && self <= 6553
+                                rule: 0 < self && self <= 65535
                             route:
                               description: Match a specific route.
                               properties:

--- a/networking/v1alpha3/envoy_filter.pb.go
+++ b/networking/v1alpha3/envoy_filter.pb.go
@@ -1317,7 +1317,7 @@ type EnvoyFilter_WaypointMatch struct {
 	// The service port to match on.
 	// If not specified, matches all ports.
 	//
-	// +kubebuilder:validation:XValidation:message="port must be between 1-65535",rule="0 < self && self <= 65535
+	// +kubebuilder:validation:XValidation:message="port must be between 1-65535",rule="0 < self && self <= 65535"
 	PortNumber uint32 `protobuf:"varint,1,opt,name=port_number,json=portNumber,proto3" json:"port_number,omitempty"`
 	// Match a specific route.
 	Route *EnvoyFilter_WaypointMatch_RouteMatch `protobuf:"bytes,2,opt,name=route,proto3" json:"route,omitempty"`

--- a/networking/v1alpha3/envoy_filter.proto
+++ b/networking/v1alpha3/envoy_filter.proto
@@ -739,7 +739,7 @@ message EnvoyFilter {
     // The service port to match on.
     // If not specified, matches all ports.
     //
-    // +kubebuilder:validation:XValidation:message="port must be between 1-65535",rule="0 < self && self <= 65535
+    // +kubebuilder:validation:XValidation:message="port must be between 1-65535",rule="0 < self && self <= 65535"
     uint32 port_number = 1;
 
     // Conditions specified in `RouteMatch` must be met for the patch

--- a/releasenotes/notes/3688.yaml
+++ b/releasenotes/notes/3688.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/api/pull/3688
+releaseNotes:
+  - |
+    **Fixed** EnvoyFilter port validation rule for `WaypointMatch` which had a truncated upper bound (`6553` instead of `65535`).


### PR DESCRIPTION
Apparently the missing quotation causes trunctation. Fixes istio/istio#59832