### PR TITLE
Add outlier detection failure matcher

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -1185,6 +1185,15 @@ spec:
                                 `minHealthPercent` hosts in healthy mode.
                               format: int32
                               type: integer
+                            outlierDetectionHttpErrorCodes:
+                              description: HTTP status codes to additionally treat
+                                as outlier detection failures, beyond the default
+                                behavior of only treating 5xx responses as failures.
+                              items:
+                                maximum: 599
+                                minimum: 100
+                                type: integer
+                              type: array
                             splitExternalLocalOriginErrors:
                               description: Determines whether to distinguish local
                                 origin failures from external errors.
@@ -1599,6 +1608,16 @@ spec:
                                       mode.
                                     format: int32
                                     type: integer
+                                  outlierDetectionHttpErrorCodes:
+                                    description: HTTP status codes to additionally
+                                      treat as outlier detection failures, beyond
+                                      the default behavior of only treating 5xx responses
+                                      as failures.
+                                    items:
+                                      maximum: 599
+                                      minimum: 100
+                                      type: integer
+                                    type: array
                                   splitExternalLocalOriginErrors:
                                     description: Determines whether to distinguish
                                       local origin failures from external errors.
@@ -2169,6 +2188,15 @@ spec:
                           hosts in healthy mode.
                         format: int32
                         type: integer
+                      outlierDetectionHttpErrorCodes:
+                        description: HTTP status codes to additionally treat as outlier
+                          detection failures, beyond the default behavior of only
+                          treating 5xx responses as failures.
+                        items:
+                          maximum: 599
+                          minimum: 100
+                          type: integer
+                        type: array
                       splitExternalLocalOriginErrors:
                         description: Determines whether to distinguish local origin
                           failures from external errors.
@@ -2570,6 +2598,15 @@ spec:
                                 `minHealthPercent` hosts in healthy mode.
                               format: int32
                               type: integer
+                            outlierDetectionHttpErrorCodes:
+                              description: HTTP status codes to additionally treat
+                                as outlier detection failures, beyond the default
+                                behavior of only treating 5xx responses as failures.
+                              items:
+                                maximum: 599
+                                minimum: 100
+                                type: integer
+                              type: array
                             splitExternalLocalOriginErrors:
                               description: Determines whether to distinguish local
                                 origin failures from external errors.
@@ -3295,6 +3332,15 @@ spec:
                                 `minHealthPercent` hosts in healthy mode.
                               format: int32
                               type: integer
+                            outlierDetectionHttpErrorCodes:
+                              description: HTTP status codes to additionally treat
+                                as outlier detection failures, beyond the default
+                                behavior of only treating 5xx responses as failures.
+                              items:
+                                maximum: 599
+                                minimum: 100
+                                type: integer
+                              type: array
                             splitExternalLocalOriginErrors:
                               description: Determines whether to distinguish local
                                 origin failures from external errors.
@@ -3709,6 +3755,16 @@ spec:
                                       mode.
                                     format: int32
                                     type: integer
+                                  outlierDetectionHttpErrorCodes:
+                                    description: HTTP status codes to additionally
+                                      treat as outlier detection failures, beyond
+                                      the default behavior of only treating 5xx responses
+                                      as failures.
+                                    items:
+                                      maximum: 599
+                                      minimum: 100
+                                      type: integer
+                                    type: array
                                   splitExternalLocalOriginErrors:
                                     description: Determines whether to distinguish
                                       local origin failures from external errors.
@@ -4279,6 +4335,15 @@ spec:
                           hosts in healthy mode.
                         format: int32
                         type: integer
+                      outlierDetectionHttpErrorCodes:
+                        description: HTTP status codes to additionally treat as outlier
+                          detection failures, beyond the default behavior of only
+                          treating 5xx responses as failures.
+                        items:
+                          maximum: 599
+                          minimum: 100
+                          type: integer
+                        type: array
                       splitExternalLocalOriginErrors:
                         description: Determines whether to distinguish local origin
                           failures from external errors.
@@ -4680,6 +4745,15 @@ spec:
                                 `minHealthPercent` hosts in healthy mode.
                               format: int32
                               type: integer
+                            outlierDetectionHttpErrorCodes:
+                              description: HTTP status codes to additionally treat
+                                as outlier detection failures, beyond the default
+                                behavior of only treating 5xx responses as failures.
+                              items:
+                                maximum: 599
+                                minimum: 100
+                                type: integer
+                              type: array
                             splitExternalLocalOriginErrors:
                               description: Determines whether to distinguish local
                                 origin failures from external errors.
