### PR TITLE
gateway: add the alpn protocols setting to the gateway TLS

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -8599,6 +8599,13 @@ spec:
                       description: Set of TLS related options that govern the server's
                         behavior.
                       properties:
+                        alpnProtocols:
+                          description: 'Optional: If specified, the ALPN protocols
+                            advertised by the proxy during the TLS handshake are overridden
+                            with this list.'
+                          items:
+                            type: string
+                          type: array
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -8886,6 +8893,13 @@ spec:
                       description: Set of TLS related options that govern the server's
                         behavior.
                       properties:
+                        alpnProtocols:
+                          description: 'Optional: If specified, the ALPN protocols
+                            advertised by the proxy during the TLS handshake are overridden
+                            with this list.'
+                          items:
+                            type: string
+                          type: array
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -9173,6 +9187,13 @@ spec:
                       description: Set of TLS related options that govern the server's
                         behavior.
                       properties:
+                        alpnProtocols:
+                          description: 'Optional: If specified, the ALPN protocols
+                            advertised by the proxy during the TLS handshake are overridden
+                            with this list.'
+                          items:
+                            type: string
+                          type: array
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -10850,6 +10871,13 @@ spec:
                         termination on the sidecar for requests originating from outside
                         the mesh.
                       properties:
+                        alpnProtocols:
+                          description: 'Optional: If specified, the ALPN protocols
+                            advertised by the proxy during the TLS handshake are overridden
+                            with this list.'
+                          items:
+                            type: string
+                          type: array
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -11477,6 +11505,13 @@ spec:
                         termination on the sidecar for requests originating from outside
                         the mesh.
                       properties:
+                        alpnProtocols:
+                          description: 'Optional: If specified, the ALPN protocols
+                            advertised by the proxy during the TLS handshake are overridden
+                            with this list.'
+                          items:
+                            type: string
+                          type: array
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.
@@ -12104,6 +12139,13 @@ spec:
                         termination on the sidecar for requests originating from outside
                         the mesh.
                       properties:
+                        alpnProtocols:
+                          description: 'Optional: If specified, the ALPN protocols
+                            advertised by the proxy during the TLS handshake are overridden
+                            with this list.'
+                          items:
+                            type: string
+                          type: array
                         caCertCredentialName:
                           description: For mutual TLS, the name of the secret or the
                             configmap that holds CA certificates.

