### PR TITLE
[release-1.27] stats: add bootstrap annotations for stats flush and eviction

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -681,6 +681,46 @@ Supported values are "brotli", "gzip", and "zstd".
 		},
 	}
 
+	SidecarStatsEvictionInterval = Instance {
+		Name:          "sidecar.istio.io/statsEvictionInterval",
+		Description:   "Specifies the expiration interval for the Istio standard "+
+                        "metrics. This gets rounded to a multiple of the flush "+
+                        "interval. A time series is expected to be evicted after 2 "+
+                        "iterations of this interval from the last measurement.",
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Pod,
+		},
+	}
+
+	SidecarStatsFlushInterval = Instance {
+		Name:          "sidecar.istio.io/statsFlushInterval",
+		Description:   "Specifies the flush interval for push-based stat sinks, "+
+                        "e.g. OTLP. Default interval is `5s`.",
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Pod,
+		},
+	}
+
+	SidecarStatsHistogramBins = Instance {
+		Name:          "sidecar.istio.io/statsHistogramBins",
+		Description:   "Specifies the bin size per time series for the Istio "+
+                        "standard metrics histograms. Reducing this value from the "+
+                        "default `100` decreases overall memory usage for sparse "+
+                        "and/or high cardinality histograms.",
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Pod,
+		},
+	}
+
 	SidecarStatsHistogramBuckets = Instance {
 		Name:          "sidecar.istio.io/statsHistogramBuckets",
 		Description:   "Specifies the custom histogram buckets with a prefix "+
@@ -968,6 +1008,9 @@ func AllResourceAnnotations() []*Instance {
 		&SidecarProxyMemoryLimit,
 		&SidecarRewriteAppHTTPProbers,
 		&SidecarStatsCompression,
+		&SidecarStatsEvictionInterval,
+		&SidecarStatsFlushInterval,
+		&SidecarStatsHistogramBins,
 		&SidecarStatsHistogramBuckets,
 		&SidecarStatsInclusionPrefixes,
 		&SidecarStatsInclusionRegexps,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -730,6 +730,72 @@ Supported values are <code>brotli</code>, <code>gzip</code>, and <code>zstd</cod
     </tr>
   </tbody>
 </table>
+<h2 id="SidecarStatsEvictionInterval">sidecar.istio.io/statsEvictionInterval</h2>
+<table class="annotations">
+  <tbody>
+    <tr>
+      <th>Name</th>
+      <td><code>sidecar.istio.io/statsEvictionInterval</code></td>
+    </tr>
+    <tr>
+      <th>Feature Status</th>
+      <td>Alpha</td>
+    </tr>
+    <tr>
+      <th>Resource Types</th>
+      <td>[Pod]</td>
+    </tr>
+    <tr>
+      <th>Description</th>
+      <td><p>Specifies the expiration interval for the Istio standard metrics. This gets rounded to a multiple of the flush interval. A time series is expected to be evicted after 2 iterations of this interval from the last measurement.</p>
+</td>
+    </tr>
+  </tbody>
+</table>
+<h2 id="SidecarStatsFlushInterval">sidecar.istio.io/statsFlushInterval</h2>
+<table class="annotations">
+  <tbody>
+    <tr>
+      <th>Name</th>
+      <td><code>sidecar.istio.io/statsFlushInterval</code></td>
+    </tr>
+    <tr>
+      <th>Feature Status</th>
+      <td>Alpha</td>
+    </tr>
+    <tr>
+      <th>Resource Types</th>
+      <td>[Pod]</td>
+    </tr>
+    <tr>
+      <th>Description</th>
+      <td><p>Specifies the flush interval for push-based stat sinks, e.g. OTLP. Default interval is <code>5s</code>.</p>
+</td>
+    </tr>
+  </tbody>
+</table>
+<h2 id="SidecarStatsHistogramBins">sidecar.istio.io/statsHistogramBins</h2>
+<table class="annotations">
+  <tbody>
+    <tr>
+      <th>Name</th>
+      <td><code>sidecar.istio.io/statsHistogramBins</code></td>
+    </tr>
+    <tr>
+      <th>Feature Status</th>
+      <td>Alpha</td>
+    </tr>
+    <tr>
+      <th>Resource Types</th>
+      <td>[Pod]</td>
+    </tr>
+    <tr>
+      <th>Description</th>
+      <td><p>Specifies the bin size per time series for the Istio standard metrics histograms. Reducing this value from the default <code>100</code> decreases overall memory usage for sparse and/or high cardinality histograms.</p>
+</td>
+    </tr>
+  </tbody>
+</table>
 <h2 id="SidecarStatsHistogramBuckets">sidecar.istio.io/statsHistogramBuckets</h2>
 <table class="annotations">
   <tbody>

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -191,6 +191,35 @@ annotations:
     resources:
       - Pod
 
+  - name: sidecar.istio.io/statsFlushInterval
+    featureStatus: Alpha
+    description: Specifies the flush interval for push-based stat sinks, e.g. OTLP. Default interval is `5s`.
+    deprecated: false
+    hidden: false
+    resources:
+      - Pod
+
+  - name: sidecar.istio.io/statsEvictionInterval
+    featureStatus: Alpha
+    description: Specifies the expiration interval for the Istio standard
+      metrics. This gets rounded to a multiple of the flush interval. A time
+      series is expected to be evicted after 2 iterations of this interval from
+      the last measurement.
+    deprecated: false
+    hidden: false
+    resources:
+      - Pod
+
+  - name: sidecar.istio.io/statsHistogramBins
+    featureStatus: Alpha
+    description: Specifies the bin size per time series for the Istio standard
+      metrics histograms. Reducing this value from the default `100` decreases
+      overall memory usage for sparse and/or high cardinality histograms.
+    deprecated: false
+    hidden: false
+    resources:
+      - Pod
+
   - name: sidecar.istio.io/userVolume
     featureStatus: Alpha
     description: Specifies one or more user volumes (as a JSON array) to be added to


### PR DESCRIPTION
Back port of #3562

This is part of a coordinated backport to back port stats eviction support from Envoy 1.36 / Istio 1.28 to Envoy 1.35 / Istio 1.27, to address unbounded metric memory growth in waypoint proxies. The full set of changes to be back ported across repositories:

- envoyproxy/envoy#40395
- envoyproxy/envoy#42168
- istio/proxy#6529
- istio/api#3562 (This PR)
- istio/istio#57736
- istio/istio#58570