@@ -5405,6 +5479,15 @@ spec:
                                 `minHealthPercent` hosts in healthy mode.
                               format: int32
                               type: integer
+                            outlierDetectionHttpErrorCodes:
+                              description: HTTP status codes to additionally treat
+                                as outlier detection failures, beyond the default
+                                behavior of only treating 5xx responses as failures.
+                              items:
+                                maximum: 599
+                                minimum: 100
+                                type: integer
+                              type: array
                             splitExternalLocalOriginErrors:
                               description: Determines whether to distinguish local
                                 origin failures from external errors.
@@ -5819,6 +5902,16 @@ spec:
                                       mode.
                                     format: int32
                                     type: integer
+                                  outlierDetectionHttpErrorCodes:
+                                    description: HTTP status codes to additionally
+                                      treat as outlier detection failures, beyond
+                                      the default behavior of only treating 5xx responses
+                                      as failures.
+                                    items:
+                                      maximum: 599
+                                      minimum: 100
+                                      type: integer
+                                    type: array
                                   splitExternalLocalOriginErrors:
                                     description: Determines whether to distinguish
                                       local origin failures from external errors.
@@ -6389,6 +6482,15 @@ spec:
                           hosts in healthy mode.
                         format: int32
                         type: integer
+                      outlierDetectionHttpErrorCodes:
+                        description: HTTP status codes to additionally treat as outlier
+                          detection failures, beyond the default behavior of only
+                          treating 5xx responses as failures.
+                        items:
+                          maximum: 599
+                          minimum: 100
+                          type: integer
+                        type: array
                       splitExternalLocalOriginErrors:
                         description: Determines whether to distinguish local origin
                           failures from external errors.
@@ -6790,6 +6892,15 @@ spec:
                                 `minHealthPercent` hosts in healthy mode.
                               format: int32
                               type: integer
+                            outlierDetectionHttpErrorCodes:
+                              description: HTTP status codes to additionally treat
+                                as outlier detection failures, beyond the default
+                                behavior of only treating 5xx responses as failures.
+                              items:
+                                maximum: 599
+                                minimum: 100
+                                type: integer
+                              type: array
                             splitExternalLocalOriginErrors:
                               description: Determines whether to distinguish local
                                 origin failures from external errors.

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -1186,8 +1186,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies HTTP response status codes that
-                                should be treated as outlier detection errors.
+                              description: Specifies the HTTP response status codes
+                                that are treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -1608,8 +1608,8 @@ spec:
                                     format: int32
                                     type: integer
                                   outlierDetectionHttpErrorCodes:
-                                    description: Specifies HTTP response status codes
-                                      that should be treated as outlier detection
+                                    description: Specifies the HTTP response status
+                                      codes that are treated as outlier detection
                                       errors.
                                     items:
                                       maximum: 599
@@ -2187,8 +2187,8 @@ spec:
                         format: int32
                         type: integer
                       outlierDetectionHttpErrorCodes:
-                        description: Specifies HTTP response status codes that should
-                          be treated as outlier detection errors.
+                        description: Specifies the HTTP response status codes that
+                          are treated as outlier detection errors.
                         items:
                           maximum: 599
                           minimum: 100
@@ -2596,8 +2596,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies HTTP response status codes that
-                                should be treated as outlier detection errors.
+                              description: Specifies the HTTP response status codes
+                                that are treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -3329,8 +3329,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies HTTP response status codes that
-                                should be treated as outlier detection errors.
+                              description: Specifies the HTTP response status codes
+                                that are treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -3751,8 +3751,8 @@ spec:
                                     format: int32
                                     type: integer
                                   outlierDetectionHttpErrorCodes:
-                                    description: Specifies HTTP response status codes
-                                      that should be treated as outlier detection
+                                    description: Specifies the HTTP response status
+                                      codes that are treated as outlier detection
                                       errors.
                                     items:
                                       maximum: 599
@@ -4330,8 +4330,8 @@ spec:
                         format: int32
                         type: integer
                       outlierDetectionHttpErrorCodes:
-                        description: Specifies HTTP response status codes that should
-                          be treated as outlier detection errors.
+                        description: Specifies the HTTP response status codes that
+                          are treated as outlier detection errors.
                         items:
                           maximum: 599
                           minimum: 100
