### PR TITLE
feat: RequestAuthentication add presence field to JWTRule (#60823)

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -17229,6 +17229,15 @@ spec:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
                       type: string
+                    presence:
+                      description: |-
+                        Configures whether the JWT token must be present in the request.
+
+                        Valid Options: OPTIONAL, REQUIRED
+                      enum:
+                      - OPTIONAL
+                      - REQUIRED
+                      type: string
                     spaceDelimitedClaims:
                       description: List of JWT claim names that should be treated
                         as space-delimited strings.
@@ -17517,6 +17526,15 @@ spec:
                     outputPayloadToHeader:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
+                      type: string
+                    presence:
+                      description: |-
+                        Configures whether the JWT token must be present in the request.
+
+                        Valid Options: OPTIONAL, REQUIRED
+                      enum:
+                      - OPTIONAL
+                      - REQUIRED
                       type: string
                     spaceDelimitedClaims:
                       description: List of JWT claim names that should be treated

--- a/releasenotes/notes/jwt-required-field.yaml
+++ b/releasenotes/notes/jwt-required-field.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - https://github.com/istio/istio/issues/60823
+
+releaseNotes:
+  - |
+    **Added** `presence` field in `RequestAuthentication` under `spec.jwtRules` to configure
+    whether a JWT token is required (`REQUIRED`) or optional (`OPTIONAL`, default).
+    When set to `REQUIRED`, requests missing the token are rejected with 401 even if other
+    JWT rules are satisfied, enabling configurations where all tokens must be present and valid simultaneously.
+    The default behavior is `OPTIONAL`, which allows requests to pass if at least one JWT rule is satisfied, even if others are missing or invalid (current behavior).

--- a/security/v1/request_authentication_alias.gen.go
+++ b/security/v1/request_authentication_alias.gen.go
@@ -71,6 +71,17 @@ type RequestAuthentication = v1beta1.RequestAuthentication
 // +kubebuilder:validation:XValidation:message="only one of jwks or jwksUri can be set",rule="oneof(self.jwksUri, self.jwks_uri, self.jwks)"
 type JWTRule = v1beta1.JWTRule
 
+// Specifies whether the JWT token is required or optional in the request.
+type JWTRule_JWTRequirement = v1beta1.JWTRule_JWTRequirement
+
+// The JWT token is optional. Requests without a token are allowed as long as
+// no invalid token is present. This is the default behavior.
+const JWTRule_OPTIONAL JWTRule_JWTRequirement = v1beta1.JWTRule_OPTIONAL
+
+// The JWT token must be present and valid. Requests without this token will
+// be rejected with 401 even if other JWT rules are satisfied.
+const JWTRule_REQUIRED JWTRule_JWTRequirement = v1beta1.JWTRule_REQUIRED
+
 // This message specifies a header location to extract JWT token.
 type JWTHeader = v1beta1.JWTHeader
 

--- a/security/v1beta1/request_authentication.pb.go
+++ b/security/v1beta1/request_authentication.pb.go
@@ -243,6 +243,57 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Specifies whether the JWT token is required or optional in the request.
+type JWTRule_JWTRequirement int32
+
+const (
+	// The JWT token is optional. Requests without a token are allowed as long as
+	// no invalid token is present. This is the default behavior.
+	JWTRule_OPTIONAL JWTRule_JWTRequirement = 0
+	// The JWT token must be present and valid. Requests without this token will
+	// be rejected with 401 even if other JWT rules are satisfied.
+	JWTRule_REQUIRED JWTRule_JWTRequirement = 1
+)
+
+// Enum value maps for JWTRule_JWTRequirement.
+var (
+	JWTRule_JWTRequirement_name = map[int32]string{
+		0: "OPTIONAL",
+		1: "REQUIRED",
+	}
+	JWTRule_JWTRequirement_value = map[string]int32{
+		"OPTIONAL": 0,
+		"REQUIRED": 1,
+	}
+)
+
+func (x JWTRule_JWTRequirement) Enum() *JWTRule_JWTRequirement {
+	p := new(JWTRule_JWTRequirement)
+	*p = x
+	return p
+}
+
+func (x JWTRule_JWTRequirement) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (JWTRule_JWTRequirement) Descriptor() protoreflect.EnumDescriptor {
+	return file_security_v1beta1_request_authentication_proto_enumTypes[0].Descriptor()
+}
+
+func (JWTRule_JWTRequirement) Type() protoreflect.EnumType {
+	return &file_security_v1beta1_request_authentication_proto_enumTypes[0]
+}
+
+func (x JWTRule_JWTRequirement) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use JWTRule_JWTRequirement.Descriptor instead.
+func (JWTRule_JWTRequirement) EnumDescriptor() ([]byte, []int) {
+	return file_security_v1beta1_request_authentication_proto_rawDescGZIP(), []int{1, 0}
+}
+
 // <!-- crd generation tags
 // +cue-gen:RequestAuthentication:groupName:security.istio.io
 // +cue-gen:RequestAuthentication:versions:v1,v1beta1
@@ -549,8 +600,14 @@ type JWTRule struct {
 	// +protoc-gen-crd:list-value-validation:MinLength=1
 	// +kubebuilder:validation:MaxItems=64
 	SpaceDelimitedClaims []string `protobuf:"bytes,14,rep,name=space_delimited_claims,json=spaceDelimitedClaims,proto3" json:"space_delimited_claims,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// Configures whether the JWT token must be present in the request.
+	// When set to `REQUIRED`, requests without this token will be rejected with 401
+	// even if other JWT rules are satisfied. When `OPTIONAL` (the default), a missing
+	// token is allowed as long as no invalid token is present. This is useful when
+	// multiple JWT rules are configured and all tokens must be present and valid simultaneously.
+	Presence      JWTRule_JWTRequirement `protobuf:"varint,15,opt,name=presence,proto3,enum=istio.security.v1beta1.JWTRule_JWTRequirement" json:"presence,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *JWTRule) Reset() {
@@ -665,6 +722,13 @@ func (x *JWTRule) GetSpaceDelimitedClaims() []string {
 		return x.SpaceDelimitedClaims
 	}
 	return nil
+}
+
+func (x *JWTRule) GetPresence() JWTRule_JWTRequirement {
+	if x != nil {
+		return x.Presence
+	}
+	return JWTRule_OPTIONAL
 }
 
 // This message specifies a header location to extract JWT token.
@@ -795,7 +859,7 @@ const file_security_v1beta1_request_authentication_proto_rawDesc = "" +
 	"\n" +
 	"targetRefs\x18\x04 \x03(\v2).istio.type.v1beta1.PolicyTargetReferenceR\n" +
 	"targetRefs\x12<\n" +
-	"\tjwt_rules\x18\x02 \x03(\v2\x1f.istio.security.v1beta1.JWTRuleR\bjwtRules\"\xb0\x04\n" +
+	"\tjwt_rules\x18\x02 \x03(\v2\x1f.istio.security.v1beta1.JWTRuleR\bjwtRules\"\xaa\x05\n" +
 	"\aJWTRule\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1c\n" +
 	"\taudiences\x18\x02 \x03(\tR\taudiences\x12\x19\n" +
@@ -810,7 +874,11 @@ const file_security_v1beta1_request_authentication_proto_rawDesc = "" +
 	"\x16forward_original_token\x18\t \x01(\bR\x14forwardOriginalToken\x12\\\n" +
 	"\x17output_claim_to_headers\x18\v \x03(\v2%.istio.security.v1beta1.ClaimToHeaderR\x14outputClaimToHeaders\x123\n" +
 	"\atimeout\x18\r \x01(\v2\x19.google.protobuf.DurationR\atimeout\x124\n" +
-	"\x16space_delimited_claims\x18\x0e \x03(\tR\x14spaceDelimitedClaims\"=\n" +
+	"\x16space_delimited_claims\x18\x0e \x03(\tR\x14spaceDelimitedClaims\x12J\n" +
+	"\bpresence\x18\x0f \x01(\x0e2..istio.security.v1beta1.JWTRule.JWTRequirementR\bpresence\",\n" +
+	"\x0eJWTRequirement\x12\f\n" +
+	"\bOPTIONAL\x10\x00\x12\f\n" +
+	"\bREQUIRED\x10\x01\"=\n" +
 	"\tJWTHeader\x12\x18\n" +
 	"\x04name\x18\x01 \x01(\tB\x04\xe2A\x01\x02R\x04name\x12\x16\n" +
 	"\x06prefix\x18\x02 \x01(\tR\x06prefix\"I\n" +
@@ -830,29 +898,32 @@ func file_security_v1beta1_request_authentication_proto_rawDescGZIP() []byte {
 	return file_security_v1beta1_request_authentication_proto_rawDescData
 }
 
+var file_security_v1beta1_request_authentication_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_security_v1beta1_request_authentication_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_security_v1beta1_request_authentication_proto_goTypes = []any{
-	(*RequestAuthentication)(nil),         // 0: istio.security.v1beta1.RequestAuthentication
-	(*JWTRule)(nil),                       // 1: istio.security.v1beta1.JWTRule
-	(*JWTHeader)(nil),                     // 2: istio.security.v1beta1.JWTHeader
-	(*ClaimToHeader)(nil),                 // 3: istio.security.v1beta1.ClaimToHeader
-	(*v1beta1.WorkloadSelector)(nil),      // 4: istio.type.v1beta1.WorkloadSelector
-	(*v1beta1.PolicyTargetReference)(nil), // 5: istio.type.v1beta1.PolicyTargetReference
-	(*duration.Duration)(nil),             // 6: google.protobuf.Duration
+	(JWTRule_JWTRequirement)(0),           // 0: istio.security.v1beta1.JWTRule.JWTRequirement
+	(*RequestAuthentication)(nil),         // 1: istio.security.v1beta1.RequestAuthentication
+	(*JWTRule)(nil),                       // 2: istio.security.v1beta1.JWTRule
+	(*JWTHeader)(nil),                     // 3: istio.security.v1beta1.JWTHeader
+	(*ClaimToHeader)(nil),                 // 4: istio.security.v1beta1.ClaimToHeader
+	(*v1beta1.WorkloadSelector)(nil),      // 5: istio.type.v1beta1.WorkloadSelector
+	(*v1beta1.PolicyTargetReference)(nil), // 6: istio.type.v1beta1.PolicyTargetReference
+	(*duration.Duration)(nil),             // 7: google.protobuf.Duration
 }
 var file_security_v1beta1_request_authentication_proto_depIdxs = []int32{
-	4, // 0: istio.security.v1beta1.RequestAuthentication.selector:type_name -> istio.type.v1beta1.WorkloadSelector
-	5, // 1: istio.security.v1beta1.RequestAuthentication.targetRef:type_name -> istio.type.v1beta1.PolicyTargetReference
-	5, // 2: istio.security.v1beta1.RequestAuthentication.targetRefs:type_name -> istio.type.v1beta1.PolicyTargetReference
-	1, // 3: istio.security.v1beta1.RequestAuthentication.jwt_rules:type_name -> istio.security.v1beta1.JWTRule
-	2, // 4: istio.security.v1beta1.JWTRule.from_headers:type_name -> istio.security.v1beta1.JWTHeader
-	3, // 5: istio.security.v1beta1.JWTRule.output_claim_to_headers:type_name -> istio.security.v1beta1.ClaimToHeader
-	6, // 6: istio.security.v1beta1.JWTRule.timeout:type_name -> google.protobuf.Duration
-	7, // [7:7] is the sub-list for method output_type
-	7, // [7:7] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	5, // 0: istio.security.v1beta1.RequestAuthentication.selector:type_name -> istio.type.v1beta1.WorkloadSelector
+	6, // 1: istio.security.v1beta1.RequestAuthentication.targetRef:type_name -> istio.type.v1beta1.PolicyTargetReference
+	6, // 2: istio.security.v1beta1.RequestAuthentication.targetRefs:type_name -> istio.type.v1beta1.PolicyTargetReference
+	2, // 3: istio.security.v1beta1.RequestAuthentication.jwt_rules:type_name -> istio.security.v1beta1.JWTRule
+	3, // 4: istio.security.v1beta1.JWTRule.from_headers:type_name -> istio.security.v1beta1.JWTHeader
+	4, // 5: istio.security.v1beta1.JWTRule.output_claim_to_headers:type_name -> istio.security.v1beta1.ClaimToHeader
+	7, // 6: istio.security.v1beta1.JWTRule.timeout:type_name -> google.protobuf.Duration
+	0, // 7: istio.security.v1beta1.JWTRule.presence:type_name -> istio.security.v1beta1.JWTRule.JWTRequirement
+	8, // [8:8] is the sub-list for method output_type
+	8, // [8:8] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_security_v1beta1_request_authentication_proto_init() }
@@ -865,13 +936,14 @@ func file_security_v1beta1_request_authentication_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_security_v1beta1_request_authentication_proto_rawDesc), len(file_security_v1beta1_request_authentication_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      1,
 			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_security_v1beta1_request_authentication_proto_goTypes,
 		DependencyIndexes: file_security_v1beta1_request_authentication_proto_depIdxs,
+		EnumInfos:         file_security_v1beta1_request_authentication_proto_enumTypes,
 		MessageInfos:      file_security_v1beta1_request_authentication_proto_msgTypes,
 	}.Build()
 	File_security_v1beta1_request_authentication_proto = out.File

--- a/security/v1beta1/request_authentication.pb.html
+++ b/security/v1beta1/request_authentication.pb.html
@@ -6,7 +6,7 @@ layout: protoc-gen-docs
 generator: protoc-gen-docs
 schema: istio.security.v1beta1.RequestAuthentication
 aliases: [/docs/reference/config/security/v1beta1/request_authentication, /docs/reference/config/security/v1beta1/jwt, /docs/reference/config/security/v1beta1/jwt.html]
-number_of_entries: 4
+number_of_entries: 5
 ---
 <p>RequestAuthentication defines what request authentication methods are supported by a workload.
 It will reject a request if the request contains invalid authentication information, based on the
@@ -478,6 +478,50 @@ treats &lsquo;scope&rsquo; and &lsquo;permission&rsquo; claims as space-delimite
 claim strings, maintaining compatibility with existing JWT token formats.</p>
 <p>Note: The default claims &lsquo;scope&rsquo; and &lsquo;permission&rsquo; are always treated as space-delimited
 regardless of this setting.</p>
+
+</td>
+</tr>
+<tr id="JWTRule-presence">
+<td><div class="field"><div class="name"><code><a href="#JWTRule-presence">presence</a></code></div>
+<div class="type"><a href="#JWTRule-JWTRequirement">JWTRequirement</a></div>
+</div></td>
+<td>
+<p>Configures whether the JWT token must be present in the request.
+When set to <code>REQUIRED</code>, requests without this token will be rejected with 401
+even if other JWT rules are satisfied. When <code>OPTIONAL</code> (the default), a missing
+token is allowed as long as no invalid token is present. This is useful when
+multiple JWT rules are configured and all tokens must be present and valid simultaneously.</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h3 id="JWTRule-JWTRequirement">JWTRequirement</h3>
+<section>
+<p>Specifies whether the JWT token is required or optional in the request.</p>
+
+<table class="enum-values">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="JWTRule-JWTRequirement-OPTIONAL">
+<td><code><a href="#JWTRule-JWTRequirement-OPTIONAL">OPTIONAL</a></code></td>
+<td>
+<p>The JWT token is optional. Requests without a token are allowed as long as
+no invalid token is present. This is the default behavior.</p>
+
+</td>
+</tr>
+<tr id="JWTRule-JWTRequirement-REQUIRED">
+<td><code><a href="#JWTRule-JWTRequirement-REQUIRED">REQUIRED</a></code></td>
+<td>
+<p>The JWT token must be present and valid. Requests without this token will
+be rejected with 401 even if other JWT rules are satisfied.</p>
 
 </td>
 </tr>

--- a/security/v1beta1/request_authentication.proto
+++ b/security/v1beta1/request_authentication.proto
@@ -487,8 +487,26 @@ message JWTRule {
   // +kubebuilder:validation:MaxItems=64
   repeated string space_delimited_claims = 14;
 
+  // Specifies whether the JWT token is required or optional in the request.
+  enum JWTRequirement {
+    // The JWT token is optional. Requests without a token are allowed as long as
+    // no invalid token is present. This is the default behavior.
+    OPTIONAL = 0;
+
+    // The JWT token must be present and valid. Requests without this token will
+    // be rejected with 401 even if other JWT rules are satisfied.
+    REQUIRED = 1;
+  }
+
+  // Configures whether the JWT token must be present in the request.
+  // When set to `REQUIRED`, requests without this token will be rejected with 401
+  // even if other JWT rules are satisfied. When `OPTIONAL` (the default), a missing
+  // token is allowed as long as no invalid token is present. This is useful when
+  // multiple JWT rules are configured and all tokens must be present and valid simultaneously.
+  JWTRequirement presence = 15;
+
   // $hide_from_docs
-  // Next available field number: 15
+  // Next available field number: 16
 }
 
 // This message specifies a header location to extract JWT token.

--- a/tests/testdata/reqauth-invalid.yaml
+++ b/tests/testdata/reqauth-invalid.yaml
@@ -221,3 +221,13 @@ spec:
     spaceDelimitedClaims:
     - ""
 ---
+_err: 'Unsupported value: "MANDATORY"'
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: invalid-presence-value
+spec:
+  jwtRules:
+  - issuer: example
+    presence: MANDATORY
+---

--- a/tests/testdata/reqauth-valid.yaml
+++ b/tests/testdata/reqauth-valid.yaml
@@ -23,3 +23,4 @@ spec:
     spaceDelimitedClaims:
     - "custom_scope"
     - "provider.login.scope"
+    presence: REQUIRED


### PR DESCRIPTION
Adds a `presence` field of type `JWTRequirement` to `JWTRule` in `RequestAuthentication`.

When `presence: REQUIRED`, the JWT for that rule must be present and valid. Requests without it are rejected with `401 Unauthorized`, even if other JWT rules in the same policy are satisfied.

This enables workloads that must validate multiple JWT tokens from different issuers and headers (for example, an identity token in `Authorization` and a scope token in a custom header). Defaults to `OPTIONAL`.

Issue reference: https://github.com/istio/istio/issues/60823

## Example

```yaml
apiVersion: security.istio.io/v1
kind: RequestAuthentication
metadata:
  name: multi-jwt
spec:
  selector:
    matchLabels:
      app: my-service
  jwtRules:
  - issuer: "https://idp.example.com"
    jwksUri: "https://idp.example.com/.well-known/jwks.json"
    fromHeaders:
    - name: authorization
      prefix: "Bearer "
    presence: REQUIRED
  - issuer: "https://scope.example.com"
    jwksUri: "https://scope.example.com/.well-known/jwks.json"
    fromHeaders:
    - name: x-scope-token
    presence: REQUIRED
```

These changes require the implementation of the new feature in the istio/istio repo. I'll create the PR as draft and once this is reviewed and merged, I'll undraft the other one