### PR TITLE
Add the support on clock_skew_seconds in request authentication

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -16709,6 +16709,12 @@ spec:
                         minLength: 1
                         type: string
                       type: array
+                    clockSkewSeconds:
+                      description: The clock skew, in seconds, allowed when verifying
+                        the JWT `exp` and `nbf` claims.
+                      maximum: 4294967295
+                      minimum: 0
+                      type: integer
                     forwardOriginalToken:
                       description: If set to true, the original token will be kept
                         for the upstream request.
@@ -16998,6 +17004,12 @@ spec:
                         minLength: 1
                         type: string
                       type: array
+                    clockSkewSeconds:
+                      description: The clock skew, in seconds, allowed when verifying
+                        the JWT `exp` and `nbf` claims.
+                      maximum: 4294967295
+                      minimum: 0
+                      type: integer
                     forwardOriginalToken:
                       description: If set to true, the original token will be kept
                         for the upstream request.

--- a/releasenotes/notes/jwt-clock-skew-seconds.yaml
+++ b/releasenotes/notes/jwt-clock-skew-seconds.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - https://github.com/istio/istio/issues/60259
+
+releaseNotes:
+  - |
+    **Added** `clockSkewSeconds` field in `RequestAuthentication` under `spec.jwtRules.` to configure the
+    clock skew tolerance (in seconds) applied when validating the JWT `exp` and `nbf` claims. When unset,
+    the previous default of 60 seconds is preserved.

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -549,8 +549,11 @@ type JWTRule struct {
 	// +protoc-gen-crd:list-value-validation:MinLength=1
 	// +kubebuilder:validation:MaxItems=64
 	SpaceDelimitedClaims []string `protobuf:"bytes,14,rep,name=space_delimited_claims,json=spaceDelimitedClaims,proto3" json:"space_delimited_claims,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// The clock skew, in seconds, allowed when verifying the JWT `exp` and `nbf`
+	// claims. If not specified, the default is 60 seconds.
+	ClockSkewSeconds uint32 `protobuf:"varint,15,opt,name=clock_skew_seconds,json=clockSkewSeconds,proto3" json:"clock_skew_seconds,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *JWTRule) Reset() {
@@ -665,6 +668,13 @@ func (x *JWTRule) GetSpaceDelimitedClaims() []string {
 		return x.SpaceDelimitedClaims
 	}
 	return nil
+}
+
+func (x *JWTRule) GetClockSkewSeconds() uint32 {
+	if x != nil {
+		return x.ClockSkewSeconds
+	}
+	return 0
 }
 
 // This message specifies a header location to extract JWT token.
@@ -795,7 +805,7 @@ const file_security_v1beta1_request_authentication_proto_rawDesc = "" +
 	"\n" +
 	"targetRefs\x18\x04 \x03(\v2).istio.type.v1beta1.PolicyTargetReferenceR\n" +
 	"targetRefs\x12<\n" +
-	"\tjwt_rules\x18\x02 \x03(\v2\x1f.istio.security.v1beta1.JWTRuleR\bjwtRules\"\xb0\x04\n" +
+	"\tjwt_rules\x18\x02 \x03(\v2\x1f.istio.security.v1beta1.JWTRuleR\bjwtRules\"\xde\x04\n" +
 	"\aJWTRule\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1c\n" +
 	"\taudiences\x18\x02 \x03(\tR\taudiences\x12\x19\n" +
@@ -810,7 +820,8 @@ const file_security_v1beta1_request_authentication_proto_rawDesc = "" +
 	"\x16forward_original_token\x18\t \x01(\bR\x14forwardOriginalToken\x12\\\n" +
 	"\x17output_claim_to_headers\x18\v \x03(\v2%.istio.security.v1beta1.ClaimToHeaderR\x14outputClaimToHeaders\x123\n" +
 	"\atimeout\x18\r \x01(\v2\x19.google.protobuf.DurationR\atimeout\x124\n" +
-	"\x16space_delimited_claims\x18\x0e \x03(\tR\x14spaceDelimitedClaims\"=\n" +
+	"\x16space_delimited_claims\x18\x0e \x03(\tR\x14spaceDelimitedClaims\x12,\n" +
+	"\x12clock_skew_seconds\x18\x0f \x01(\rR\x10clockSkewSeconds\"=\n" +
 	"\tJWTHeader\x12\x18\n" +
 	"\x04name\x18\x01 \x01(\tB\x04\xe2A\x01\x02R\x04name\x12\x16\n" +
 	"\x06prefix\x18\x02 \x01(\tR\x06prefix\"I\n" +

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -481,6 +481,16 @@ regardless of this setting.</p>
 
 </td>
 </tr>
+<tr id="JWTRule-clock_skew_seconds">
+<td><div class="field"><div class="name"><code><a href="#JWTRule-clock_skew_seconds">clockSkewSeconds</a></code></div>
+<div class="type">uint32</div>
+</div></td>
+<td>
+<p>The clock skew, in seconds, allowed when verifying the JWT <code>exp</code> and <code>nbf</code>
+claims. If not specified, the default is 60 seconds.</p>
+
+</td>
+</tr>
 </tbody>
 </table>
 </section>

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -487,8 +487,12 @@ message JWTRule {
   // +kubebuilder:validation:MaxItems=64
   repeated string space_delimited_claims = 14;
 
+  // The clock skew, in seconds, allowed when verifying the JWT `exp` and `nbf`
+  // claims. If not specified, the default is 60 seconds.
+  uint32 clock_skew_seconds = 15;
+
   // $hide_from_docs
-  // Next available field number: 15
+  // Next available field number: 16
 }
 
 // This message specifies a header location to extract JWT token.


### PR DESCRIPTION
It's to mimic the support of `clock_skew_seconds` on jwt_authn https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/jwt_authn/v3/config.proto