@@ -4739,8 +4739,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies HTTP response status codes that
-                                should be treated as outlier detection errors.
+                              description: Specifies the HTTP response status codes
+                                that are treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -5472,8 +5472,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies HTTP response status codes that
-                                should be treated as outlier detection errors.
+                              description: Specifies the HTTP response status codes
+                                that are treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -5894,8 +5894,8 @@ spec:
                                     format: int32
                                     type: integer
                                   outlierDetectionHttpErrorCodes:
-                                    description: Specifies HTTP response status codes
-                                      that should be treated as outlier detection
+                                    description: Specifies the HTTP response status
+                                      codes that are treated as outlier detection
                                       errors.
                                     items:
                                       maximum: 599
@@ -6473,8 +6473,8 @@ spec:
                         format: int32
                         type: integer
                       outlierDetectionHttpErrorCodes:
-                        description: Specifies HTTP response status codes that should
-                          be treated as outlier detection errors.
+                        description: Specifies the HTTP response status codes that
+                          are treated as outlier detection errors.
                         items:
                           maximum: 599
                           minimum: 100
@@ -6882,8 +6882,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies HTTP response status codes that
-                                should be treated as outlier detection errors.
+                              description: Specifies the HTTP response status codes
+                                that are treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -1186,9 +1186,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies additional HTTP response status
-                                codes that should be treated as outlier detection
-                                errors, in addition to the default 5xx behavior.
+                              description: Specifies HTTP response status codes that
+                                should be treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -1609,10 +1608,9 @@ spec:
                                     format: int32
                                     type: integer
                                   outlierDetectionHttpErrorCodes:
-                                    description: Specifies additional HTTP response
-                                      status codes that should be treated as outlier
-                                      detection errors, in addition to the default
-                                      5xx behavior.
+                                    description: Specifies HTTP response status codes
+                                      that should be treated as outlier detection
+                                      errors.
                                     items:
                                       maximum: 599
                                       minimum: 100
@@ -2189,9 +2187,8 @@ spec:
                         format: int32
                         type: integer
                       outlierDetectionHttpErrorCodes:
-                        description: Specifies additional HTTP response status codes
-                          that should be treated as outlier detection errors, in addition
-                          to the default 5xx behavior.
+                        description: Specifies HTTP response status codes that should
+                          be treated as outlier detection errors.
                         items:
                           maximum: 599
                           minimum: 100
@@ -2599,9 +2596,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies additional HTTP response status
-                                codes that should be treated as outlier detection
-                                errors, in addition to the default 5xx behavior.
+                              description: Specifies HTTP response status codes that
+                                should be treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -3333,9 +3329,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies additional HTTP response status
-                                codes that should be treated as outlier detection
-                                errors, in addition to the default 5xx behavior.
+                              description: Specifies HTTP response status codes that
+                                should be treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -3756,10 +3751,9 @@ spec:
                                     format: int32
                                     type: integer
                                   outlierDetectionHttpErrorCodes:
-                                    description: Specifies additional HTTP response
-                                      status codes that should be treated as outlier
-                                      detection errors, in addition to the default
-                                      5xx behavior.
+                                    description: Specifies HTTP response status codes
+                                      that should be treated as outlier detection
+                                      errors.
                                     items:
                                       maximum: 599
                                       minimum: 100
@@ -4336,9 +4330,8 @@ spec:
                         format: int32
                         type: integer
                       outlierDetectionHttpErrorCodes:
-                        description: Specifies additional HTTP response status codes
-                          that should be treated as outlier detection errors, in addition
-                          to the default 5xx behavior.
+                        description: Specifies HTTP response status codes that should
+                          be treated as outlier detection errors.
                         items:
                           maximum: 599
                           minimum: 100
@@ -4746,9 +4739,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies additional HTTP response status
-                                codes that should be treated as outlier detection
-                                errors, in addition to the default 5xx behavior.
+                              description: Specifies HTTP response status codes that
+                                should be treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -5480,9 +5472,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies additional HTTP response status
-                                codes that should be treated as outlier detection
-                                errors, in addition to the default 5xx behavior.
+                              description: Specifies HTTP response status codes that
+                                should be treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -5903,10 +5894,9 @@ spec:
                                     format: int32
                                     type: integer
                                   outlierDetectionHttpErrorCodes:
-                                    description: Specifies additional HTTP response
-                                      status codes that should be treated as outlier
-                                      detection errors, in addition to the default
-                                      5xx behavior.
+                                    description: Specifies HTTP response status codes
+                                      that should be treated as outlier detection
+                                      errors.
                                     items:
                                       maximum: 599
                                       minimum: 100
