### PR TITLE
Improve generated documentation for load balancer fields

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -973,6 +973,9 @@ spec:
                                   - ringHash
                                 - required:
                                   - maglev
+                              description: Consistent Hash-based load balancing can
+                                be used to provide soft session affinity based on
+                                HTTP headers, cookies or other properties.
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -1039,6 +1042,7 @@ spec:
                                   type: boolean
                               type: object
                             localityLbSetting:
+                              description: Locality load balancer settings.
                               properties:
                                 distribute:
                                   description: 'Optional: only one of distribute,
@@ -1087,8 +1091,8 @@ spec:
                                   type: array
                               type: object
                             simple:
-                              description: |2-
-
+                              description: |-
+                                Standard load balancing algorithms that require no tuning.
 
                                 Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                               enum:
@@ -1373,6 +1377,9 @@ spec:
                                         - ringHash
                                       - required:
                                         - maglev
+                                    description: Consistent Hash-based load balancing
+                                      can be used to provide soft session affinity
+                                      based on HTTP headers, cookies or other properties.
                                     properties:
                                       httpCookie:
                                         description: Hash based on HTTP cookie.
@@ -1444,6 +1451,7 @@ spec:
                                         type: boolean
                                     type: object
                                   localityLbSetting:
+                                    description: Locality load balancer settings.
                                     properties:
                                       distribute:
                                         description: 'Optional: only one of distribute,
@@ -1492,8 +1500,8 @@ spec:
                                         type: array
                                     type: object
                                   simple:
-                                    description: |2-
-
+                                    description: |-
+                                      Standard load balancing algorithms that require no tuning.
 
                                       Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                     enum:
@@ -1953,6 +1961,9 @@ spec:
                             - ringHash
                           - required:
                             - maglev
+                        description: Consistent Hash-based load balancing can be used
+                          to provide soft session affinity based on HTTP headers,
+                          cookies or other properties.
                         properties:
                           httpCookie:
                             description: Hash based on HTTP cookie.
@@ -2018,6 +2029,7 @@ spec:
                             type: boolean
                         type: object
                       localityLbSetting:
+                        description: Locality load balancer settings.
                         properties:
                           distribute:
                             description: 'Optional: only one of distribute, failover
@@ -2065,8 +2077,8 @@ spec:
                             type: array
                         type: object
                       simple:
-                        description: |2-
-
+                        description: |-
+                          Standard load balancing algorithms that require no tuning.
 
                           Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                         enum:
@@ -2346,6 +2358,9 @@ spec:
                                   - ringHash
                                 - required:
                                   - maglev
+                              description: Consistent Hash-based load balancing can
+                                be used to provide soft session affinity based on
+                                HTTP headers, cookies or other properties.
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -2412,6 +2427,7 @@ spec:
                                   type: boolean
                               type: object
                             localityLbSetting:
+                              description: Locality load balancer settings.
                               properties:
                                 distribute:
                                   description: 'Optional: only one of distribute,
@@ -2460,8 +2476,8 @@ spec:
                                   type: array
                               type: object
                             simple:
-                              description: |2-
-
+                              description: |-
+                                Standard load balancing algorithms that require no tuning.
 
                                 Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                               enum:
@@ -3067,6 +3083,9 @@ spec:
                                   - ringHash
                                 - required:
                                   - maglev
+                              description: Consistent Hash-based load balancing can
+                                be used to provide soft session affinity based on
+                                HTTP headers, cookies or other properties.
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -3133,6 +3152,7 @@ spec:
                                   type: boolean
                               type: object
                             localityLbSetting:
+                              description: Locality load balancer settings.
                               properties:
                                 distribute:
                                   description: 'Optional: only one of distribute,
@@ -3181,8 +3201,8 @@ spec:
                                   type: array
                               type: object
                             simple:
-                              description: |2-
-
+                              description: |-
+                                Standard load balancing algorithms that require no tuning.
 
                                 Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                               enum:
@@ -3467,6 +3487,9 @@ spec:
                                         - ringHash
                                       - required:
                                         - maglev
