### PR TITLE
networking: add suffix match type to StringMatch

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -12487,12 +12487,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -12500,6 +12504,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           type: array
@@ -12710,12 +12716,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -12723,6 +12733,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           gateways:
@@ -12742,12 +12754,16 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - suffix
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - suffix
                               properties:
                                 exact:
                                   type: string
@@ -12755,6 +12771,8 @@ spec:
                                   type: string
                                 regex:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                  type: string
+                                suffix:
                                   type: string
                               type: object
                             description: The header keys must be lowercase and use
@@ -12778,12 +12796,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -12791,6 +12813,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           name:
@@ -12813,12 +12837,16 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - suffix
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - suffix
                               properties:
                                 exact:
                                   type: string
@@ -12826,6 +12854,8 @@ spec:
                                   type: string
                                 regex:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                  type: string
+                                suffix:
                                   type: string
                               type: object
                             description: Query parameters for matching.
@@ -12844,12 +12874,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -12857,6 +12891,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           sourceLabels:
@@ -12888,12 +12924,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -12901,6 +12941,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           withoutHeaders:
@@ -12914,12 +12956,16 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - suffix
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - suffix
                               properties:
                                 exact:
                                   type: string
@@ -12927,6 +12973,8 @@ spec:
                                   type: string
                                 regex:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                  type: string
+                                suffix:
                                   type: string
                               type: object
                             description: withoutHeader has the same syntax with the
@@ -13543,12 +13591,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -13556,6 +13608,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           type: array
@@ -13766,12 +13820,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -13779,6 +13837,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           gateways:
@@ -13798,12 +13858,16 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - suffix
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - suffix
                               properties:
                                 exact:
                                   type: string
@@ -13811,6 +13875,8 @@ spec:
                                   type: string
                                 regex:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                  type: string
+                                suffix:
                                   type: string
                               type: object
                             description: The header keys must be lowercase and use
@@ -13834,12 +13900,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -13847,6 +13917,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           name:
@@ -13869,12 +13941,16 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - suffix
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - suffix
                               properties:
                                 exact:
                                   type: string
@@ -13882,6 +13958,8 @@ spec:
                                   type: string
                                 regex:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                  type: string
+                                suffix:
                                   type: string
                               type: object
                             description: Query parameters for matching.
@@ -13900,12 +13978,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -13913,6 +13995,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           sourceLabels:
@@ -13944,12 +14028,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -13957,6 +14045,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           withoutHeaders:
@@ -13970,12 +14060,16 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - suffix
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - suffix
                               properties:
                                 exact:
                                   type: string
@@ -13983,6 +14077,8 @@ spec:
                                   type: string
                                 regex:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                  type: string
+                                suffix:
                                   type: string
                               type: object
                             description: withoutHeader has the same syntax with the
@@ -14599,12 +14695,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -14612,6 +14712,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           type: array
@@ -14822,12 +14924,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -14835,6 +14941,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           gateways:
@@ -14854,12 +14962,16 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - suffix
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - suffix
                               properties:
                                 exact:
                                   type: string
@@ -14867,6 +14979,8 @@ spec:
                                   type: string
                                 regex:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                  type: string
+                                suffix:
                                   type: string
                               type: object
                             description: The header keys must be lowercase and use
@@ -14890,12 +15004,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -14903,6 +15021,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           name:
@@ -14925,12 +15045,16 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - suffix
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - suffix
                               properties:
                                 exact:
                                   type: string
@@ -14938,6 +15062,8 @@ spec:
                                   type: string
                                 regex:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                  type: string
+                                suffix:
                                   type: string
                               type: object
                             description: Query parameters for matching.
@@ -14956,12 +15082,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -14969,6 +15099,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           sourceLabels:
@@ -15000,12 +15132,16 @@ spec:
                                   - prefix
                                 - required:
                                   - regex
