### PR TITLE
Add annotation to 'ignore' specific policy attachment objects

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -29,6 +29,8 @@ const (
 	Unknown ResourceTypes = iota
     Any
     AuthorizationPolicy
+    BackendTLSPolicy
+    BackendTrafficPolicy
     Gateway
     GatewayClass
     Ingress
@@ -46,20 +48,24 @@ func (r ResourceTypes) String() string {
 	case 2:
 		return "AuthorizationPolicy"
 	case 3:
-		return "Gateway"
+		return "BackendTLSPolicy"
 	case 4:
-		return "GatewayClass"
+		return "BackendTrafficPolicy"
 	case 5:
-		return "Ingress"
+		return "Gateway"
 	case 6:
-		return "Namespace"
+		return "GatewayClass"
 	case 7:
-		return "Pod"
+		return "Ingress"
 	case 8:
-		return "Service"
+		return "Namespace"
 	case 9:
-		return "ServiceEntry"
+		return "Pod"
 	case 10:
+		return "Service"
+	case 11:
+		return "ServiceEntry"
+	case 12:
 		return "WorkloadEntry"
 	}
 	return "Unknown"
@@ -282,6 +288,21 @@ This takes the format: "<protocol>" or "<protocol>/<port>".
 		Deprecated:    false,
 		Resources: []ResourceTypes{
 			AuthorizationPolicy,
+		},
+	}
+
+	IoIstioIgnorePolicyAttachment = Instance {
+		Name:          "istio.io/ignore-policy-attachment",
+		Description:   "When set to true on a policy attachment CRD object "+
+                        "(BackendTLSPolicy, BackendTrafficPolicy), the object will "+
+                        "not be used by the Istio control plane to generate "+
+                        "configuration or conflict with other policies.",
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			BackendTLSPolicy,
+			BackendTrafficPolicy,
 		},
 	}
 
@@ -981,6 +1002,7 @@ func AllResourceAnnotations() []*Instance {
 		&IoIstioConnectedAt,
 		&IoIstioDisconnectedAt,
 		&IoIstioDryRun,
+		&IoIstioIgnorePolicyAttachment,
 		&IoIstioRerouteVirtualInterfaces,
 		&IoIstioRev,
 		&IoIstioWorkloadController,
@@ -1040,6 +1062,8 @@ func AllResourceTypes() []string {
 	return []string {
 		"Any",
 		"AuthorizationPolicy",
+		"BackendTLSPolicy",
+		"BackendTrafficPolicy",
 		"Gateway",
 		"GatewayClass",
 		"Ingress",

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -122,6 +122,28 @@ User should not manually modify this annotation.</p>
     </tr>
   </tbody>
 </table>
+<h2 id="IoIstioIgnorePolicyAttachment">istio.io/ignore-policy-attachment</h2>
+<table class="annotations">
+  <tbody>
+    <tr>
+      <th>Name</th>
+      <td><code>istio.io/ignore-policy-attachment</code></td>
+    </tr>
+    <tr>
+      <th>Feature Status</th>
+      <td>Alpha</td>
+    </tr>
+    <tr>
+      <th>Resource Types</th>
+      <td>[BackendTLSPolicy BackendTrafficPolicy]</td>
+    </tr>
+    <tr>
+      <th>Description</th>
+      <td><p>When set to true on a policy attachment CRD object (BackendTLSPolicy, BackendTrafficPolicy), the object will not be used by the Istio control plane to generate configuration or conflict with other policies.</p>
+</td>
+    </tr>
+  </tbody>
+</table>
 <h2 id="IoIstioRerouteVirtualInterfaces">istio.io/reroute-virtual-interfaces</h2>
 <table class="annotations">
   <tbody>

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -447,6 +447,18 @@ annotations:
     resources:
       - Pod
 
+  - name: istio.io/ignore-policy-attachment
+    featureStatus: Alpha
+    description: When set to true on a policy attachment CRD object (BackendTLSPolicy,
+      BackendTrafficPolicy), the object will not be used by the
+      Istio control plane to generate configuration or conflict with other
+      policies.
+    deprecated: false
+    hidden: false
+    resources:
+      - BackendTLSPolicy
+      - BackendTrafficPolicy
+
   - name: proxy.istio.io/overrides
     featureStatus: Alpha
     description: Used internally to indicate user-specified overrides in the proxy container of the pod during injection.

--- a/releasenotes/notes/60122.yaml
+++ b/releasenotes/notes/60122.yaml
@@ -1,0 +1,21 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- https://github.com/istio/istio/issues/60122
+releaseNotes:
+- |
+  **Added** support for excluding policy configuration from Istio when the
+  `istio.io/ignore-policy-attachment` annotation is set to "true" on a
+  BackendTLSPolicy, or XBackendTrafficPolicy object. This allows users to
+  prevent specific policies from being translated into Istio configuration,
+  when policy is intended for a different gateway controller than Istio.
+  
+  Example usage:
+  ```yaml
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: BackendTLSPolicy
+  metadata:
+    annotations:
+      istio.io/ignore-policy-attachment: "true"
+  ```


### PR DESCRIPTION
Following up on https://github.com/istio/istio/pull/60240#discussion_r3251046575. Adding in the `istio.io/ignore-policy-attachment` annotation in order to include it in official docs.