+                                    description: Consistent Hash-based load balancing
+                                      can be used to provide soft session affinity
+                                      based on HTTP headers, cookies or other properties.
                                     properties:
                                       httpCookie:
                                         description: Hash based on HTTP cookie.
@@ -3538,6 +3561,7 @@ spec:
                                         type: boolean
                                     type: object
                                   localityLbSetting:
+                                    description: Locality load balancer settings.
                                     properties:
                                       distribute:
                                         description: 'Optional: only one of distribute,
@@ -3586,8 +3610,8 @@ spec:
                                         type: array
                                     type: object
                                   simple:
-                                    description: |2-
-
+                                    description: |-
+                                      Standard load balancing algorithms that require no tuning.
 
                                       Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                     enum:
@@ -4047,6 +4071,9 @@ spec:
                             - ringHash
                           - required:
                             - maglev
+                        description: Consistent Hash-based load balancing can be used
+                          to provide soft session affinity based on HTTP headers,
+                          cookies or other properties.
                         properties:
                           httpCookie:
                             description: Hash based on HTTP cookie.
@@ -4112,6 +4139,7 @@ spec:
                             type: boolean
                         type: object
                       localityLbSetting:
+                        description: Locality load balancer settings.
                         properties:
                           distribute:
                             description: 'Optional: only one of distribute, failover
@@ -4159,8 +4187,8 @@ spec:
                             type: array
                         type: object
                       simple:
-                        description: |2-
-
+                        description: |-
+                          Standard load balancing algorithms that require no tuning.
 
                           Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                         enum:
@@ -4440,6 +4468,9 @@ spec:
                                   - ringHash
                                 - required:
                                   - maglev
+                              description: Consistent Hash-based load balancing can
+                                be used to provide soft session affinity based on
+                                HTTP headers, cookies or other properties.
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -4506,6 +4537,7 @@ spec:
                                   type: boolean
                               type: object
                             localityLbSetting:
+                              description: Locality load balancer settings.
                               properties:
                                 distribute:
                                   description: 'Optional: only one of distribute,
@@ -4554,8 +4586,8 @@ spec:
                                   type: array
                               type: object
                             simple:
-                              description: |2-
-
+                              description: |-
+                                Standard load balancing algorithms that require no tuning.
 
                                 Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                               enum:
@@ -5161,6 +5193,9 @@ spec:
                                   - ringHash
                                 - required:
                                   - maglev
+                              description: Consistent Hash-based load balancing can
+                                be used to provide soft session affinity based on
+                                HTTP headers, cookies or other properties.
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -5227,6 +5262,7 @@ spec:
                                   type: boolean
                               type: object
                             localityLbSetting:
+                              description: Locality load balancer settings.
                               properties:
                                 distribute:
                                   description: 'Optional: only one of distribute,
@@ -5275,8 +5311,8 @@ spec:
                                   type: array
                               type: object
                             simple:
-                              description: |2-
-
+                              description: |-
+                                Standard load balancing algorithms that require no tuning.
 
                                 Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                               enum:
@@ -5561,6 +5597,9 @@ spec:
                                         - ringHash
                                       - required:
                                         - maglev
+                                    description: Consistent Hash-based load balancing
+                                      can be used to provide soft session affinity
+                                      based on HTTP headers, cookies or other properties.
                                     properties:
                                       httpCookie:
                                         description: Hash based on HTTP cookie.
@@ -5632,6 +5671,7 @@ spec:
                                         type: boolean
                                     type: object
                                   localityLbSetting:
+                                    description: Locality load balancer settings.
                                     properties:
                                       distribute:
                                         description: 'Optional: only one of distribute,
@@ -5680,8 +5720,8 @@ spec:
                                         type: array
                                     type: object
                                   simple:
-                                    description: |2-
-
+                                    description: |-
+                                      Standard load balancing algorithms that require no tuning.
 
                                       Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                                     enum:
@@ -6141,6 +6181,9 @@ spec:
                             - ringHash
                           - required:
                             - maglev
+                        description: Consistent Hash-based load balancing can be used
+                          to provide soft session affinity based on HTTP headers,
+                          cookies or other properties.
                         properties:
                           httpCookie:
                             description: Hash based on HTTP cookie.
