### PR TITLE
[feat] GWAPI: introduce insecure_skip_verify to ServerTLSSettings

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -7567,10 +7567,6 @@ spec:
                       description: Set of TLS related options that govern the server's
                         behavior.
                       properties:
-                        allowInsecure:
-                          description: 'Optional: If set to true, the proxy will accept
-                            connections even when the certificate does not pass validation.'
-                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -7605,6 +7601,12 @@ spec:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
                             to use HTTPS.
+                          type: boolean
+                        insecureSkipVerify:
+                          description: 'Optional: If set to true, the proxy will try
+                            to validate the certificate, but even if the validation
+                            fails, it will allow the connection through.'
+                          nullable: true
                           type: boolean
                         maxProtocolVersion:
                           description: |-
@@ -7846,10 +7848,6 @@ spec:
                       description: Set of TLS related options that govern the server's
                         behavior.
                       properties:
-                        allowInsecure:
-                          description: 'Optional: If set to true, the proxy will accept
-                            connections even when the certificate does not pass validation.'
-                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -7884,6 +7882,12 @@ spec:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
                             to use HTTPS.
+                          type: boolean
+                        insecureSkipVerify:
+                          description: 'Optional: If set to true, the proxy will try
+                            to validate the certificate, but even if the validation
+                            fails, it will allow the connection through.'
+                          nullable: true
                           type: boolean
                         maxProtocolVersion:
                           description: |-
@@ -8125,10 +8129,6 @@ spec:
                       description: Set of TLS related options that govern the server's
                         behavior.
                       properties:
-                        allowInsecure:
-                          description: 'Optional: If set to true, the proxy will accept
-                            connections even when the certificate does not pass validation.'
-                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -8163,6 +8163,12 @@ spec:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
                             to use HTTPS.
+                          type: boolean
+                        insecureSkipVerify:
+                          description: 'Optional: If set to true, the proxy will try
+                            to validate the certificate, but even if the validation
+                            fails, it will allow the connection through.'
+                          nullable: true
                           type: boolean
                         maxProtocolVersion:
                           description: |-
@@ -9794,10 +9800,6 @@ spec:
                         termination on the sidecar for requests originating from outside
                         the mesh.
                       properties:
-                        allowInsecure:
-                          description: 'Optional: If set to true, the proxy will accept
-                            connections even when the certificate does not pass validation.'
-                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -9832,6 +9834,12 @@ spec:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
                             to use HTTPS.
+                          type: boolean
+                        insecureSkipVerify:
+                          description: 'Optional: If set to true, the proxy will try
+                            to validate the certificate, but even if the validation
+                            fails, it will allow the connection through.'
+                          nullable: true
                           type: boolean
                         maxProtocolVersion:
                           description: |-
@@ -10413,10 +10421,6 @@ spec:
                         termination on the sidecar for requests originating from outside
                         the mesh.
                       properties:
-                        allowInsecure:
-                          description: 'Optional: If set to true, the proxy will accept
-                            connections even when the certificate does not pass validation.'
-                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -10451,6 +10455,12 @@ spec:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
                             to use HTTPS.
+                          type: boolean
+                        insecureSkipVerify:
+                          description: 'Optional: If set to true, the proxy will try
+                            to validate the certificate, but even if the validation
+                            fails, it will allow the connection through.'
+                          nullable: true
                           type: boolean
                         maxProtocolVersion:
                           description: |-
@@ -11032,10 +11042,6 @@ spec:
                         termination on the sidecar for requests originating from outside
                         the mesh.
                       properties:
-                        allowInsecure:
-                          description: 'Optional: If set to true, the proxy will accept
-                            connections even when the certificate does not pass validation.'
-                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -11070,6 +11076,12 @@ spec:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
                             to use HTTPS.
+                          type: boolean
+                        insecureSkipVerify:
+                          description: 'Optional: If set to true, the proxy will try
+                            to validate the certificate, but even if the validation
+                            fails, it will allow the connection through.'
+                          nullable: true
                           type: boolean
                         maxProtocolVersion:
                           description: |-

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -7567,6 +7567,10 @@ spec:
                       description: Set of TLS related options that govern the server's
                         behavior.
                       properties:
+                        allowInsecure:
+                          description: 'Optional: If set to true, the proxy will accept
+                            connections even when the certificate does not pass validation.'
+                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -7842,6 +7846,10 @@ spec:
                       description: Set of TLS related options that govern the server's
                         behavior.
                       properties:
+                        allowInsecure:
+                          description: 'Optional: If set to true, the proxy will accept
+                            connections even when the certificate does not pass validation.'
+                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -8117,6 +8125,10 @@ spec:
                       description: Set of TLS related options that govern the server's
                         behavior.
                       properties:
+                        allowInsecure:
+                          description: 'Optional: If set to true, the proxy will accept
+                            connections even when the certificate does not pass validation.'
+                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -9782,6 +9794,10 @@ spec:
                         termination on the sidecar for requests originating from outside
                         the mesh.
                       properties:
+                        allowInsecure:
+                          description: 'Optional: If set to true, the proxy will accept
+                            connections even when the certificate does not pass validation.'
+                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -10397,6 +10413,10 @@ spec:
                         termination on the sidecar for requests originating from outside
                         the mesh.
                       properties:
+                        allowInsecure:
+                          description: 'Optional: If set to true, the proxy will accept
+                            connections even when the certificate does not pass validation.'
+                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -11012,6 +11032,10 @@ spec:
                         termination on the sidecar for requests originating from outside
                         the mesh.
                       properties:
+                        allowInsecure:
+                          description: 'Optional: If set to true, the proxy will accept
+                            connections even when the certificate does not pass validation.'
+                          type: boolean
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -198,6 +198,7 @@
 package v1alpha3
 
 import (
+	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -837,13 +838,16 @@ type ServerTLSSettings struct {
 	// * `AES256-SHA`
 	// * `DES-CBC3-SHA`
 	CipherSuites []string `protobuf:"bytes,9,rep,name=cipher_suites,json=cipherSuites,proto3" json:"cipher_suites,omitempty"`
-	// Optional: If set to true, the proxy will accept connections even when the certificate
-	// does not pass validation. This is a security risk and is not recommened, but it's part
-	// of the Gateway API and we support it to comply with the Gateway API conformance
-	// requirements.
-	AllowInsecure bool `protobuf:"varint,17,opt,name=allow_insecure,json=allowInsecure,proto3" json:"allow_insecure,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Optional: If set to true, the proxy will try to validate the certificate, but even if the
+	// validation fails, it will allow the connection through.
+	//
+	// It's needed to implement Gateway API AllowInsecureFallback feature. The different between
+	// AllowInsecureFallback and not verifying client certificate at all is that Gateway is able
+	// to pass the client certificate to the backend in the x-forwarded-client-cert HTTP header and
+	// backend can verify the certificate.
+	InsecureSkipVerify *wrappers.BoolValue `protobuf:"bytes,17,opt,name=insecure_skip_verify,json=insecureSkipVerify,proto3" json:"insecure_skip_verify,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *ServerTLSSettings) Reset() {
@@ -988,11 +992,11 @@ func (x *ServerTLSSettings) GetCipherSuites() []string {
 	return nil
 }
 
-func (x *ServerTLSSettings) GetAllowInsecure() bool {
+func (x *ServerTLSSettings) GetInsecureSkipVerify() *wrappers.BoolValue {
 	if x != nil {
-		return x.AllowInsecure
+		return x.InsecureSkipVerify
 	}
-	return false
+	return nil
 }
 
 // TLSCertificate describes the server's TLS certificate.
@@ -1069,7 +1073,7 @@ var File_networking_v1alpha3_gateway_proto protoreflect.FileDescriptor
 
 const file_networking_v1alpha3_gateway_proto_rawDesc = "" +
 	"\n" +
-	"!networking/v1alpha3/gateway.proto\x12\x19istio.networking.v1alpha3\x1a\x1fgoogle/api/field_behavior.proto\"\xd1\x01\n" +
+	"!networking/v1alpha3/gateway.proto\x12\x19istio.networking.v1alpha3\x1a\x1fgoogle/api/field_behavior.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\xd1\x01\n" +
 	"\aGateway\x12;\n" +
 	"\aservers\x18\x01 \x03(\v2!.istio.networking.v1alpha3.ServerR\aservers\x12L\n" +
 	"\bselector\x18\x02 \x03(\v20.istio.networking.v1alpha3.Gateway.SelectorEntryR\bselector\x1a;\n" +
@@ -1088,7 +1092,7 @@ const file_networking_v1alpha3_gateway_proto_rawDesc = "" +
 	"\bprotocol\x18\x02 \x01(\tB\x04\xe2A\x01\x02R\bprotocol\x12\x18\n" +
 	"\x04name\x18\x03 \x01(\tB\x04\xe2A\x01\x02R\x04name\x12#\n" +
 	"\vtarget_port\x18\x04 \x01(\rB\x02\x18\x01R\n" +
-	"targetPort\"\x95\n" +
+	"targetPort\"\xbc\n" +
 	"\n" +
 	"\x11ServerTLSSettings\x12%\n" +
 	"\x0ehttps_redirect\x18\x01 \x01(\bR\rhttpsRedirect\x12H\n" +
@@ -1108,8 +1112,8 @@ const file_networking_v1alpha3_gateway_proto_rawDesc = "" +
 	"\x17verify_certificate_hash\x18\f \x03(\tR\x15verifyCertificateHash\x12j\n" +
 	"\x14min_protocol_version\x18\a \x01(\x0e28.istio.networking.v1alpha3.ServerTLSSettings.TLSProtocolR\x12minProtocolVersion\x12j\n" +
 	"\x14max_protocol_version\x18\b \x01(\x0e28.istio.networking.v1alpha3.ServerTLSSettings.TLSProtocolR\x12maxProtocolVersion\x12#\n" +
-	"\rcipher_suites\x18\t \x03(\tR\fcipherSuites\x12%\n" +
-	"\x0eallow_insecure\x18\x11 \x01(\bR\rallowInsecure\x1a\x89\x01\n" +
+	"\rcipher_suites\x18\t \x03(\tR\fcipherSuites\x12L\n" +
+	"\x14insecure_skip_verify\x18\x11 \x01(\v2\x1a.google.protobuf.BoolValueR\x12insecureSkipVerify\x1a\x89\x01\n" +
 	"\x0eTLSCertificate\x12-\n" +
 	"\x12server_certificate\x18\x01 \x01(\tR\x11serverCertificate\x12\x1f\n" +
 	"\vprivate_key\x18\x02 \x01(\tR\n" +
@@ -1154,6 +1158,7 @@ var file_networking_v1alpha3_gateway_proto_goTypes = []any{
 	(*ServerTLSSettings)(nil),                // 5: istio.networking.v1alpha3.ServerTLSSettings
 	nil,                                      // 6: istio.networking.v1alpha3.Gateway.SelectorEntry
 	(*ServerTLSSettings_TLSCertificate)(nil), // 7: istio.networking.v1alpha3.ServerTLSSettings.TLSCertificate
+	(*wrappers.BoolValue)(nil),               // 8: google.protobuf.BoolValue
 }
 var file_networking_v1alpha3_gateway_proto_depIdxs = []int32{
 	3, // 0: istio.networking.v1alpha3.Gateway.servers:type_name -> istio.networking.v1alpha3.Server
@@ -1164,11 +1169,12 @@ var file_networking_v1alpha3_gateway_proto_depIdxs = []int32{
 	7, // 5: istio.networking.v1alpha3.ServerTLSSettings.tls_certificates:type_name -> istio.networking.v1alpha3.ServerTLSSettings.TLSCertificate
 	1, // 6: istio.networking.v1alpha3.ServerTLSSettings.min_protocol_version:type_name -> istio.networking.v1alpha3.ServerTLSSettings.TLSProtocol
 	1, // 7: istio.networking.v1alpha3.ServerTLSSettings.max_protocol_version:type_name -> istio.networking.v1alpha3.ServerTLSSettings.TLSProtocol
-	8, // [8:8] is the sub-list for method output_type
-	8, // [8:8] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	8, // 8: istio.networking.v1alpha3.ServerTLSSettings.insecure_skip_verify:type_name -> google.protobuf.BoolValue
+	9, // [9:9] is the sub-list for method output_type
+	9, // [9:9] is the sub-list for method input_type
+	9, // [9:9] is the sub-list for extension type_name
+	9, // [9:9] is the sub-list for extension extendee
+	0, // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_networking_v1alpha3_gateway_proto_init() }

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -841,7 +841,7 @@ type ServerTLSSettings struct {
 	// Optional: If set to true, the proxy will try to validate the certificate, but even if the
 	// validation fails, it will allow the connection through.
 	//
-	// It's needed to implement Gateway API AllowInsecureFallback feature. The different between
+	// It's needed to implement Gateway API AllowInsecureFallback feature. The difference between
 	// AllowInsecureFallback and not verifying client certificate at all is that Gateway is able
 	// to pass the client certificate to the backend in the x-forwarded-client-cert HTTP header and
 	// backend can verify the certificate.

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -836,7 +836,12 @@ type ServerTLSSettings struct {
 	// * `AES128-SHA`
 	// * `AES256-SHA`
 	// * `DES-CBC3-SHA`
-	CipherSuites  []string `protobuf:"bytes,9,rep,name=cipher_suites,json=cipherSuites,proto3" json:"cipher_suites,omitempty"`
+	CipherSuites []string `protobuf:"bytes,9,rep,name=cipher_suites,json=cipherSuites,proto3" json:"cipher_suites,omitempty"`
+	// Optional: If set to true, the proxy will accept connections even when the certificate
+	// does not pass validation. This is a security risk and is not recommened, but it's part
+	// of the Gateway API and we support it to comply with the Gateway API conformance
+	// requirements.
+	AllowInsecure bool `protobuf:"varint,17,opt,name=allow_insecure,json=allowInsecure,proto3" json:"allow_insecure,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -983,6 +988,13 @@ func (x *ServerTLSSettings) GetCipherSuites() []string {
 	return nil
 }
 
+func (x *ServerTLSSettings) GetAllowInsecure() bool {
+	if x != nil {
+		return x.AllowInsecure
+	}
+	return false
+}
+
 // TLSCertificate describes the server's TLS certificate.
 type ServerTLSSettings_TLSCertificate struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1076,7 +1088,8 @@ const file_networking_v1alpha3_gateway_proto_rawDesc = "" +
 	"\bprotocol\x18\x02 \x01(\tB\x04\xe2A\x01\x02R\bprotocol\x12\x18\n" +
 	"\x04name\x18\x03 \x01(\tB\x04\xe2A\x01\x02R\x04name\x12#\n" +
 	"\vtarget_port\x18\x04 \x01(\rB\x02\x18\x01R\n" +
-	"targetPort\"\xee\t\n" +
+	"targetPort\"\x95\n" +
+	"\n" +
 	"\x11ServerTLSSettings\x12%\n" +
 	"\x0ehttps_redirect\x18\x01 \x01(\bR\rhttpsRedirect\x12H\n" +
 	"\x04mode\x18\x02 \x01(\x0e24.istio.networking.v1alpha3.ServerTLSSettings.TLSmodeR\x04mode\x12-\n" +
@@ -1095,7 +1108,8 @@ const file_networking_v1alpha3_gateway_proto_rawDesc = "" +
 	"\x17verify_certificate_hash\x18\f \x03(\tR\x15verifyCertificateHash\x12j\n" +
 	"\x14min_protocol_version\x18\a \x01(\x0e28.istio.networking.v1alpha3.ServerTLSSettings.TLSProtocolR\x12minProtocolVersion\x12j\n" +
 	"\x14max_protocol_version\x18\b \x01(\x0e28.istio.networking.v1alpha3.ServerTLSSettings.TLSProtocolR\x12maxProtocolVersion\x12#\n" +
-	"\rcipher_suites\x18\t \x03(\tR\fcipherSuites\x1a\x89\x01\n" +
+	"\rcipher_suites\x18\t \x03(\tR\fcipherSuites\x12%\n" +
+	"\x0eallow_insecure\x18\x11 \x01(\bR\rallowInsecure\x1a\x89\x01\n" +
 	"\x0eTLSCertificate\x12-\n" +
 	"\x12server_certificate\x18\x01 \x01(\tR\x11serverCertificate\x12\x1f\n" +
 	"\vprivate_key\x18\x02 \x01(\tR\n" +

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -841,7 +841,7 @@ type ServerTLSSettings struct {
 	// Optional: If set to true, the proxy will try to validate the certificate, but even if the
 	// validation fails, it will allow the connection through.
 	//
-	// It's needed to implement Gateway API AllowInsecureFallback feature. The difference between
+	// It's needed to implement Gateway API AllowInsecureFallback feature. The different between
 	// AllowInsecureFallback and not verifying client certificate at all is that Gateway is able
 	// to pass the client certificate to the backend in the x-forwarded-client-cert HTTP header and
 	// backend can verify the certificate.

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -622,15 +622,17 @@ The supported list of ciphers are:</p>
 
 </td>
 </tr>
-<tr id="ServerTLSSettings-allow_insecure">
-<td><div class="field"><div class="name"><code><a href="#ServerTLSSettings-allow_insecure">allowInsecure</a></code></div>
-<div class="type">bool</div>
+<tr id="ServerTLSSettings-insecure_skip_verify">
+<td><div class="field"><div class="name"><code><a href="#ServerTLSSettings-insecure_skip_verify">insecureSkipVerify</a></code></div>
+<div class="type"><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#boolvalue">BoolValue</a></div>
 </div></td>
 <td>
-<p>If set to true, the proxy will accept connections even when the certificate
-does not pass validation. This is a security risk and is not recommened, but it&rsquo;s part
-of the Gateway API and we support it to comply with the Gateway API conformance
-requirements.</p>
+<p>If set to true, the proxy will try to validate the certificate, but even if the
+validation fails, it will allow the connection through.</p>
+<p>It&rsquo;s needed to implement Gateway API AllowInsecureFallback feature. The different between
+AllowInsecureFallback and not verifying client certificate at all is that Gateway is able
+to pass the client certificate to the backend in the x-forwarded-client-cert HTTP header and
+backend can verify the certificate.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -622,6 +622,18 @@ The supported list of ciphers are:</p>
 
 </td>
 </tr>
+<tr id="ServerTLSSettings-allow_insecure">
+<td><div class="field"><div class="name"><code><a href="#ServerTLSSettings-allow_insecure">allowInsecure</a></code></div>
+<div class="type">bool</div>
+</div></td>
+<td>
+<p>If set to true, the proxy will accept connections even when the certificate
+does not pass validation. This is a security risk and is not recommened, but it&rsquo;s part
+of the Gateway API and we support it to comply with the Gateway API conformance
+requirements.</p>
+
+</td>
+</tr>
 </tbody>
 </table>
 </section>

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -193,6 +193,7 @@ syntax = "proto3";
 package istio.networking.v1alpha3;
 
 import "google/api/field_behavior.proto";
+import "google/protobuf/wrappers.proto";
 
 option go_package = "istio.io/api/networking/v1alpha3";
 
@@ -578,9 +579,12 @@ message ServerTLSSettings {
   // * `DES-CBC3-SHA`
   repeated string cipher_suites = 9;
 
-  // Optional: If set to true, the proxy will accept connections even when the certificate
-  // does not pass validation. This is a security risk and is not recommened, but it's part
-  // of the Gateway API and we support it to comply with the Gateway API conformance
-  // requirements.
-  bool allow_insecure = 17;
+  // Optional: If set to true, the proxy will try to validate the certificate, but even if the
+  // validation fails, it will allow the connection through.
+  //
+  // It's needed to implement Gateway API AllowInsecureFallback feature. The different between
+  // AllowInsecureFallback and not verifying client certificate at all is that Gateway is able
+  // to pass the client certificate to the backend in the x-forwarded-client-cert HTTP header and
+  // backend can verify the certificate.
+  google.protobuf.BoolValue insecure_skip_verify = 17;
 }

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -577,4 +577,10 @@ message ServerTLSSettings {
   // * `AES256-SHA`
   // * `DES-CBC3-SHA`
   repeated string cipher_suites = 9;
+
+  // Optional: If set to true, the proxy will accept connections even when the certificate
+  // does not pass validation. This is a security risk and is not recommened, but it's part
+  // of the Gateway API and we support it to comply with the Gateway API conformance
+  // requirements.
+  bool allow_insecure = 17;
 }

--- a/releasenotes/notes/3727.yaml
+++ b/releasenotes/notes/3727.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+releaseNotes:
+- |
+  **Added** `insecure_skip_verify` field to `ServerTLSSettings`. When set to `true`, this will tell the gateway to allow the
+  incoming connection even if the client certificate does not pass the checks. It will be used to implement Gateway API
+  `AllowInsecureFallback` feature in Istio.


### PR DESCRIPTION
The intention is to use this flag to configure Envoy to perform the verification of the client certificate if it's provided, but allow the connection through even if the verification failed.

This will be used to implement Gateway API AllowInsecureFallback feature in Istio. The intention behind that feature is to allow connections even when gateway cannot verify the client certificate, but the gateway can then pass the client cert (if it was provided) through to the actual backend (in x-forward-client-cert HTTP header) and backend could potentially verify the cert instead of the gateway.

None of the existing TLS modes that Istio supports covers this functionality, so we need some kind of new mode or a flag to indicate that we should allow connections through even if the certificate is not valid.

The closest thing we have is `OPTIONAL_MUTUAL` mode, but in this mode Istio will allow connections through if the client does not present the certificate, but if client presents the certificate, Istio will properly verify it and will reject the connection if the cert fails this verification.

NOTE: We already have a similar field in the `ClientTLSSettings`, but that's used for verifying certificates on outgoing connections, while this new field in `ServerTLSSettings` controls how gateway will validate the incoming TLS connections.

In Istio, by default, Gateways already populates `x-forward-client-cert` header in gateways (it uses `SANITIZE_SET` by default), but it could be overwritten via `GatewayTopology` in the mesh config to not populate the header at all or to append the certificate to the existing header.

NOTE: I will followup this PR with anoth PR in Istio repo with implementation that actually uses this new field a bit later (I already have the implementation that passes conformance tests in my own repo, but I need to take another look at it before I send for a review).

Signed-off-by: Mikhail Krinkin <mkrinkin@microsoft.com>