--- a/networking/v1alpha3/gateway.pb.go
+++ b/networking/v1alpha3/gateway.pb.go
@@ -849,7 +849,13 @@ type ServerTLSSettings struct {
 	// Optional: If specified, only support the specified ecdh curves.
 	// Otherwise default to the default ecdh list supported by Envoy
 	// as specified [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto).
-	EcdhCurves    []string `protobuf:"bytes,18,rep,name=ecdh_curves,json=ecdhCurves,proto3" json:"ecdh_curves,omitempty"`
+	EcdhCurves []string `protobuf:"bytes,18,rep,name=ecdh_curves,json=ecdhCurves,proto3" json:"ecdh_curves,omitempty"`
+	// Optional: If specified, the ALPN protocols advertised by the proxy during
+	// the TLS handshake are overridden with this list.
+	//
+	// Note: Setting an ALPN list that is incompatible with the protocol
+	// configured for the server port may break the traffic served by this port.
+	AlpnProtocols []string `protobuf:"bytes,19,rep,name=alpn_protocols,json=alpnProtocols,proto3" json:"alpn_protocols,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1010,6 +1016,13 @@ func (x *ServerTLSSettings) GetEcdhCurves() []string {
 	return nil
 }
 
+func (x *ServerTLSSettings) GetAlpnProtocols() []string {
+	if x != nil {
+		return x.AlpnProtocols
+	}
+	return nil
+}
+
 // TLSCertificate describes the server's TLS certificate.
 type ServerTLSSettings_TLSCertificate struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1103,8 +1116,7 @@ const file_networking_v1alpha3_gateway_proto_rawDesc = "" +
 	"\bprotocol\x18\x02 \x01(\tB\x04\xe2A\x01\x02R\bprotocol\x12\x18\n" +
 	"\x04name\x18\x03 \x01(\tB\x04\xe2A\x01\x02R\x04name\x12#\n" +
 	"\vtarget_port\x18\x04 \x01(\rB\x02\x18\x01R\n" +
-	"targetPort\"\xdd\n" +
-	"\n" +
+	"targetPort\"\x84\v\n" +
 	"\x11ServerTLSSettings\x12%\n" +
 	"\x0ehttps_redirect\x18\x01 \x01(\bR\rhttpsRedirect\x12H\n" +
 	"\x04mode\x18\x02 \x01(\x0e24.istio.networking.v1alpha3.ServerTLSSettings.TLSmodeR\x04mode\x12-\n" +
@@ -1126,7 +1138,8 @@ const file_networking_v1alpha3_gateway_proto_rawDesc = "" +
 	"\rcipher_suites\x18\t \x03(\tR\fcipherSuites\x12L\n" +
 	"\x14insecure_skip_verify\x18\x11 \x01(\v2\x1a.google.protobuf.BoolValueR\x12insecureSkipVerify\x12\x1f\n" +
 	"\vecdh_curves\x18\x12 \x03(\tR\n" +
-	"ecdhCurves\x1a\x89\x01\n" +
+	"ecdhCurves\x12%\n" +
+	"\x0ealpn_protocols\x18\x13 \x03(\tR\ralpnProtocols\x1a\x89\x01\n" +
 	"\x0eTLSCertificate\x12-\n" +
 	"\x12server_certificate\x18\x01 \x01(\tR\x11serverCertificate\x12\x1f\n" +
 	"\vprivate_key\x18\x02 \x01(\tR\n" +

--- a/networking/v1alpha3/gateway.pb.html
+++ b/networking/v1alpha3/gateway.pb.html
@@ -647,6 +647,18 @@ as specified <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensi
 
 </td>
 </tr>
+<tr id="ServerTLSSettings-alpn_protocols">
+<td><div class="field"><div class="name"><code><a href="#ServerTLSSettings-alpn_protocols">alpnProtocols</a></code></div>
+<div class="type">string[]</div>
+</div></td>
+<td>
+<p>If specified, the ALPN protocols advertised by the proxy during
+the TLS handshake are overridden with this list.</p>
+<p>Note: Setting an ALPN list that is incompatible with the protocol
+configured for the server port may break the traffic served by this port.</p>
+
+</td>
+</tr>
 </tbody>
 </table>
 </section>

--- a/networking/v1alpha3/gateway.proto
+++ b/networking/v1alpha3/gateway.proto
@@ -592,4 +592,11 @@ message ServerTLSSettings {
   // Otherwise default to the default ecdh list supported by Envoy
   // as specified [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto).
   repeated string ecdh_curves = 18;
+
+  // Optional: If specified, the ALPN protocols advertised by the proxy during
+  // the TLS handshake are overridden with this list.
+  //
+  // Note: Setting an ALPN list that is incompatible with the protocol
+  // configured for the server port may break the traffic served by this port.
+  repeated string alpn_protocols = 19;
 }

--- a/releasenotes/notes/gateway-alpn-protocols.yaml
+++ b/releasenotes/notes/gateway-alpn-protocols.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue: []
+releaseNotes:
+  - |
+    **Added** `alpnProtocols` to the `Gateway` server TLS settings, allowing
+    the ALPN protocols advertised by the gateway during the TLS handshake to
+    be overridden. The proxy advertises `h2` and `http/1.1` by default.


### PR DESCRIPTION
For now, for the HTTPS over TCP, the APLN is hard coded to `http1.1,h2` and there is no friendly API to configure it. But I found we actually have supported lots of attributes of TLS context like the TLS version and so on.

It should be good to add the alpn protocol support there.