+                                - required:
+                                  - suffix
                             - required:
                               - exact
                             - required:
                               - prefix
                             - required:
                               - regex
+                            - required:
+                              - suffix
                             properties:
                               exact:
                                 type: string
@@ -15013,6 +15149,8 @@ spec:
                                 type: string
                               regex:
                                 description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                type: string
+                              suffix:
                                 type: string
                             type: object
                           withoutHeaders:
@@ -15026,12 +15164,16 @@ spec:
                                     - prefix
                                   - required:
                                     - regex
+                                  - required:
+                                    - suffix
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
+                              - required:
+                                - suffix
                               properties:
                                 exact:
                                   type: string
@@ -15039,6 +15181,8 @@ spec:
                                   type: string
                                 regex:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
+                                  type: string
+                                suffix:
                                   type: string
                               type: object
                             description: withoutHeader has the same syntax with the

--- a/networking/v1/virtual_service_alias.gen.go
+++ b/networking/v1/virtual_service_alias.gen.go
@@ -685,7 +685,7 @@ type HTTPBody_Bytes = v1alpha3.HTTPBody_Bytes
 type HTTPRewrite = v1alpha3.HTTPRewrite
 type RegexRewrite = v1alpha3.RegexRewrite
 
-// Describes how to match a given string in HTTP headers. `exact` and `prefix` matching is
+// Describes how to match a given string in HTTP headers. `exact`, `prefix` and `suffix` matching is
 // case-sensitive. `regex` matching supports case-insensitive matches.
 type StringMatch = v1alpha3.StringMatch
 
@@ -699,6 +699,9 @@ type StringMatch_Prefix = v1alpha3.StringMatch_Prefix
 //
 // Example: `(?i)^aaa$` can be used to case-insensitive match a string consisting of three a's.
 type StringMatch_Regex = v1alpha3.StringMatch_Regex
+
+// suffix-based match
+type StringMatch_Suffix = v1alpha3.StringMatch_Suffix
 
 // Describes the retry policy to use when a HTTP request fails. For
 // example, the following rule sets the maximum number of retries to 3 when

