### PR TITLE
docs: note that OutlierDetection implicitly activates locality LB failover

### DIFF
--- a/networking/v1/destination_rule_alias.gen.go
+++ b/networking/v1/destination_rule_alias.gen.go
@@ -287,6 +287,15 @@ const ConnectionPoolSettings_HTTPSettings_UPGRADE ConnectionPoolSettings_HTTPSet
 // detection](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier)
 // for more details.
 //
+// **Note:** Istio's default mesh configuration enables locality load balancing
+// (`localityLbSetting.enabled: true`). As a result, configuring
+// `OutlierDetection` in a `DestinationRule` will automatically activate
+// locality-aware failover behavior — Envoy uses the outlier detection state to
+// determine when endpoints are unhealthy and should be failed over to the next
+// locality. To suppress this implicit failover, explicitly set
+// `localityLbSetting.enabled: false` in the `DestinationRule`'s load balancer
+// settings.
+//
 // The following rule sets a connection pool size of 100 HTTP1 connections
 // with no more than 10 req/connection to the "reviews" service. In addition,
 // it sets a limit of 1000 concurrent HTTP/2 requests and configures upstream

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1082,6 +1082,15 @@ func (x *ConnectionPoolSettings) GetHttp() *ConnectionPoolSettings_HTTPSettings 
 // detection](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier)
 // for more details.
 //
+// **Note:** Istio's default mesh configuration enables locality load balancing
+// (`localityLbSetting.enabled: true`). As a result, configuring
+// `OutlierDetection` in a `DestinationRule` will automatically activate
+// locality-aware failover behavior — Envoy uses the outlier detection state to
+// determine when endpoints are unhealthy and should be failed over to the next
+// locality. To suppress this implicit failover, explicitly set
+// `localityLbSetting.enabled: false` in the `DestinationRule`'s load balancer
+// settings.
+//
 // The following rule sets a connection pool size of 100 HTTP1 connections
 // with no more than 10 req/connection to the "reviews" service. In addition,
 // it sets a limit of 1000 concurrent HTTP/2 requests and configures upstream

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1326,6 +1326,14 @@ failures to a given host counts as an error when measuring the
 consecutive errors metric. See Envoy&rsquo;s <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier">outlier
 detection</a>
 for more details.</p>
+<p><strong>Note:</strong> Istio&rsquo;s default mesh configuration enables locality load balancing
+(<code>localityLbSetting.enabled: true</code>). As a result, configuring
+<code>OutlierDetection</code> in a <code>DestinationRule</code> will automatically activate
+locality-aware failover behavior — Envoy uses the outlier detection state to
+determine when endpoints are unhealthy and should be failed over to the next
+locality. To suppress this implicit failover, explicitly set
+<code>localityLbSetting.enabled: false</code> in the <code>DestinationRule</code>&rsquo;s load balancer
+settings.</p>
 <p>The following rule sets a connection pool size of 100 HTTP1 connections
 with no more than 10 req/connection to the &ldquo;reviews&rdquo; service. In addition,
 it sets a limit of 1000 concurrent HTTP/2 requests and configures upstream

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -713,6 +713,15 @@ message ConnectionPoolSettings {
 // detection](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier)
 // for more details.
 //
+// **Note:** Istio's default mesh configuration enables locality load balancing
+// (`localityLbSetting.enabled: true`). As a result, configuring
+// `OutlierDetection` in a `DestinationRule` will automatically activate
+// locality-aware failover behavior — Envoy uses the outlier detection state to
+// determine when endpoints are unhealthy and should be failed over to the next
+// locality. To suppress this implicit failover, explicitly set
+// `localityLbSetting.enabled: false` in the `DestinationRule`'s load balancer
+// settings.
+//
 // The following rule sets a connection pool size of 100 HTTP1 connections
 // with no more than 10 req/connection to the "reviews" service. In addition,
 // it sets a limit of 1000 concurrent HTTP/2 requests and configures upstream

--- a/networking/v1beta1/destination_rule_alias.gen.go
+++ b/networking/v1beta1/destination_rule_alias.gen.go
@@ -287,6 +287,15 @@ const ConnectionPoolSettings_HTTPSettings_UPGRADE ConnectionPoolSettings_HTTPSet
 // detection](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier)
 // for more details.
 //
+// **Note:** Istio's default mesh configuration enables locality load balancing
+// (`localityLbSetting.enabled: true`). As a result, configuring
+// `OutlierDetection` in a `DestinationRule` will automatically activate
+// locality-aware failover behavior — Envoy uses the outlier detection state to
+// determine when endpoints are unhealthy and should be failed over to the next
+// locality. To suppress this implicit failover, explicitly set
+// `localityLbSetting.enabled: false` in the `DestinationRule`'s load balancer
+// settings.
+//
 // The following rule sets a connection pool size of 100 HTTP1 connections
 // with no more than 10 req/connection to the "reviews" service. In addition,
 // it sets a limit of 1000 concurrent HTTP/2 requests and configures upstream


### PR DESCRIPTION
Adds a note to the `OutlierDetection` message doc comment in `destination_rule.proto` explaining that because Istio's default mesh config enables `LocalityLbSetting` (`Enabled:true`), configuring `OutlierDetection` in a `DestinationRule` automatically activates locality-aware failover — even without an explicit `localityLbSetting` in the rule. Documents the opt-out: set `localityLbSetting.enabled: false` in the DR's load balancer settings.