@@ -6483,9 +6473,8 @@ spec:
                         format: int32
                         type: integer
                       outlierDetectionHttpErrorCodes:
-                        description: Specifies additional HTTP response status codes
-                          that should be treated as outlier detection errors, in addition
-                          to the default 5xx behavior.
+                        description: Specifies HTTP response status codes that should
+                          be treated as outlier detection errors.
                         items:
                           maximum: 599
                           minimum: 100
@@ -6893,9 +6882,8 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: Specifies additional HTTP response status
-                                codes that should be treated as outlier detection
-                                errors, in addition to the default 5xx behavior.
+                              description: Specifies HTTP response status codes that
+                                should be treated as outlier detection errors.
                               items:
                                 maximum: 599
                                 minimum: 100

--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -1186,9 +1186,9 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: HTTP status codes to additionally treat
-                                as outlier detection failures, beyond the default
-                                behavior of only treating 5xx responses as failures.
+                              description: Specifies additional HTTP response status
+                                codes that should be treated as outlier detection
+                                errors, in addition to the default 5xx behavior.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -1609,10 +1609,10 @@ spec:
                                     format: int32
                                     type: integer
                                   outlierDetectionHttpErrorCodes:
-                                    description: HTTP status codes to additionally
-                                      treat as outlier detection failures, beyond
-                                      the default behavior of only treating 5xx responses
-                                      as failures.
+                                    description: Specifies additional HTTP response
+                                      status codes that should be treated as outlier
+                                      detection errors, in addition to the default
+                                      5xx behavior.
                                     items:
                                       maximum: 599
                                       minimum: 100
@@ -2189,9 +2189,9 @@ spec:
                         format: int32
                         type: integer
                       outlierDetectionHttpErrorCodes:
-                        description: HTTP status codes to additionally treat as outlier
-                          detection failures, beyond the default behavior of only
-                          treating 5xx responses as failures.
+                        description: Specifies additional HTTP response status codes
+                          that should be treated as outlier detection errors, in addition
+                          to the default 5xx behavior.
                         items:
                           maximum: 599
                           minimum: 100
@@ -2599,9 +2599,9 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: HTTP status codes to additionally treat
-                                as outlier detection failures, beyond the default
-                                behavior of only treating 5xx responses as failures.
+                              description: Specifies additional HTTP response status
+                                codes that should be treated as outlier detection
+                                errors, in addition to the default 5xx behavior.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -3333,9 +3333,9 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: HTTP status codes to additionally treat
-                                as outlier detection failures, beyond the default
-                                behavior of only treating 5xx responses as failures.
+                              description: Specifies additional HTTP response status
+                                codes that should be treated as outlier detection
+                                errors, in addition to the default 5xx behavior.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -3756,10 +3756,10 @@ spec:
                                     format: int32
                                     type: integer
                                   outlierDetectionHttpErrorCodes:
-                                    description: HTTP status codes to additionally
-                                      treat as outlier detection failures, beyond
-                                      the default behavior of only treating 5xx responses
-                                      as failures.
+                                    description: Specifies additional HTTP response
+                                      status codes that should be treated as outlier
+                                      detection errors, in addition to the default
+                                      5xx behavior.
                                     items:
                                       maximum: 599
                                       minimum: 100
@@ -4336,9 +4336,9 @@ spec:
                         format: int32
                         type: integer
                       outlierDetectionHttpErrorCodes:
-                        description: HTTP status codes to additionally treat as outlier
-                          detection failures, beyond the default behavior of only
-                          treating 5xx responses as failures.
+                        description: Specifies additional HTTP response status codes
+                          that should be treated as outlier detection errors, in addition
+                          to the default 5xx behavior.
                         items:
                           maximum: 599
                           minimum: 100
@@ -4746,9 +4746,9 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: HTTP status codes to additionally treat
-                                as outlier detection failures, beyond the default
-                                behavior of only treating 5xx responses as failures.
+                              description: Specifies additional HTTP response status
+                                codes that should be treated as outlier detection
+                                errors, in addition to the default 5xx behavior.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -5480,9 +5480,9 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: HTTP status codes to additionally treat
-                                as outlier detection failures, beyond the default
-                                behavior of only treating 5xx responses as failures.
+                              description: Specifies additional HTTP response status
+                                codes that should be treated as outlier detection
+                                errors, in addition to the default 5xx behavior.
                               items:
                                 maximum: 599
                                 minimum: 100
@@ -5903,10 +5903,10 @@ spec:
                                     format: int32
                                     type: integer
                                   outlierDetectionHttpErrorCodes:
-                                    description: HTTP status codes to additionally
-                                      treat as outlier detection failures, beyond
-                                      the default behavior of only treating 5xx responses
-                                      as failures.
+                                    description: Specifies additional HTTP response
+                                      status codes that should be treated as outlier
+                                      detection errors, in addition to the default
+                                      5xx behavior.
                                     items:
                                       maximum: 599
                                       minimum: 100
@@ -6483,9 +6483,9 @@ spec:
                         format: int32
                         type: integer
                       outlierDetectionHttpErrorCodes:
-                        description: HTTP status codes to additionally treat as outlier
-                          detection failures, beyond the default behavior of only
-                          treating 5xx responses as failures.
+                        description: Specifies additional HTTP response status codes
+                          that should be treated as outlier detection errors, in addition
+                          to the default 5xx behavior.
                         items:
                           maximum: 599
                           minimum: 100
@@ -6893,9 +6893,9 @@ spec:
                               format: int32
                               type: integer
                             outlierDetectionHttpErrorCodes:
-                              description: HTTP status codes to additionally treat
-                                as outlier detection failures, beyond the default
-                                behavior of only treating 5xx responses as failures.
+                              description: Specifies additional HTTP response status
+                                codes that should be treated as outlier detection
+                                errors, in addition to the default 5xx behavior.
                               items:
                                 maximum: 599
                                 minimum: 100

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1193,8 +1193,17 @@ type OutlierDetection struct {
 	// disabled by setting it to 0%. The default is 0% as it's not typically
 	// applicable in k8s environments with few pods per service.
 	MinHealthPercent int32 `protobuf:"varint,5,opt,name=min_health_percent,json=minHealthPercent,proto3" json:"min_health_percent,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// HTTP status codes to additionally treat as outlier detection failures,
+	// beyond the default behavior of only treating 5xx responses as failures.
+	// `consecutiveGatewayErrors` and `consecutive5xxErrors` are unaffected by
+	// this field. When unset, only 5xx responses are treated as failures.
+	//
+	// +cue-gen:OutlierDetection:releaseChannel:extended
+	// +protoc-gen-crd:list-value-validation:Minimum=100
+	// +protoc-gen-crd:list-value-validation:Maximum=599
+	OutlierDetectionHttpErrorCodes []uint32 `protobuf:"varint,10,rep,packed,name=outlier_detection_http_error_codes,json=outlierDetectionHttpErrorCodes,proto3" json:"outlier_detection_http_error_codes,omitempty"`
+	unknownFields                  protoimpl.UnknownFields
+	sizeCache                      protoimpl.SizeCache
 }
 
 func (x *OutlierDetection) Reset() {
@@ -1289,6 +1298,13 @@ func (x *OutlierDetection) GetMinHealthPercent() int32 {
 		return x.MinHealthPercent
 	}
 	return 0
+}
+
+func (x *OutlierDetection) GetOutlierDetectionHttpErrorCodes() []uint32 {
+	if x != nil {
+		return x.OutlierDetectionHttpErrorCodes
+	}
+	return nil
 }
 
 // SSL/TLS related settings for upstream connections. See Envoy's [TLS
@@ -3049,7 +3065,7 @@ const file_networking_v1alpha3_destination_rule_proto_rawDesc = "" +
 	"\x0fH2UpgradePolicy\x12\v\n" +
 	"\aDEFAULT\x10\x00\x12\x12\n" +
 	"\x0eDO_NOT_UPGRADE\x10\x01\x12\v\n" +
-	"\aUPGRADE\x10\x02\"\x8a\x05\n" +
+	"\aUPGRADE\x10\x02\"\xd6\x05\n" +
 	"\x10OutlierDetection\x121\n" +
 	"\x12consecutive_errors\x18\x01 \x01(\x05B\x02\x18\x01R\x11consecutiveErrors\x12J\n" +
 	"\"split_external_local_origin_errors\x18\b \x01(\bR\x1esplitExternalLocalOriginErrors\x12g\n" +
@@ -3059,7 +3075,9 @@ const file_networking_v1alpha3_destination_rule_proto_rawDesc = "" +
 	"\binterval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\binterval\x12G\n" +
 	"\x12base_ejection_time\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x10baseEjectionTime\x120\n" +
 	"\x14max_ejection_percent\x18\x04 \x01(\x05R\x12maxEjectionPercent\x12,\n" +
-	"\x12min_health_percent\x18\x05 \x01(\x05R\x10minHealthPercent\"\xe4\x03\n" +
+	"\x12min_health_percent\x18\x05 \x01(\x05R\x10minHealthPercent\x12J\n" +
+	"\"outlier_detection_http_error_codes\x18\n" +
+	" \x03(\rR\x1eoutlierDetectionHttpErrorCodes\"\xe4\x03\n" +
 	"\x11ClientTLSSettings\x12H\n" +
 	"\x04mode\x18\x01 \x01(\x0e24.istio.networking.v1alpha3.ClientTLSSettings.TLSmodeR\x04mode\x12-\n" +
 	"\x12client_certificate\x18\x02 \x01(\tR\x11clientCertificate\x12\x1f\n" +

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1193,11 +1193,11 @@ type OutlierDetection struct {
 	// disabled by setting it to 0%. The default is 0% as it's not typically
 	// applicable in k8s environments with few pods per service.
 	MinHealthPercent int32 `protobuf:"varint,5,opt,name=min_health_percent,json=minHealthPercent,proto3" json:"min_health_percent,omitempty"`
-	// Specifies additional HTTP response status codes that should be treated as
-	// outlier detection errors, in addition to the default 5xx behavior.
-	// `consecutiveGatewayErrors` and `consecutive5xxErrors` are unaffected by
-	// this field. Values must be in the range [100, 599]. When unset, only 5xx
-	// responses are treated as failures.
+	// Specifies HTTP response status codes that should be treated as
+	// outlier detection errors. Overrides the default 5xx behavior.
+	// `consecutiveGatewayErrors` and `consecutive5xxErrors` are
+	// unaffected by this field. Values must be in the range [100, 599].
+	// When unset, only 5xx responses are treated as failures.
 	//
 	// +protoc-gen-crd:list-value-validation:Minimum=100
 	// +protoc-gen-crd:list-value-validation:Maximum=599

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1198,6 +1198,10 @@ type OutlierDetection struct {
 	// codes will be treated as errors by outlier detection. If not specified,
 	// only 5xx responses are treated as errors.
 	//
+	// Note: Host ejection is still driven by the `consecutive5xxErrors` and
+	// `consecutiveGatewayErrors` thresholds; this field only redefines which
+	// HTTP status codes are counted as errors toward those thresholds.
+	//
 	// Values must be in the range [100, 599].
 	//
 	// +protoc-gen-crd:list-value-validation:Minimum=100

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1193,11 +1193,12 @@ type OutlierDetection struct {
 	// disabled by setting it to 0%. The default is 0% as it's not typically
 	// applicable in k8s environments with few pods per service.
 	MinHealthPercent int32 `protobuf:"varint,5,opt,name=min_health_percent,json=minHealthPercent,proto3" json:"min_health_percent,omitempty"`
-	// Specifies HTTP response status codes that should be treated as
-	// outlier detection errors. Overrides the default 5xx behavior.
-	// `consecutiveGatewayErrors` and `consecutive5xxErrors` are
-	// unaffected by this field. Values must be in the range [100, 599].
-	// When unset, only 5xx responses are treated as failures.
+	// Specifies the HTTP response status codes that are treated as outlier
+	// detection errors. If specified, only responses with one of these status
+	// codes will be treated as errors by outlier detection. If not specified,
+	// only 5xx responses are treated as errors.
+	//
+	// Values must be in the range [100, 599].
 	//
 	// +protoc-gen-crd:list-value-validation:Minimum=100
 	// +protoc-gen-crd:list-value-validation:Maximum=599

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1193,12 +1193,12 @@ type OutlierDetection struct {
 	// disabled by setting it to 0%. The default is 0% as it's not typically
 	// applicable in k8s environments with few pods per service.
 	MinHealthPercent int32 `protobuf:"varint,5,opt,name=min_health_percent,json=minHealthPercent,proto3" json:"min_health_percent,omitempty"`
-	// HTTP status codes to additionally treat as outlier detection failures,
-	// beyond the default behavior of only treating 5xx responses as failures.
+	// Specifies additional HTTP response status codes that should be treated as
+	// outlier detection errors, in addition to the default 5xx behavior.
 	// `consecutiveGatewayErrors` and `consecutive5xxErrors` are unaffected by
-	// this field. When unset, only 5xx responses are treated as failures.
+	// this field. Values must be in the range [100, 599]. When unset, only 5xx
+	// responses are treated as failures.
 	//
-	// +cue-gen:OutlierDetection:releaseChannel:extended
 	// +protoc-gen-crd:list-value-validation:Minimum=100
 	// +protoc-gen-crd:list-value-validation:Maximum=599
 	OutlierDetectionHttpErrorCodes []uint32 `protobuf:"varint,10,rep,packed,name=outlier_detection_http_error_codes,json=outlierDetectionHttpErrorCodes,proto3" json:"outlier_detection_http_error_codes,omitempty"`

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1561,6 +1561,9 @@ applicable in k8s environments with few pods per service.</p>
 detection errors. If specified, only responses with one of these status
 codes will be treated as errors by outlier detection. If not specified,
 only 5xx responses are treated as errors.</p>
+<p>Note: Host ejection is still driven by the <code>consecutive5xxErrors</code> and
+<code>consecutiveGatewayErrors</code> thresholds; this field only redefines which
+HTTP status codes are counted as errors toward those thresholds.</p>
 <p>Values must be in the range [100, 599].</p>
 
 </td>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1557,11 +1557,11 @@ applicable in k8s environments with few pods per service.</p>
 <div class="type">uint32[]</div>
 </div></td>
 <td>
-<p>Specifies HTTP response status codes that should be treated as
-outlier detection errors. Overrides the default 5xx behavior.
-<code>consecutiveGatewayErrors</code> and <code>consecutive5xxErrors</code> are
-unaffected by this field. Values must be in the range [100, 599].
-When unset, only 5xx responses are treated as failures.</p>
+<p>Specifies the HTTP response status codes that are treated as outlier
+detection errors. If specified, only responses with one of these status
+codes will be treated as errors by outlier detection. If not specified,
+only 5xx responses are treated as errors.</p>
+<p>Values must be in the range [100, 599].</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1557,11 +1557,11 @@ applicable in k8s environments with few pods per service.</p>
 <div class="type">uint32[]</div>
 </div></td>
 <td>
-<p>Specifies additional HTTP response status codes that should be treated as
-outlier detection errors, in addition to the default 5xx behavior.
-<code>consecutiveGatewayErrors</code> and <code>consecutive5xxErrors</code> are unaffected by
-this field. Values must be in the range [100, 599]. When unset, only 5xx
-responses are treated as failures.</p>
+<p>Specifies HTTP response status codes that should be treated as
+outlier detection errors. Overrides the default 5xx behavior.
+<code>consecutiveGatewayErrors</code> and <code>consecutive5xxErrors</code> are
+unaffected by this field. Values must be in the range [100, 599].
+When unset, only 5xx responses are treated as failures.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1552,6 +1552,18 @@ applicable in k8s environments with few pods per service.</p>
 
 </td>
 </tr>
+<tr id="OutlierDetection-outlier_detection_http_error_codes">
+<td><div class="field"><div class="name"><code><a href="#OutlierDetection-outlier_detection_http_error_codes">outlierDetectionHttpErrorCodes</a></code></div>
+<div class="type">uint32[]</div>
+</div></td>
+<td>
+<p>HTTP status codes to additionally treat as outlier detection failures,
+beyond the default behavior of only treating 5xx responses as failures.
+<code>consecutiveGatewayErrors</code> and <code>consecutive5xxErrors</code> are unaffected by
+this field. When unset, only 5xx responses are treated as failures.</p>
+
+</td>
+</tr>
 </tbody>
 </table>
 </section>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1557,10 +1557,11 @@ applicable in k8s environments with few pods per service.</p>
 <div class="type">uint32[]</div>
 </div></td>
 <td>
-<p>HTTP status codes to additionally treat as outlier detection failures,
-beyond the default behavior of only treating 5xx responses as failures.
+<p>Specifies additional HTTP response status codes that should be treated as
+outlier detection errors, in addition to the default 5xx behavior.
 <code>consecutiveGatewayErrors</code> and <code>consecutive5xxErrors</code> are unaffected by
-this field. When unset, only 5xx responses are treated as failures.</p>
+this field. Values must be in the range [100, 599]. When unset, only 5xx
+responses are treated as failures.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -870,6 +870,10 @@ message OutlierDetection {
   // codes will be treated as errors by outlier detection. If not specified,
   // only 5xx responses are treated as errors.
   //
+  // Note: Host ejection is still driven by the `consecutive5xxErrors` and
+  // `consecutiveGatewayErrors` thresholds; this field only redefines which
+  // HTTP status codes are counted as errors toward those thresholds.
+  //
   // Values must be in the range [100, 599].
   //
   // +protoc-gen-crd:list-value-validation:Minimum=100

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -865,12 +865,12 @@ message OutlierDetection {
   // applicable in k8s environments with few pods per service.
   int32 min_health_percent = 5;
 
-  // HTTP status codes to additionally treat as outlier detection failures,
-  // beyond the default behavior of only treating 5xx responses as failures.
+  // Specifies additional HTTP response status codes that should be treated as
+  // outlier detection errors, in addition to the default 5xx behavior.
   // `consecutiveGatewayErrors` and `consecutive5xxErrors` are unaffected by
-  // this field. When unset, only 5xx responses are treated as failures.
+  // this field. Values must be in the range [100, 599]. When unset, only 5xx
+  // responses are treated as failures.
   //
-  // +cue-gen:OutlierDetection:releaseChannel:extended
   // +protoc-gen-crd:list-value-validation:Minimum=100
   // +protoc-gen-crd:list-value-validation:Maximum=599
   repeated uint32 outlier_detection_http_error_codes = 10;

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -864,6 +864,16 @@ message OutlierDetection {
   // disabled by setting it to 0%. The default is 0% as it's not typically
   // applicable in k8s environments with few pods per service.
   int32 min_health_percent = 5;
+
+  // HTTP status codes to additionally treat as outlier detection failures,
+  // beyond the default behavior of only treating 5xx responses as failures.
+  // `consecutiveGatewayErrors` and `consecutive5xxErrors` are unaffected by
+  // this field. When unset, only 5xx responses are treated as failures.
+  //
+  // +cue-gen:OutlierDetection:releaseChannel:extended
+  // +protoc-gen-crd:list-value-validation:Minimum=100
+  // +protoc-gen-crd:list-value-validation:Maximum=599
+  repeated uint32 outlier_detection_http_error_codes = 10;
 }
 
 // SSL/TLS related settings for upstream connections. See Envoy's [TLS

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -865,11 +865,11 @@ message OutlierDetection {
   // applicable in k8s environments with few pods per service.
   int32 min_health_percent = 5;
 
-  // Specifies additional HTTP response status codes that should be treated as
-  // outlier detection errors, in addition to the default 5xx behavior.
-  // `consecutiveGatewayErrors` and `consecutive5xxErrors` are unaffected by
-  // this field. Values must be in the range [100, 599]. When unset, only 5xx
-  // responses are treated as failures.
+  // Specifies HTTP response status codes that should be treated as
+  // outlier detection errors. Overrides the default 5xx behavior.
+  // `consecutiveGatewayErrors` and `consecutive5xxErrors` are
+  // unaffected by this field. Values must be in the range [100, 599].
+  // When unset, only 5xx responses are treated as failures.
   //
   // +protoc-gen-crd:list-value-validation:Minimum=100
   // +protoc-gen-crd:list-value-validation:Maximum=599

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -865,11 +865,12 @@ message OutlierDetection {
   // applicable in k8s environments with few pods per service.
   int32 min_health_percent = 5;
 
-  // Specifies HTTP response status codes that should be treated as
-  // outlier detection errors. Overrides the default 5xx behavior.
-  // `consecutiveGatewayErrors` and `consecutive5xxErrors` are
-  // unaffected by this field. Values must be in the range [100, 599].
-  // When unset, only 5xx responses are treated as failures.
+  // Specifies the HTTP response status codes that are treated as outlier
+  // detection errors. If specified, only responses with one of these status
+  // codes will be treated as errors by outlier detection. If not specified,
+  // only 5xx responses are treated as errors.
+  //
+  // Values must be in the range [100, 599].
   //
   // +protoc-gen-crd:list-value-validation:Minimum=100
   // +protoc-gen-crd:list-value-validation:Maximum=599


### PR DESCRIPTION
## What this PR does
Adds `outlier_detection_http_error_codes` to `OutlierDetection` in DestinationRule,
allowing users to specify additional HTTP status codes (beyond the default 5xx) to
be treated as outlier detection failures.

Maps to Envoy's new `outlier_detection.failure_matcher` in `HttpProtocolOptions`
(envoyproxy/envoy#39947).

Follows the same simplification pattern as `consecutiveGatewayErrors` /
`consecutive5xxErrors` (#1189) — a plain repeated field rather than exposing
Envoy's raw MatchPredicate, consistent with Istio's existing approach (e.g.
VirtualService's `retryOn`).

## Related
Implements the API portion of istio/istio#60828

## Next steps
Wiring into `istio/istio`'s `cluster_traffic_policy.go` (HttpProtocolOptions
section) will follow in a separate PR.