--- a/networking/v1alpha3/virtual_service.pb.go
+++ b/networking/v1alpha3/virtual_service.pb.go
@@ -1332,6 +1332,8 @@ type HTTPMatchRequest struct {
 	//
 	// - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
 	//
+	// **Note:** `suffix` matching is not supported for `uri`.
+	//
 	// **Note:** Case-insensitive matching could be enabled via the
 	// `ignoreUriCase` flag.
 	Uri *StringMatch `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
@@ -1343,6 +1345,8 @@ type HTTPMatchRequest struct {
 	// - `prefix: "value"` for prefix-based match
 	//
 	// - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
+	//
+	// - `suffix: "value"` for suffix-based match
 	Scheme *StringMatch `protobuf:"bytes,2,opt,name=scheme,proto3" json:"scheme,omitempty"`
 	// HTTP Method
 	// values are case-sensitive and formatted as follows:
@@ -1352,6 +1356,8 @@ type HTTPMatchRequest struct {
 	// - `prefix: "value"` for prefix-based match
 	//
 	// - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
+	//
+	// - `suffix: "value"` for suffix-based match
 	Method *StringMatch `protobuf:"bytes,3,opt,name=method,proto3" json:"method,omitempty"`
 	// HTTP Authority
 	// values are case-sensitive and formatted as follows:
@@ -1361,6 +1367,8 @@ type HTTPMatchRequest struct {
 	// - `prefix: "value"` for prefix-based match
 	//
 	// - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
+	//
+	// - `suffix: "value"` for suffix-based match
 	Authority *StringMatch `protobuf:"bytes,4,opt,name=authority,proto3" json:"authority,omitempty"`
 	// The header keys must be lowercase and use hyphen as the separator,
 	// e.g. _x-request-id_.
@@ -1372,6 +1380,8 @@ type HTTPMatchRequest struct {
 	// - `prefix: "value"` for prefix-based match
 	//
 	// - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
+	//
+	// - `suffix: "value"` for suffix-based match
 	//
 	// If the value is empty and only the name of header is specified, presence of the header is checked.
 	// To provide an empty value, use `{}`, for example:
@@ -1416,6 +1426,9 @@ type HTTPMatchRequest struct {
 	//   - For a query parameter like "?key=123", the map key would be "key" and the
 	//     string match could be defined as `regex: "\d+$"`. Note that this
 	//     configuration will only match values like "123" but not "a123" or "123a".
+	//
+	//   - For a query parameter like "?key=ab123" or "?key=xy123", the map key would be "key" and the
+	//     string match could be defined as `suffix: "123"`.
 	QueryParams map[string]*StringMatch `protobuf:"bytes,9,rep,name=query_params,json=queryParams,proto3" json:"query_params,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Flag to specify whether the URI matching should be case-insensitive.
 	//
@@ -2576,7 +2589,7 @@ func (x *RegexRewrite) GetRewrite() string {
 	return ""
 }
 
-// Describes how to match a given string in HTTP headers. `exact` and `prefix` matching is
+// Describes how to match a given string in HTTP headers. `exact`, `prefix` and `suffix` matching is
 // case-sensitive. `regex` matching supports case-insensitive matches.
 type StringMatch struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -2585,6 +2598,7 @@ type StringMatch struct {
 	//	*StringMatch_Exact
 	//	*StringMatch_Prefix
 	//	*StringMatch_Regex
+	//	*StringMatch_Suffix
 	MatchType     isStringMatch_MatchType `protobuf_oneof:"match_type"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2654,6 +2668,15 @@ func (x *StringMatch) GetRegex() string {
 	return ""
 }
 
+func (x *StringMatch) GetSuffix() string {
+	if x != nil {
+		if x, ok := x.MatchType.(*StringMatch_Suffix); ok {
+			return x.Suffix
+		}
+	}
+	return ""
+}
+
 type isStringMatch_MatchType interface {
 	isStringMatch_MatchType()
 }
@@ -2675,11 +2698,18 @@ type StringMatch_Regex struct {
 	Regex string `protobuf:"bytes,3,opt,name=regex,proto3,oneof"`
 }
 
+type StringMatch_Suffix struct {
+	// suffix-based match
+	Suffix string `protobuf:"bytes,4,opt,name=suffix,proto3,oneof"`
+}
+
 func (*StringMatch_Exact) isStringMatch_MatchType() {}
 
 func (*StringMatch_Prefix) isStringMatch_MatchType() {}
 
 func (*StringMatch_Regex) isStringMatch_MatchType() {}
+
+func (*StringMatch_Suffix) isStringMatch_MatchType() {}
 
 // Describes the retry policy to use when a HTTP request fails. For
 // example, the following rule sets the maximum number of retries to 3 when
@@ -3695,11 +3725,12 @@ const file_networking_v1alpha3_virtual_service_proto_rawDesc = "" +
 	"\x11uri_regex_rewrite\x18\x03 \x01(\v2'.istio.networking.v1alpha3.RegexRewriteR\x0furiRegexRewrite\">\n" +
 	"\fRegexRewrite\x12\x14\n" +
 	"\x05match\x18\x01 \x01(\tR\x05match\x12\x18\n" +
-	"\arewrite\x18\x02 \x01(\tR\arewrite\"e\n" +
+	"\arewrite\x18\x02 \x01(\tR\arewrite\"\x7f\n" +
 	"\vStringMatch\x12\x16\n" +
 	"\x05exact\x18\x01 \x01(\tH\x00R\x05exact\x12\x18\n" +
 	"\x06prefix\x18\x02 \x01(\tH\x00R\x06prefix\x12\x16\n" +
-	"\x05regex\x18\x03 \x01(\tH\x00R\x05regexB\f\n" +
+	"\x05regex\x18\x03 \x01(\tH\x00R\x05regex\x12\x18\n" +
+	"\x06suffix\x18\x04 \x01(\tH\x00R\x06suffixB\f\n" +
 	"\n" +
 	"match_type\"\xe9\x02\n" +
 	"\tHTTPRetry\x12\x1a\n" +
@@ -3901,6 +3932,7 @@ func file_networking_v1alpha3_virtual_service_proto_init() {
 		(*StringMatch_Exact)(nil),
 		(*StringMatch_Prefix)(nil),
 		(*StringMatch_Regex)(nil),
+		(*StringMatch_Suffix)(nil),
 	}
 	file_networking_v1alpha3_virtual_service_proto_msgTypes[33].OneofWrappers = []any{
 		(*HTTPFaultInjection_Delay_FixedDelay)(nil),

--- a/networking/v1alpha3/virtual_service.pb.html
+++ b/networking/v1alpha3/virtual_service.pb.html
@@ -969,6 +969,7 @@ values are case-sensitive and formatted as follows:</p>
 <p><code>regex: &quot;value&quot;</code> for <a href="https://github.com/google/re2/wiki/Syntax">RE2 style regex-based match</a>.</p>
 </li>
 </ul>
+<p><strong>Note:</strong> <code>suffix</code> matching is not supported for <code>uri</code>.</p>
 <p><strong>Note:</strong> Case-insensitive matching could be enabled via the
 <code>ignoreUriCase</code> flag.</p>
 
@@ -991,6 +992,9 @@ values are case-sensitive and formatted as follows:</p>
 <li>
 <p><code>regex: &quot;value&quot;</code> for <a href="https://github.com/google/re2/wiki/Syntax">RE2 style regex-based match</a>.</p>
 </li>
+<li>
+<p><code>suffix: &quot;value&quot;</code> for suffix-based match</p>
+</li>
 </ul>
 
 </td>
@@ -1011,6 +1015,9 @@ values are case-sensitive and formatted as follows:</p>
 </li>
 <li>
 <p><code>regex: &quot;value&quot;</code> for <a href="https://github.com/google/re2/wiki/Syntax">RE2 style regex-based match</a>.</p>
+</li>
+<li>
+<p><code>suffix: &quot;value&quot;</code> for suffix-based match</p>
 </li>
 </ul>
 
@@ -1033,6 +1040,9 @@ values are case-sensitive and formatted as follows:</p>
 <li>
 <p><code>regex: &quot;value&quot;</code> for <a href="https://github.com/google/re2/wiki/Syntax">RE2 style regex-based match</a>.</p>
 </li>
+<li>
+<p><code>suffix: &quot;value&quot;</code> for suffix-based match</p>
+</li>
 </ul>
 
 </td>
@@ -1054,6 +1064,9 @@ e.g. <em>x-request-id</em>.</p>
 </li>
 <li>
 <p><code>regex: &quot;value&quot;</code> for <a href="https://github.com/google/re2/wiki/Syntax">RE2 style regex-based match</a>.</p>
+</li>
+<li>
+<p><code>suffix: &quot;value&quot;</code> for suffix-based match</p>
 </li>
 </ul>
 <p>If the value is empty and only the name of header is specified, presence of the header is checked.
@@ -1126,6 +1139,10 @@ string match could be defined as <code>prefix: &quot;ab&quot;</code>.</p>
 <p>For a query parameter like &ldquo;?key=123&rdquo;, the map key would be &ldquo;key&rdquo; and the
 string match could be defined as <code>regex: &quot;\d+$&quot;</code>. Note that this
 configuration will only match values like &ldquo;123&rdquo; but not &ldquo;a123&rdquo; or &ldquo;123a&rdquo;.</p>
+</li>
+<li>
+<p>For a query parameter like &ldquo;?key=ab123&rdquo; or &ldquo;?key=xy123&rdquo;, the map key would be &ldquo;key&rdquo; and the
+string match could be defined as <code>suffix: &quot;123&quot;</code>.</p>
 </li>
 </ul>
 
@@ -1880,7 +1897,7 @@ case-insensitive match and transform the path to &ldquo;/aaa/yyy/bbb&rdquo;.</p>
 </section>
 <h2 id="StringMatch">StringMatch</h2>
 <section>
-<p>Describes how to match a given string in HTTP headers. <code>exact</code> and <code>prefix</code> matching is
+<p>Describes how to match a given string in HTTP headers. <code>exact</code>, <code>prefix</code> and <code>suffix</code> matching is
 case-sensitive. <code>regex</code> matching supports case-insensitive matches.</p>
 
 <table class="message-fields">
@@ -1916,6 +1933,15 @@ case-sensitive. <code>regex</code> matching supports case-insensitive matches.</
 <td>
 <p><a href="https://github.com/google/re2/wiki/Syntax">RE2 style regex-based match</a>.</p>
 <p>Example: <code>(?i)^aaa$</code> can be used to case-insensitive match a string consisting of three a&rsquo;s.</p>
+
+</td>
+</tr>
+<tr id="StringMatch-suffix" class="oneof">
+<td><div class="field"><div class="name"><code><a href="#StringMatch-suffix">suffix</a></code></div>
+<div class="type">string (oneof)</div>
+</div></td>
+<td>
+<p>suffix-based match</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/virtual_service.proto
+++ b/networking/v1alpha3/virtual_service.proto
@@ -747,6 +747,8 @@ message HTTPMatchRequest {
   //
   // - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
   //
+  // **Note:** `suffix` matching is not supported for `uri`.
+  //
   // **Note:** Case-insensitive matching could be enabled via the
   // `ignoreUriCase` flag.
   StringMatch uri = 1;
@@ -760,6 +762,8 @@ message HTTPMatchRequest {
   //
   // - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
   //
+  // - `suffix: "value"` for suffix-based match
+  //
   StringMatch scheme = 2;
 
   // HTTP Method
@@ -771,6 +775,8 @@ message HTTPMatchRequest {
   //
   // - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
   //
+  // - `suffix: "value"` for suffix-based match
+  //
   StringMatch method = 3;
 
   // HTTP Authority
@@ -781,6 +787,8 @@ message HTTPMatchRequest {
   // - `prefix: "value"` for prefix-based match
   //
   // - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
+  //
+  // - `suffix: "value"` for suffix-based match
   //
   StringMatch authority = 4;
 
@@ -794,6 +802,8 @@ message HTTPMatchRequest {
   // - `prefix: "value"` for prefix-based match
   //
   // - `regex: "value"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).
+  //
+  // - `suffix: "value"` for suffix-based match
   //
   // If the value is empty and only the name of header is specified, presence of the header is checked.
   // To provide an empty value, use `{}`, for example:
@@ -841,6 +851,9 @@ message HTTPMatchRequest {
   // - For a query parameter like "?key=123", the map key would be "key" and the
   //   string match could be defined as `regex: "\d+$"`. Note that this
   //   configuration will only match values like "123" but not "a123" or "123a".
+  //
+  // - For a query parameter like "?key=ab123" or "?key=xy123", the map key would be "key" and the
+  //   string match could be defined as `suffix: "123"`.
   map<string, StringMatch> query_params = 9;
 
   // Flag to specify whether the URI matching should be case-insensitive.
@@ -1292,7 +1305,7 @@ message RegexRewrite {
   string rewrite = 2;
 }
 
-// Describes how to match a given string in HTTP headers. `exact` and `prefix` matching is
+// Describes how to match a given string in HTTP headers. `exact`, `prefix` and `suffix` matching is
 // case-sensitive. `regex` matching supports case-insensitive matches.
 message StringMatch {
   oneof match_type {
@@ -1306,6 +1319,9 @@ message StringMatch {
     //
     // Example: `(?i)^aaa$` can be used to case-insensitive match a string consisting of three a's.
     string regex = 3;
+
+    // suffix-based match
+    string suffix = 4;
   }
 }
 

--- a/networking/v1beta1/virtual_service_alias.gen.go
+++ b/networking/v1beta1/virtual_service_alias.gen.go
@@ -685,7 +685,7 @@ type HTTPBody_Bytes = v1alpha3.HTTPBody_Bytes
 type HTTPRewrite = v1alpha3.HTTPRewrite
 type RegexRewrite = v1alpha3.RegexRewrite
 
-// Describes how to match a given string in HTTP headers. `exact` and `prefix` matching is
+// Describes how to match a given string in HTTP headers. `exact`, `prefix` and `suffix` matching is
 // case-sensitive. `regex` matching supports case-insensitive matches.
 type StringMatch = v1alpha3.StringMatch
 
@@ -699,6 +699,9 @@ type StringMatch_Prefix = v1alpha3.StringMatch_Prefix
 //
 // Example: `(?i)^aaa$` can be used to case-insensitive match a string consisting of three a's.
 type StringMatch_Regex = v1alpha3.StringMatch_Regex
+
+// suffix-based match
+type StringMatch_Suffix = v1alpha3.StringMatch_Suffix
 
 // Describes the retry policy to use when a HTTP request fails. For
 // example, the following rule sets the maximum number of retries to 3 when

--- a/releasenotes/notes/stringmatch-suffix.yaml
+++ b/releasenotes/notes/stringmatch-suffix.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+
+kind: feature
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/61292
+
+releaseNotes:
+- |
+    **Added** `suffix` match type to `StringMatch`, supported in `VirtualService` HTTP match conditions
+    (`headers`, `withoutHeaders`, `authority`, `scheme`, `method`, `queryParams`) and CORS `allowOrigins`.
+    Suffix matching is not supported for `uri`.

--- a/tests/testdata/virtualservice-valid.yaml
+++ b/tests/testdata/virtualservice-valid.yaml
@@ -1,0 +1,69 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: string-match-types
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - match:
+    - uri:
+        prefix: /reviews
+      authority:
+        exact: reviews.prod.svc.cluster.local
+      headers:
+        end-user:
+          regex: jas.n
+    route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: suffix-match
+spec:
+  hosts:
+  - '*.example.com'
+  http:
+  - match:
+    - authority:
+        suffix: .a.example.com
+      headers:
+        referer:
+          suffix: .example.com
+      queryParams:
+        token:
+          suffix: -dev
+      withoutHeaders:
+        end-user:
+          suffix: son
+    route:
+    - destination:
+        host: a.example.com
+  - route:
+    - destination:
+        host: b.example.com
+---
+# Note: corsPolicy.allowOrigins deliberately has no `suffix` entry. These fixtures are synced
+# into istio/istio, where the dependency-update commit runs them against the webhook validator
+# before the webhook supports suffix CORS origins; suffix allowOrigins are covered by the
+# webhook's own unit tests instead.
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: cors-match
+spec:
+  hosts:
+  - ratings.prod.svc.cluster.local
+  http:
+  - corsPolicy:
+      allowOrigins:
+      - exact: https://example.com
+      - prefix: https://example
+      - regex: https://.*\.example\.com
+      allowMethods:
+      - GET
+    route:
+    - destination:
+        host: ratings.prod.svc.cluster.local


### PR DESCRIPTION
Adds a suffix option to StringMatch, mapping to Envoy's native StringMatcher suffix. Supported in VirtualService HTTP match conditions (headers, withoutHeaders, authority, scheme, method, queryParams) and CORS allowOrigins.
Not supported for uri matching.

Ref: https://github.com/istio/istio/issues/61292