### PR TITLE
Add well-known labels and annotation for weighted waypoint canary

### DIFF
--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -313,6 +313,24 @@ Note: When using docker-in-docker container, the default bridge interface name i
 		},
 	}
 
+	IoIstioUseWaypointCanaryWeight = Instance {
+		Name:          "istio.io/use-waypoint-canary-weight",
+		Description:   `Sets the percentage (0-100) of a service's traffic that is shifted to its canary waypoint
+("istio.io/use-waypoint-canary"). The remainder continues to the primary
+"istio.io/use-waypoint". Defaults to 0 (canary resolved but receives no traffic) when unset.
+A value of 100 sends all traffic to the canary (a transient promotion step). Invalid values
+(non-integer or outside 0-100) are rejected and the service stays on the primary waypoint.
+`,
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Service,
+			ServiceEntry,
+			Namespace,
+		},
+	}
+
 	IoIstioWorkloadController = Instance {
 		Name:          "istio.io/workloadController",
 		Description:   "On a WorkloadEntry should store the current/last pilot "+
@@ -983,6 +1001,7 @@ func AllResourceAnnotations() []*Instance {
 		&IoIstioDryRun,
 		&IoIstioRerouteVirtualInterfaces,
 		&IoIstioRev,
+		&IoIstioUseWaypointCanaryWeight,
 		&IoIstioWorkloadController,
 		&IoKubernetesIngressClass,
 		&NetworkingExportTo,

--- a/annotation/annotations.gen.go
+++ b/annotation/annotations.gen.go
@@ -315,11 +315,15 @@ Note: When using docker-in-docker container, the default bridge interface name i
 
 	IoIstioUseWaypointCanaryWeight = Instance {
 		Name:          "istio.io/use-waypoint-canary-weight",
-		Description:   `Sets the percentage (0-100) of a service's traffic that is shifted to its canary waypoint
-("istio.io/use-waypoint-canary"). The remainder continues to the primary
-"istio.io/use-waypoint". Defaults to 0 (canary resolved but receives no traffic) when unset.
-A value of 100 sends all traffic to the canary (a transient promotion step). Invalid values
-(non-integer or outside 0-100) are rejected and the service stays on the primary waypoint.
+		Description:   `Sets the relative weight (0-100) of the canary waypoint ("istio.io/use-waypoint-canary"); the
+primary "istio.io/use-waypoint" receives the remainder. On the in-mesh path a waypoint is
+selected per connection, so this is the share of new connections directed to the canary, not a
+per-request split: a connection is pinned to its selected waypoint for its lifetime, and the
+realized share converges over many connections. On the ingress path
+("istio.io/ingress-use-waypoint") selection is per request. Defaults to 0 (canary resolved for
+validation but receives no connections) when unset. A value of 100 directs all selection to the
+canary (a transient promotion step). Invalid values (non-integer or outside 0-100) are rejected
+and the service stays on the primary waypoint.
 `,
 		FeatureStatus: Alpha,
 		Hidden:        false,

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -167,6 +167,32 @@ Note: When using docker-in-docker container, the default bridge interface name i
     </tr>
   </tbody>
 </table>
+<h2 id="IoIstioUseWaypointCanaryWeight">istio.io/use-waypoint-canary-weight</h2>
+<table class="annotations">
+  <tbody>
+    <tr>
+      <th>Name</th>
+      <td><code>istio.io/use-waypoint-canary-weight</code></td>
+    </tr>
+    <tr>
+      <th>Feature Status</th>
+      <td>Alpha</td>
+    </tr>
+    <tr>
+      <th>Resource Types</th>
+      <td>[Service ServiceEntry Namespace]</td>
+    </tr>
+    <tr>
+      <th>Description</th>
+      <td><p>Sets the percentage (0-100) of a service&rsquo;s traffic that is shifted to its canary waypoint
+(<code>istio.io/use-waypoint-canary</code>). The remainder continues to the primary
+<code>istio.io/use-waypoint</code>. Defaults to 0 (canary resolved but receives no traffic) when unset.
+A value of 100 sends all traffic to the canary (a transient promotion step). Invalid values
+(non-integer or outside 0-100) are rejected and the service stays on the primary waypoint.</p>
+</td>
+    </tr>
+  </tbody>
+</table>
 <h2 id="IoKubernetesIngressClass">kubernetes.io/ingress.class</h2>
 <table class="annotations">
   <tbody>

--- a/annotation/annotations.pb.html
+++ b/annotation/annotations.pb.html
@@ -184,11 +184,15 @@ Note: When using docker-in-docker container, the default bridge interface name i
     </tr>
     <tr>
       <th>Description</th>
-      <td><p>Sets the percentage (0-100) of a service&rsquo;s traffic that is shifted to its canary waypoint
-(<code>istio.io/use-waypoint-canary</code>). The remainder continues to the primary
-<code>istio.io/use-waypoint</code>. Defaults to 0 (canary resolved but receives no traffic) when unset.
-A value of 100 sends all traffic to the canary (a transient promotion step). Invalid values
-(non-integer or outside 0-100) are rejected and the service stays on the primary waypoint.</p>
+      <td><p>Sets the relative weight (0-100) of the canary waypoint (<code>istio.io/use-waypoint-canary</code>); the
+primary <code>istio.io/use-waypoint</code> receives the remainder. On the in-mesh path a waypoint is
+selected per connection, so this is the share of new connections directed to the canary, not a
+per-request split: a connection is pinned to its selected waypoint for its lifetime, and the
+realized share converges over many connections. On the ingress path
+(<code>istio.io/ingress-use-waypoint</code>) selection is per request. Defaults to 0 (canary resolved for
+validation but receives no connections) when unset. A value of 100 directs all selection to the
+canary (a transient promotion step). Invalid values (non-integer or outside 0-100) are rejected
+and the service stays on the primary waypoint.</p>
 </td>
     </tr>
   </tbody>

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -600,11 +600,15 @@ annotations:
   - name: istio.io/use-waypoint-canary-weight
     featureStatus: Alpha
     description: |
-      Sets the percentage (0-100) of a service's traffic that is shifted to its canary waypoint
-      (`istio.io/use-waypoint-canary`). The remainder continues to the primary
-      `istio.io/use-waypoint`. Defaults to 0 (canary resolved but receives no traffic) when unset.
-      A value of 100 sends all traffic to the canary (a transient promotion step). Invalid values
-      (non-integer or outside 0-100) are rejected and the service stays on the primary waypoint.
+      Sets the relative weight (0-100) of the canary waypoint (`istio.io/use-waypoint-canary`); the
+      primary `istio.io/use-waypoint` receives the remainder. On the in-mesh path a waypoint is
+      selected per connection, so this is the share of new connections directed to the canary, not a
+      per-request split: a connection is pinned to its selected waypoint for its lifetime, and the
+      realized share converges over many connections. On the ingress path
+      (`istio.io/ingress-use-waypoint`) selection is per request. Defaults to 0 (canary resolved for
+      validation but receives no connections) when unset. A value of 100 directs all selection to the
+      canary (a transient promotion step). Invalid values (non-integer or outside 0-100) are rejected
+      and the service stays on the primary waypoint.
     deprecated: false
     hidden: false
     resources:

--- a/annotation/annotations.yaml
+++ b/annotation/annotations.yaml
@@ -597,6 +597,21 @@ annotations:
       - Service
       - ServiceEntry
 
+  - name: istio.io/use-waypoint-canary-weight
+    featureStatus: Alpha
+    description: |
+      Sets the percentage (0-100) of a service's traffic that is shifted to its canary waypoint
+      (`istio.io/use-waypoint-canary`). The remainder continues to the primary
+      `istio.io/use-waypoint`. Defaults to 0 (canary resolved but receives no traffic) when unset.
+      A value of 100 sends all traffic to the canary (a transient promotion step). Invalid values
+      (non-integer or outside 0-100) are rejected and the service stays on the primary waypoint.
+    deprecated: false
+    hidden: false
+    resources:
+      - Service
+      - ServiceEntry
+      - Namespace
+
   - name: ambient.istio.io/bypass-inbound-capture
     featureStatus: Alpha
     description: |

--- a/label/labels.gen.go
+++ b/label/labels.gen.go
@@ -231,6 +231,45 @@ Note: the waypoint must allow the type, see "istio.io/waypoint-for".
 		},
 	}
 
+	IoIstioUseWaypointCanary = Instance {
+		Name:          "istio.io/use-waypoint-canary",
+		Description:   `When set on a "Service" or "ServiceEntry" (or its "Namespace"), names a second, canary waypoint for the
+service in addition to the primary "istio.io/use-waypoint". A configurable percentage of the
+service's in-mesh (and, with "istio.io/ingress-use-waypoint", ingress) traffic is shifted to
+this canary waypoint, controlled by the "istio.io/use-waypoint-canary-weight" annotation.
+This is the migration primitive for canarying a service between two waypoints (for example
+two waypoint revisions, or two waypoint implementations).
+
+The canary is assumed to be in the same namespace; for cross-namespace, see
+"istio.io/use-waypoint-canary-namespace". The canary waypoint must allow the type, see
+"istio.io/waypoint-for".
+`,
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Service,
+			ServiceEntry,
+			Namespace,
+		},
+	}
+
+	IoIstioUseWaypointCanaryNamespace = Instance {
+		Name:          "istio.io/use-waypoint-canary-namespace",
+		Description:   `When set on a resource, indicates the canary waypoint ("istio.io/use-waypoint-canary") is in
+the provided namespace. This must be set in addition to "istio.io/use-waypoint-canary", when a
+cross-namespace reference is desired.
+`,
+		FeatureStatus: Alpha,
+		Hidden:        false,
+		Deprecated:    false,
+		Resources: []ResourceTypes{
+			Service,
+			ServiceEntry,
+			Namespace,
+		},
+	}
+
 	IoIstioUseWaypointNamespace = Instance {
 		Name:          "istio.io/use-waypoint-namespace",
 		Description:   `When set on a resource, indicates the resource has an associated waypoint in the provided namespace.
@@ -499,6 +538,8 @@ func AllResourceLabels() []*Instance {
 		&IoIstioRev,
 		&IoIstioTag,
 		&IoIstioUseWaypoint,
+		&IoIstioUseWaypointCanary,
+		&IoIstioUseWaypointCanaryNamespace,
 		&IoIstioUseWaypointNamespace,
 		&IoIstioWaypointFor,
 		&NetworkingEnableAutoallocateIp,

--- a/label/labels.gen.go
+++ b/label/labels.gen.go
@@ -234,8 +234,8 @@ Note: the waypoint must allow the type, see "istio.io/waypoint-for".
 	IoIstioUseWaypointCanary = Instance {
 		Name:          "istio.io/use-waypoint-canary",
 		Description:   `When set on a "Service" or "ServiceEntry" (or its "Namespace"), names a second, canary waypoint for the
-service in addition to the primary "istio.io/use-waypoint". A configurable percentage of the
-service's in-mesh (and, with "istio.io/ingress-use-waypoint", ingress) traffic is shifted to
+service in addition to the primary "istio.io/use-waypoint". A configurable share of the service's
+in-mesh connections (and, with "istio.io/ingress-use-waypoint", ingress requests) is directed to
 this canary waypoint, controlled by the "istio.io/use-waypoint-canary-weight" annotation.
 This is the migration primitive for canarying a service between two waypoints (for example
 two waypoint revisions, or two waypoint implementations).

--- a/label/labels.pb.html
+++ b/label/labels.pb.html
@@ -192,6 +192,61 @@ When set on a <code>Namespace</code>, this applies to all <code>Pod</code>/<code
     </tr>
   </tbody>
 </table>
+<h2 id="IoIstioUseWaypointCanary">istio.io/use-waypoint-canary</h2>
+<table class="annotations">
+  <tbody>
+    <tr>
+      <th>Name</th>
+      <td><code>istio.io/use-waypoint-canary</code></td>
+    </tr>
+    <tr>
+      <th>Feature Status</th>
+      <td>Alpha</td>
+    </tr>
+    <tr>
+      <th>Resource Types</th>
+      <td>[Service ServiceEntry Namespace]</td>
+    </tr>
+    <tr>
+      <th>Description</th>
+      <td><p>When set on a <code>Service</code> or <code>ServiceEntry</code> (or its <code>Namespace</code>), names a second, canary waypoint for the
+service in addition to the primary <code>istio.io/use-waypoint</code>. A configurable percentage of the
+service&rsquo;s in-mesh (and, with <code>istio.io/ingress-use-waypoint</code>, ingress) traffic is shifted to
+this canary waypoint, controlled by the <code>istio.io/use-waypoint-canary-weight</code> annotation.
+This is the migration primitive for canarying a service between two waypoints (for example
+two waypoint revisions, or two waypoint implementations).</p>
+
+<p>The canary is assumed to be in the same namespace; for cross-namespace, see
+<code>istio.io/use-waypoint-canary-namespace</code>. The canary waypoint must allow the type, see
+<code>istio.io/waypoint-for</code>.</p>
+</td>
+    </tr>
+  </tbody>
+</table>
+<h2 id="IoIstioUseWaypointCanaryNamespace">istio.io/use-waypoint-canary-namespace</h2>
+<table class="annotations">
+  <tbody>
+    <tr>
+      <th>Name</th>
+      <td><code>istio.io/use-waypoint-canary-namespace</code></td>
+    </tr>
+    <tr>
+      <th>Feature Status</th>
+      <td>Alpha</td>
+    </tr>
+    <tr>
+      <th>Resource Types</th>
+      <td>[Service ServiceEntry Namespace]</td>
+    </tr>
+    <tr>
+      <th>Description</th>
+      <td><p>When set on a resource, indicates the canary waypoint (<code>istio.io/use-waypoint-canary</code>) is in
+the provided namespace. This must be set in addition to <code>istio.io/use-waypoint-canary</code>, when a
+cross-namespace reference is desired.</p>
+</td>
+    </tr>
+  </tbody>
+</table>
 <h2 id="IoIstioUseWaypointNamespace">istio.io/use-waypoint-namespace</h2>
 <table class="annotations">
   <tbody>

--- a/label/labels.pb.html
+++ b/label/labels.pb.html
@@ -210,8 +210,8 @@ When set on a <code>Namespace</code>, this applies to all <code>Pod</code>/<code
     <tr>
       <th>Description</th>
       <td><p>When set on a <code>Service</code> or <code>ServiceEntry</code> (or its <code>Namespace</code>), names a second, canary waypoint for the
-service in addition to the primary <code>istio.io/use-waypoint</code>. A configurable percentage of the
-service&rsquo;s in-mesh (and, with <code>istio.io/ingress-use-waypoint</code>, ingress) traffic is shifted to
+service in addition to the primary <code>istio.io/use-waypoint</code>. A configurable share of the service&rsquo;s
+in-mesh connections (and, with <code>istio.io/ingress-use-waypoint</code>, ingress requests) is directed to
 this canary waypoint, controlled by the <code>istio.io/use-waypoint-canary-weight</code> annotation.
 This is the migration primitive for canarying a service between two waypoints (for example
 two waypoint revisions, or two waypoint implementations).</p>

--- a/label/labels.yaml
+++ b/label/labels.yaml
@@ -265,6 +265,39 @@ labels:
       - ServiceEntry
       - Namespace
 
+  - name: istio.io/use-waypoint-canary
+    featureStatus: Alpha
+    description: |
+      When set on a `Service` or `ServiceEntry` (or its `Namespace`), names a second, canary waypoint for the
+      service in addition to the primary `istio.io/use-waypoint`. A configurable percentage of the
+      service's in-mesh (and, with `istio.io/ingress-use-waypoint`, ingress) traffic is shifted to
+      this canary waypoint, controlled by the `istio.io/use-waypoint-canary-weight` annotation.
+      This is the migration primitive for canarying a service between two waypoints (for example
+      two waypoint revisions, or two waypoint implementations).
+
+      The canary is assumed to be in the same namespace; for cross-namespace, see
+      `istio.io/use-waypoint-canary-namespace`. The canary waypoint must allow the type, see
+      `istio.io/waypoint-for`.
+    deprecated: false
+    hidden: false
+    resources:
+      - Service
+      - ServiceEntry
+      - Namespace
+
+  - name: istio.io/use-waypoint-canary-namespace
+    featureStatus: Alpha
+    description: |
+      When set on a resource, indicates the canary waypoint (`istio.io/use-waypoint-canary`) is in
+      the provided namespace. This must be set in addition to `istio.io/use-waypoint-canary`, when a
+      cross-namespace reference is desired.
+    deprecated: false
+    hidden: false
+    resources:
+      - Service
+      - ServiceEntry
+      - Namespace
+
   - name: istio.io/ingress-use-waypoint
     featureStatus: Beta
     descriptions: |

--- a/label/labels.yaml
+++ b/label/labels.yaml
@@ -269,8 +269,8 @@ labels:
     featureStatus: Alpha
     description: |
       When set on a `Service` or `ServiceEntry` (or its `Namespace`), names a second, canary waypoint for the
-      service in addition to the primary `istio.io/use-waypoint`. A configurable percentage of the
-      service's in-mesh (and, with `istio.io/ingress-use-waypoint`, ingress) traffic is shifted to
+      service in addition to the primary `istio.io/use-waypoint`. A configurable share of the service's
+      in-mesh connections (and, with `istio.io/ingress-use-waypoint`, ingress requests) is directed to
       this canary waypoint, controlled by the `istio.io/use-waypoint-canary-weight` annotation.
       This is the migration primitive for canarying a service between two waypoints (for example
       two waypoint revisions, or two waypoint implementations).

--- a/releasenotes/notes/weighted-waypoint-canary.yaml
+++ b/releasenotes/notes/weighted-waypoint-canary.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 60801
+
+releaseNotes:
+  - |
+    **Added** the `istio.io/use-waypoint-canary` and
+    `istio.io/use-waypoint-canary-namespace` labels and the
+    `istio.io/use-waypoint-canary-weight` annotation, which let a service shift a
+    configurable percentage of its traffic to a second (canary) waypoint alongside
+    its primary `istio.io/use-waypoint`.


### PR DESCRIPTION
## What this does

Registers the well-known labels and annotation for the weighted waypoint canary feature ([Design Doc](https://docs.google.com/document/d/1VUkLScweMJ2LwsN7ttU-obmXbcXwn7y2kPibzxWMnvM/edit?usp=sharing)), which lets a service direct a configurable share of its connections (in-mesh) and requests (ingress) to a second "canary" waypoint alongside its primary one. This is the migration primitive for moving a service between two waypoints (for example two waypoint revisions, or two waypoint implementations) without changing clients or introducing a second Service.

Three additions:

| Name | Kind | Purpose |
|------|------|---------|
| `istio.io/use-waypoint-canary` | label | Names the second (canary) waypoint, alongside the primary `istio.io/use-waypoint`. |
| `istio.io/use-waypoint-canary-namespace` | label | Cross-namespace reference for the canary waypoint (mirrors `istio.io/use-waypoint-namespace`). |
| `istio.io/use-waypoint-canary-weight` | annotation | Relative weight (0-100) of the canary; the primary receives the remainder. In-mesh this is the share of new connections (selection is per-connection), at ingress the share of requests. Defaults to 0; invalid values keep the service on the primary. |

These apply to Service, ServiceEntry, and Namespace - the service-level scope. We deliberately scope alpha narrower than istio.io/use-waypoint (which also covers Pod/WorkloadEntry): a pod-scoped canary is logically valid for in-mesh traffic, but it would need a separate weighted field on the Workload API and ztunnel's workload path, and it can't apply to ingress traffic (which is keyed off the service). Keeping to service-level scope for alpha keeps the change minimal and behaves identically across in-mesh and ingress. Workload scope can follow later.

Example:

```yaml
metadata:
 labels:
   # primary (existing, unchanged)
   istio.io/use-waypoint: waypoint-a


   # optional, primary (existing, unchanged)
   istio.io/use-waypoint-namespace: waypoint-a-ns


   # NEW: canary waypoint (Gateway name)
   istio.io/use-waypoint-canary: waypoint-b
   
   # NEW: optional, only for cross-namespace canaries
   istio.io/use-waypoint-canary-namespace: waypoint-b-ns


 annotations:
   # NEW: 0..100; in-mesh: % of new connections, ingress: % of requests
   istio.io/use-waypoint-canary-weight: "5"
```

## Scope

This PR only adds the API surface: the well-known label/annotation definitions. The implementation lands separately.

## Why the canary references are labels but the weight is an annotation

The canary name references (`use-waypoint-canary` and `use-waypoint-canary-namespace`) are labels, following their `use-waypoint` and `use-waypoint-namespace` siblings.
They name a waypoint the same way the primary reference does, so they live in the same space for consistency.

The weight is an annotation because it is a configuration value, not identity:

- Labels are for identifying and selecting objects. They are indexed and used in selectors. A weight value is never something you would select on (`kubectl get -l weight=50` is meaningless), so it does not belong in the label
  space. This is the standard Kubernetes label-vs-annotation split.
- Value-carrying config in this repo is already expressed as annotations, for example `sidecar.istio.io/proxyCPULimit`, `sidecar.istio.io/proxyMemoryLimit`, `traffic.sidecar.istio.io/excludeInboundPorts`, and `traffic.sidecar.istio.io/includeOutboundPorts`. All are numeric or list config, all are annotations.
