### PR TITLE
Improve proto field summary descriptions

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -11593,10 +11593,7 @@ spec:
                       items:
                         properties:
                           authority:
-                            description: 'HTTP Authority values are case-sensitive
-                              and formatted as follows: - `exact: "value"` for exact
-                              string match - `prefix: "value"` for prefix-based match
-                              - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: HTTP Authority.
                             oneOf:
                             - not:
                                 anyOf:
@@ -11661,10 +11658,7 @@ spec:
                               should be case-insensitive.
                             type: boolean
                           method:
-                            description: 'HTTP Method values are case-sensitive and
-                              formatted as follows: - `exact: "value"` for exact string
-                              match - `prefix: "value"` for prefix-based match - `regex:
-                              "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: HTTP Method.
                             oneOf:
                             - not:
                                 anyOf:
@@ -11727,10 +11721,7 @@ spec:
                             description: Query parameters for matching.
                             type: object
                           scheme:
-                            description: 'URI Scheme values are case-sensitive and
-                              formatted as follows: - `exact: "value"` for exact string
-                              match - `prefix: "value"` for prefix-based match - `regex:
-                              "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: URI Scheme.
                             oneOf:
                             - not:
                                 anyOf:
@@ -11771,10 +11762,7 @@ spec:
                               statistics for this route.
                             type: string
                           uri:
-                            description: 'URI to match values are case-sensitive and
-                              formatted as follows: - `exact: "value"` for exact string
-                              match - `prefix: "value"` for prefix-based match - `regex:
-                              "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: URI to match.
                             oneOf:
                             - not:
                                 anyOf:
@@ -12649,10 +12637,7 @@ spec:
                       items:
                         properties:
                           authority:
-                            description: 'HTTP Authority values are case-sensitive
-                              and formatted as follows: - `exact: "value"` for exact
-                              string match - `prefix: "value"` for prefix-based match
-                              - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: HTTP Authority.
                             oneOf:
                             - not:
                                 anyOf:
@@ -12717,10 +12702,7 @@ spec:
                               should be case-insensitive.
                             type: boolean
                           method:
-                            description: 'HTTP Method values are case-sensitive and
-                              formatted as follows: - `exact: "value"` for exact string
-                              match - `prefix: "value"` for prefix-based match - `regex:
-                              "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: HTTP Method.
                             oneOf:
                             - not:
                                 anyOf:
@@ -12783,10 +12765,7 @@ spec:
                             description: Query parameters for matching.
                             type: object
                           scheme:
-                            description: 'URI Scheme values are case-sensitive and
-                              formatted as follows: - `exact: "value"` for exact string
-                              match - `prefix: "value"` for prefix-based match - `regex:
-                              "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: URI Scheme.
                             oneOf:
                             - not:
                                 anyOf:
@@ -12827,10 +12806,7 @@ spec:
                               statistics for this route.
                             type: string
                           uri:
-                            description: 'URI to match values are case-sensitive and
-                              formatted as follows: - `exact: "value"` for exact string
-                              match - `prefix: "value"` for prefix-based match - `regex:
-                              "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: URI to match.
                             oneOf:
                             - not:
                                 anyOf:
@@ -13705,10 +13681,7 @@ spec:
                       items:
                         properties:
                           authority:
-                            description: 'HTTP Authority values are case-sensitive
-                              and formatted as follows: - `exact: "value"` for exact
-                              string match - `prefix: "value"` for prefix-based match
-                              - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: HTTP Authority.
                             oneOf:
                             - not:
                                 anyOf:
@@ -13773,10 +13746,7 @@ spec:
                               should be case-insensitive.
                             type: boolean
                           method:
-                            description: 'HTTP Method values are case-sensitive and
-                              formatted as follows: - `exact: "value"` for exact string
-                              match - `prefix: "value"` for prefix-based match - `regex:
-                              "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: HTTP Method.
                             oneOf:
                             - not:
                                 anyOf:
@@ -13839,10 +13809,7 @@ spec:
                             description: Query parameters for matching.
                             type: object
                           scheme:
-                            description: 'URI Scheme values are case-sensitive and
-                              formatted as follows: - `exact: "value"` for exact string
-                              match - `prefix: "value"` for prefix-based match - `regex:
-                              "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: URI Scheme.
                             oneOf:
                             - not:
                                 anyOf:
@@ -13883,10 +13850,7 @@ spec:
                               statistics for this route.
                             type: string
                           uri:
-                            description: 'URI to match values are case-sensitive and
-                              formatted as follows: - `exact: "value"` for exact string
-                              match - `prefix: "value"` for prefix-based match - `regex:
-                              "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                            description: URI to match.
                             oneOf:
                             - not:
                                 anyOf:

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -1323,8 +1323,9 @@ type HTTPMatchRequest struct {
 	// concatenated with the parent route's name and will be logged in
 	// the access logs for requests matching this route.
 	Name string `protobuf:"bytes,11,opt,name=name,proto3" json:"name,omitempty"`
-	// URI to match
-	// values are case-sensitive and formatted as follows:
+	// URI to match.
+	//
+	// Values are case-sensitive and formatted as follows:
 	//
 	// - `exact: "value"` for exact string match
 	//
@@ -1335,8 +1336,9 @@ type HTTPMatchRequest struct {
 	// **Note:** Case-insensitive matching could be enabled via the
 	// `ignoreUriCase` flag.
 	Uri *StringMatch `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