@@ -6206,6 +6249,7 @@ spec:
                             type: boolean
                         type: object
                       localityLbSetting:
+                        description: Locality load balancer settings.
                         properties:
                           distribute:
                             description: 'Optional: only one of distribute, failover
@@ -6253,8 +6297,8 @@ spec:
                             type: array
                         type: object
                       simple:
-                        description: |2-
-
+                        description: |-
+                          Standard load balancing algorithms that require no tuning.
 
                           Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                         enum:
@@ -6534,6 +6578,9 @@ spec:
                                   - ringHash
                                 - required:
                                   - maglev
+                              description: Consistent Hash-based load balancing can
+                                be used to provide soft session affinity based on
+                                HTTP headers, cookies or other properties.
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -6600,6 +6647,7 @@ spec:
                                   type: boolean
                               type: object
                             localityLbSetting:
+                              description: Locality load balancer settings.
                               properties:
                                 distribute:
                                   description: 'Optional: only one of distribute,
@@ -6648,8 +6696,8 @@ spec:
                                   type: array
                               type: object
                             simple:
-                              description: |2-
-
+                              description: |-
+                                Standard load balancing algorithms that require no tuning.
 
                                 Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
                               enum:

--- a/networking/v1/destination_rule_alias.gen.go
+++ b/networking/v1/destination_rule_alias.gen.go
@@ -219,7 +219,10 @@ const LoadBalancerSettings_ROUND_ROBIN LoadBalancerSettings_SimpleLB = v1alpha3.
 // LEAST_REQUEST as a drop-in replacement for ROUND_ROBIN.
 const LoadBalancerSettings_LEAST_REQUEST LoadBalancerSettings_SimpleLB = v1alpha3.LoadBalancerSettings_LEAST_REQUEST
 
+// Standard load balancing algorithms that require no tuning.
 type LoadBalancerSettings_Simple = v1alpha3.LoadBalancerSettings_Simple
