### PR TITLE
Use UInt32Value for min_cluster_size to fix client-go JSON apply

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -1205,6 +1205,7 @@ spec:
                                   description: Minimum number of hosts in the upstream
                                     cluster's local region required for zone-aware
                                     load balancing to be enabled.
+                                  maximum: 4294967295
                                   minimum: 1
                                   nullable: true
                                   type: integer
@@ -1697,6 +1698,7 @@ spec:
                                         description: Minimum number of hosts in the
                                           upstream cluster's local region required
                                           for zone-aware load balancing to be enabled.
+                                        maximum: 4294967295
                                         minimum: 1
                                         nullable: true
                                         type: integer
@@ -2349,6 +2351,7 @@ spec:
                             description: Minimum number of hosts in the upstream cluster's
                               local region required for zone-aware load balancing
                               to be enabled.
+                            maximum: 4294967295
                             minimum: 1
                             nullable: true
                             type: integer
@@ -2832,6 +2835,7 @@ spec:
                                   description: Minimum number of hosts in the upstream
                                     cluster's local region required for zone-aware
                                     load balancing to be enabled.
+                                  maximum: 4294967295
                                   minimum: 1
                                   nullable: true
                                   type: integer
@@ -3639,6 +3643,7 @@ spec:
                                   description: Minimum number of hosts in the upstream
                                     cluster's local region required for zone-aware
                                     load balancing to be enabled.
+                                  maximum: 4294967295
                                   minimum: 1
                                   nullable: true
                                   type: integer
@@ -4131,6 +4136,7 @@ spec:
                                         description: Minimum number of hosts in the
                                           upstream cluster's local region required
                                           for zone-aware load balancing to be enabled.
+                                        maximum: 4294967295
                                         minimum: 1
                                         nullable: true
                                         type: integer
@@ -4783,6 +4789,7 @@ spec:
                             description: Minimum number of hosts in the upstream cluster's
                               local region required for zone-aware load balancing
                               to be enabled.
+                            maximum: 4294967295
                             minimum: 1
                             nullable: true
                             type: integer
@@ -5266,6 +5273,7 @@ spec:
                                   description: Minimum number of hosts in the upstream
                                     cluster's local region required for zone-aware
                                     load balancing to be enabled.
+                                  maximum: 4294967295
                                   minimum: 1
                                   nullable: true
                                   type: integer
@@ -6073,6 +6081,7 @@ spec:
                                   description: Minimum number of hosts in the upstream
                                     cluster's local region required for zone-aware
                                     load balancing to be enabled.
+                                  maximum: 4294967295
                                   minimum: 1
                                   nullable: true
                                   type: integer
@@ -6565,6 +6574,7 @@ spec:
                                         description: Minimum number of hosts in the
                                           upstream cluster's local region required
                                           for zone-aware load balancing to be enabled.
+                                        maximum: 4294967295
                                         minimum: 1
                                         nullable: true
                                         type: integer
@@ -7217,6 +7227,7 @@ spec:
                             description: Minimum number of hosts in the upstream cluster's
                               local region required for zone-aware load balancing
                               to be enabled.
+                            maximum: 4294967295
                             minimum: 1
                             nullable: true
                             type: integer
@@ -7700,6 +7711,7 @@ spec:
                                   description: Minimum number of hosts in the upstream
                                     cluster's local region required for zone-aware
                                     load balancing to be enabled.