-	// URI Scheme
-	// values are case-sensitive and formatted as follows:
+	// URI Scheme.
+	//
+	// Values are case-sensitive and formatted as follows:
 	//
 	// - `exact: "value"` for exact string match
 	//
@@ -1344,8 +1346,9 @@ type HTTPMatchRequest struct {
 	//
 	// - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
 	Scheme *StringMatch `protobuf:"bytes,2,opt,name=scheme,proto3" json:"scheme,omitempty"`
-	// HTTP Method
-	// values are case-sensitive and formatted as follows:
+	// HTTP Method.
+	//
+	// Values are case-sensitive and formatted as follows:
 	//
 	// - `exact: "value"` for exact string match
 	//
@@ -1353,8 +1356,9 @@ type HTTPMatchRequest struct {
 	//
 	// - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
 	Method *StringMatch `protobuf:"bytes,3,opt,name=method,proto3" json:"method,omitempty"`
-	// HTTP Authority
-	// values are case-sensitive and formatted as follows:
+	// HTTP Authority.
+	//
+	// Values are case-sensitive and formatted as follows:
 	//
 	// - `exact: "value"` for exact string match
 	//

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -956,8 +956,8 @@ the access logs for requests matching this route.</p>
 <div class="type"><a href="#StringMatch">StringMatch</a></div>
 </div></td>
 <td>
-<p>URI to match
-values are case-sensitive and formatted as follows:</p>
+<p>URI to match.</p>
+<p>Values are case-sensitive and formatted as follows:</p>
 <ul>
 <li>
 <p><code>exact: &quot;value&quot;</code> for exact string match</p>
@@ -979,8 +979,8 @@ values are case-sensitive and formatted as follows:</p>
 <div class="type"><a href="#StringMatch">StringMatch</a></div>
 </div></td>
 <td>
-<p>URI Scheme
-values are case-sensitive and formatted as follows:</p>
+<p>URI Scheme.</p>
+<p>Values are case-sensitive and formatted as follows:</p>
 <ul>
 <li>
 <p><code>exact: &quot;value&quot;</code> for exact string match</p>
@@ -1000,8 +1000,8 @@ values are case-sensitive and formatted as follows:</p>
 <div class="type"><a href="#StringMatch">StringMatch</a></div>
 </div></td>
 <td>
-<p>HTTP Method
-values are case-sensitive and formatted as follows:</p>
+<p>HTTP Method.</p>
+<p>Values are case-sensitive and formatted as follows:</p>
 <ul>
 <li>
 <p><code>exact: &quot;value&quot;</code> for exact string match</p>
@@ -1021,8 +1021,8 @@ values are case-sensitive and formatted as follows:</p>
 <div class="type"><a href="#StringMatch">StringMatch</a></div>
 </div></td>
 <td>
-<p>HTTP Authority
-values are case-sensitive and formatted as follows:</p>
+<p>HTTP Authority.</p>
+<p>Values are case-sensitive and formatted as follows:</p>
 <ul>
 <li>
 <p><code>exact: &quot;value&quot;</code> for exact string match</p>

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -738,8 +738,9 @@ message HTTPMatchRequest {
   // the access logs for requests matching this route.
   string name = 11;
 
-  // URI to match
-  // values are case-sensitive and formatted as follows:
+  // URI to match.
+  //
+  // Values are case-sensitive and formatted as follows:
   //
   // - `exact: "value"` for exact string match
   //
@@ -751,8 +752,9 @@ message HTTPMatchRequest {
   // `ignoreUriCase` flag.
   StringMatch uri = 1;
 
-  // URI Scheme
-  // values are case-sensitive and formatted as follows:
+  // URI Scheme.
+  //
+  // Values are case-sensitive and formatted as follows:
   //
   // - `exact: "value"` for exact string match
   //
@@ -762,8 +764,9 @@ message HTTPMatchRequest {
   //
   StringMatch scheme = 2;
 
-  // HTTP Method
-  // values are case-sensitive and formatted as follows:
+  // HTTP Method.
+  //
+  // Values are case-sensitive and formatted as follows:
   //
   // - `exact: "value"` for exact string match
   //
@@ -773,8 +776,9 @@ message HTTPMatchRequest {
   //
   StringMatch method = 3;
 
-  // HTTP Authority
-  // values are case-sensitive and formatted as follows:
+  // HTTP Authority.
+  //
+  // Values are case-sensitive and formatted as follows:
   //
   // - `exact: "value"` for exact string match
   //


### PR DESCRIPTION
## What does this PR change?

This PR updates proto field comments so that the first line is a complete summary sentence, followed by a blank line before the detailed description.

For example:

```proto
// HTTP method.
//
// Values are case-sensitive and formatted as follows:
```

instead of:

```proto
// HTTP Method
// values are case-sensitive and formatted as follows:
```

## Why?

The first sentence(Till first full stop) of a proto comment is used as the summary in generated documentation, including CRD descriptions (`kubectl explain`) and the Istio API reference.

Making the summary a standalone sentence results in concise, readable descriptions while preserving the existing detailed documentation.

This is in-line with other param description and format

## Testing

* Ran `make gen`
* Verified the generated CRD descriptions and API documentation render the expected summaries