+
+// Consistent Hash-based load balancing can be used to provide soft session affinity based on HTTP headers, cookies or other properties.
 type LoadBalancerSettings_ConsistentHash = v1alpha3.LoadBalancerSettings_ConsistentHash
 type WarmupConfiguration = v1alpha3.WarmupConfiguration
 

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -810,7 +810,7 @@ type LoadBalancerSettings struct {
 	//	*LoadBalancerSettings_Simple
 	//	*LoadBalancerSettings_ConsistentHash
 	LbPolicy isLoadBalancerSettings_LbPolicy `protobuf_oneof:"lb_policy"`
-	// Locality load balancer settings, this will override mesh-wide settings in entirety, meaning no merging would be performed
+	// Locality load balancer settings. This will override mesh-wide settings in entirety, meaning no merging would be performed
 	// between this object and the object one in MeshConfig
 	LocalityLbSetting *LocalityLoadBalancerSetting `protobuf:"bytes,3,opt,name=locality_lb_setting,json=localityLbSetting,proto3" json:"locality_lb_setting,omitempty"`
 	// Deprecated: use `warmup` instead.
@@ -909,10 +909,12 @@ type isLoadBalancerSettings_LbPolicy interface {
 }
 
 type LoadBalancerSettings_Simple struct {
+	// Standard load balancing algorithms that require no tuning.
 	Simple LoadBalancerSettings_SimpleLB `protobuf:"varint,1,opt,name=simple,proto3,enum=istio.networking.v1alpha3.LoadBalancerSettings_SimpleLB,oneof"`
 }
 
 type LoadBalancerSettings_ConsistentHash struct {
+	// Consistent Hash-based load balancing can be used to provide soft session affinity based on HTTP headers, cookies or other properties.
 	ConsistentHash *LoadBalancerSettings_ConsistentHashLB `protobuf:"bytes,2,opt,name=consistent_hash,json=consistentHash,proto3,oneof"`
 }
 

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -624,6 +624,8 @@ spec:
 <div class="type"><a href="#LoadBalancerSettings-SimpleLB">SimpleLB (oneof)</a></div>
 </div></td>
 <td>
+<p>Standard load balancing algorithms that require no tuning.</p>
+
 </td>
 </tr>
 <tr id="LoadBalancerSettings-consistent_hash" class="oneof">
@@ -631,6 +633,8 @@ spec:
 <div class="type"><a href="#LoadBalancerSettings-ConsistentHashLB">ConsistentHashLB (oneof)</a></div>
 </div></td>
 <td>
+<p>Consistent Hash-based load balancing can be used to provide soft session affinity based on HTTP headers, cookies or other properties.</p>
+
 </td>
 </tr>
 <tr id="LoadBalancerSettings-locality_lb_setting">
@@ -638,7 +642,7 @@ spec:
 <div class="type"><a href="#LocalityLoadBalancerSetting">LocalityLoadBalancerSetting</a></div>
 </div></td>
 <td>
-<p>Locality load balancer settings, this will override mesh-wide settings in entirety, meaning no merging would be performed
+<p>Locality load balancer settings. This will override mesh-wide settings in entirety, meaning no merging would be performed
 between this object and the object one in MeshConfig</p>
 
 </td>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -544,11 +544,14 @@ message LoadBalancerSettings {
 
   // Upstream load balancing policy.
   oneof lb_policy {
+    // Standard load balancing algorithms that require no tuning.
     SimpleLB simple = 1;
+
+    // Consistent Hash-based load balancing can be used to provide soft session affinity based on HTTP headers, cookies or other properties.
     ConsistentHashLB consistent_hash = 2;
   }
 
-  // Locality load balancer settings, this will override mesh-wide settings in entirety, meaning no merging would be performed
+  // Locality load balancer settings. This will override mesh-wide settings in entirety, meaning no merging would be performed
   // between this object and the object one in MeshConfig
   LocalityLoadBalancerSetting locality_lb_setting = 3;
 

--- a/networking/v1beta1/destination_rule_alias.gen.go
+++ b/networking/v1beta1/destination_rule_alias.gen.go
@@ -219,7 +219,10 @@ const LoadBalancerSettings_ROUND_ROBIN LoadBalancerSettings_SimpleLB = v1alpha3.
 // LEAST_REQUEST as a drop-in replacement for ROUND_ROBIN.
 const LoadBalancerSettings_LEAST_REQUEST LoadBalancerSettings_SimpleLB = v1alpha3.LoadBalancerSettings_LEAST_REQUEST
 
+// Standard load balancing algorithms that require no tuning.
 type LoadBalancerSettings_Simple = v1alpha3.LoadBalancerSettings_Simple
+
+// Consistent Hash-based load balancing can be used to provide soft session affinity based on HTTP headers, cookies or other properties.
 type LoadBalancerSettings_ConsistentHash = v1alpha3.LoadBalancerSettings_ConsistentHash
 type WarmupConfiguration = v1alpha3.WarmupConfiguration
 


### PR DESCRIPTION
This PR improves the generated API documentation for `TrafficPolicy.LoadBalancer`  by adding and refining proto comments for its fields.

## Problem
1. Some fields under `DestinationRule.spec.trafficPolicy.loadBalancer` appeared with `<no description>` in `kubectl explain` 
<img width="496" height="164" alt="image" src="https://github.com/user-attachments/assets/6253ff50-ff9c-46b5-9338-98a654b4d037" />

2.  The generated API reference also omitted descriptions for the same fields, resulting in incomplete API documentation
<img width="934" height="286" alt="image" src="https://github.com/user-attachments/assets/ba552f3d-d30e-4ced-ba2d-cac20a71ddcb" />


## Changes
- Added a description for the `simple` field at correct place.
- Added a description for the `consistent_hash` field at correct place.
- Improved the `locality_lb_setting` comment formatting by adding a terminating period, allowing the generator to recognize the summary correctly.

## Validation

Verified that the updated comments are reflected in:

- `kubectl explain destinationrule.spec.trafficPolicy.loadBalancer`
- Generated HTML documentation 

The affected fields now display meaningful descriptions instead of `<no description>`:
<img width="432" height="170" alt="image" src="https://github.com/user-attachments/assets/9f6eeb96-06e7-46ee-9916-4288a62c379d" />