+                                  maximum: 4294967295
                                   minimum: 1
                                   nullable: true
                                   type: integer

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1960,7 +1960,7 @@ type ZoneAwareLoadBalancerSetting struct {
 	// would produce poor load balancing results.
 	// If not specified, the default is 6.
 	// +kubebuilder:validation:Minimum=1
-	MinClusterSize *wrappers.UInt64Value `protobuf:"bytes,4,opt,name=min_cluster_size,json=minClusterSize,proto3" json:"min_cluster_size,omitempty"`
+	MinClusterSize *wrappers.UInt32Value `protobuf:"bytes,4,opt,name=min_cluster_size,json=minClusterSize,proto3" json:"min_cluster_size,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -2016,7 +2016,7 @@ func (x *ZoneAwareLoadBalancerSetting) GetFailoverPriority() []string {
 	return nil
 }
 
-func (x *ZoneAwareLoadBalancerSetting) GetMinClusterSize() *wrappers.UInt64Value {
+func (x *ZoneAwareLoadBalancerSetting) GetMinClusterSize() *wrappers.UInt32Value {
 	if x != nil {
 		return x.MinClusterSize
 	}
@@ -3608,7 +3608,7 @@ const file_networking_v1alpha3_destination_rule_proto_rawDesc = "" +
 	"\aenabled\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\aenabled\x12\\\n" +
 	"\bfailover\x18\x02 \x03(\v2@.istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.FailoverR\bfailover\x12+\n" +
 	"\x11failover_priority\x18\x03 \x03(\tR\x10failoverPriority\x12F\n" +
-	"\x10min_cluster_size\x18\x04 \x01(\v2\x1c.google.protobuf.UInt64ValueR\x0eminClusterSize\x1a.\n" +
+	"\x10min_cluster_size\x18\x04 \x01(\v2\x1c.google.protobuf.UInt32ValueR\x0eminClusterSize\x1a.\n" +
 	"\bFailover\x12\x12\n" +
 	"\x04from\x18\x01 \x01(\tR\x04from\x12\x0e\n" +
 	"\x02to\x18\x02 \x01(\tR\x02toB\"Z istio.io/api/networking/v1alpha3b\x06proto3"
@@ -3666,8 +3666,7 @@ var file_networking_v1alpha3_destination_rule_proto_goTypes = []any{
 	(*wrappers.DoubleValue)(nil),                  // 35: google.protobuf.DoubleValue
 	(*wrappers.UInt32Value)(nil),                  // 36: google.protobuf.UInt32Value
 	(*wrappers.BoolValue)(nil),                    // 37: google.protobuf.BoolValue
-	(*wrappers.UInt64Value)(nil),                  // 38: google.protobuf.UInt64Value
-	(*PortSelector)(nil),                          // 39: istio.networking.v1alpha3.PortSelector
+	(*PortSelector)(nil),                          // 38: istio.networking.v1alpha3.PortSelector
 }
 var file_networking_v1alpha3_destination_rule_proto_depIdxs = []int32{
 	5,  // 0: istio.networking.v1alpha3.DestinationRule.traffic_policy:type_name -> istio.networking.v1alpha3.TrafficPolicy
@@ -3707,8 +3706,8 @@ var file_networking_v1alpha3_destination_rule_proto_depIdxs = []int32{
 	37, // 34: istio.networking.v1alpha3.LocalityLoadBalancerSetting.enabled:type_name -> google.protobuf.BoolValue
 	37, // 35: istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.enabled:type_name -> google.protobuf.BoolValue
 	32, // 36: istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.failover:type_name -> istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.Failover
-	38, // 37: istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.min_cluster_size:type_name -> google.protobuf.UInt64Value
-	39, // 38: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.port:type_name -> istio.networking.v1alpha3.PortSelector
+	36, // 37: istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.min_cluster_size:type_name -> google.protobuf.UInt32Value
+	38, // 38: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.port:type_name -> istio.networking.v1alpha3.PortSelector
 	7,  // 39: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.load_balancer:type_name -> istio.networking.v1alpha3.LoadBalancerSettings
 	9,  // 40: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.connection_pool:type_name -> istio.networking.v1alpha3.ConnectionPoolSettings
 	10, // 41: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.outlier_detection:type_name -> istio.networking.v1alpha3.OutlierDetection

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -6,7 +6,7 @@ layout: protoc-gen-docs
 generator: protoc-gen-docs
 schema: istio.networking.v1alpha3.DestinationRule
 aliases: [/docs/reference/config/networking/v1alpha3/destination-rule]
-number_of_entries: 33
+number_of_entries: 32
 ---
 <p><code>DestinationRule</code> defines policies that apply to traffic intended for a
 service after routing has occurred. These rules specify configuration
@@ -2353,7 +2353,7 @@ For this to be effective consider one of the following:</p>
 </tr>
 <tr id="ZoneAwareLoadBalancerSetting-min_cluster_size">
 <td><div class="field"><div class="name"><code><a href="#ZoneAwareLoadBalancerSetting-min_cluster_size">minClusterSize</a></code></div>
-<div class="type"><a href="#google-protobuf-UInt64Value">UInt64Value</a></div>
+<div class="type"><a href="#google-protobuf-UInt32Value">UInt32Value</a></div>
 </div></td>
 <td>
 <p>Minimum number of hosts in the upstream cluster&rsquo;s local region required for zone-aware
@@ -2428,31 +2428,6 @@ the &lsquo;from&rsquo; region becomes unhealthy.</p>
 </div></td>
 <td>
 <p>The uint32 value.</p>
-
-</td>
-</tr>
-</tbody>
-</table>
-</section>
-<h4 id="google-protobuf-UInt64Value">UInt64Value</h4>
-<section>
-<p>Wrapper message for <code>uint64</code>.</p>
-<p>The JSON representation for <code>UInt64Value</code> is JSON string.</p>
-
-<table class="message-fields">
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr id="google-protobuf-UInt64Value-value">
-<td><div class="field"><div class="name"><code><a href="#google-protobuf-UInt64Value-value">value</a></code></div>
-<div class="type">uint64</div>
-</div></td>
-<td>
-<p>The uint64 value.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -1461,5 +1461,5 @@ message ZoneAwareLoadBalancerSetting {
   // would produce poor load balancing results.
   // If not specified, the default is 6.
   // +kubebuilder:validation:Minimum=1
-  google.protobuf.UInt64Value min_cluster_size = 4;
+  google.protobuf.UInt32Value min_cluster_size = 4;
 }


### PR DESCRIPTION
UInt64Value serializes as a JSON string (proto3 JSON spec) but the DestinationRule CRD schema declares minClusterSize as type: integer, so DRs containing it are rejected by the API server when applied via client-go, while kubectl apply works because it bypasses protobuf marshaling. UInt32Value serializes as a JSON number, matching the schema. A host count with a default of 6 does not require uint64 range.