### PR TITLE
destinationrule: add failure_percentage_threshold

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -1243,6 +1243,13 @@ spec:
                               minimum: 0
                               nullable: true
                               type: integer
+                            failurePercentageThreshold:
+                              description: The failure percentage to use when determining
+                                failure percentage-based outlier detection.
+                              maximum: 100
+                              minimum: 0
+                              nullable: true
+                              type: integer
                             interval:
                               description: Time interval between ejection sweep analysis.
                               type: string
@@ -1734,6 +1741,14 @@ spec:
                                     description: The number of consecutive locally
                                       originated failures before ejection occurs.
                                     maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  failurePercentageThreshold:
+                                    description: The failure percentage to use when
+                                      determining failure percentage-based outlier
+                                      detection.
+                                    maximum: 100
                                     minimum: 0
                                     nullable: true
                                     type: integer
@@ -2389,6 +2404,13 @@ spec:
                         minimum: 0
                         nullable: true
                         type: integer
+                      failurePercentageThreshold:
+                        description: The failure percentage to use when determining
+                          failure percentage-based outlier detection.
+                        maximum: 100
+                        minimum: 0
+                        nullable: true
+                        type: integer
                       interval:
                         description: Time interval between ejection sweep analysis.
                         type: string
@@ -2870,6 +2892,13 @@ spec:
                               description: The number of consecutive locally originated
                                 failures before ejection occurs.
                               maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            failurePercentageThreshold:
+                              description: The failure percentage to use when determining
+                                failure percentage-based outlier detection.
+                              maximum: 100
                               minimum: 0
                               nullable: true
                               type: integer
@@ -3681,6 +3710,13 @@ spec:
                               minimum: 0
                               nullable: true
                               type: integer
+                            failurePercentageThreshold:
+                              description: The failure percentage to use when determining
+                                failure percentage-based outlier detection.
+                              maximum: 100
+                              minimum: 0
+                              nullable: true
+                              type: integer
                             interval:
                               description: Time interval between ejection sweep analysis.
                               type: string
@@ -4172,6 +4208,14 @@ spec:
                                     description: The number of consecutive locally
                                       originated failures before ejection occurs.
                                     maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  failurePercentageThreshold:
+                                    description: The failure percentage to use when
+                                      determining failure percentage-based outlier
+                                      detection.
+                                    maximum: 100
                                     minimum: 0
                                     nullable: true
                                     type: integer
@@ -4827,6 +4871,13 @@ spec:
                         minimum: 0
                         nullable: true
                         type: integer
+                      failurePercentageThreshold:
+                        description: The failure percentage to use when determining
+                          failure percentage-based outlier detection.
+                        maximum: 100
+                        minimum: 0
+                        nullable: true
+                        type: integer
                       interval:
                         description: Time interval between ejection sweep analysis.
                         type: string
@@ -5308,6 +5359,13 @@ spec:
                               description: The number of consecutive locally originated
                                 failures before ejection occurs.
                               maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            failurePercentageThreshold:
+                              description: The failure percentage to use when determining
+                                failure percentage-based outlier detection.
+                              maximum: 100
                               minimum: 0
                               nullable: true
                               type: integer
@@ -6119,6 +6177,13 @@ spec:
                               minimum: 0
                               nullable: true
                               type: integer
+                            failurePercentageThreshold:
+                              description: The failure percentage to use when determining
+                                failure percentage-based outlier detection.
+                              maximum: 100
+                              minimum: 0
+                              nullable: true
+                              type: integer
                             interval:
                               description: Time interval between ejection sweep analysis.
                               type: string
@@ -6610,6 +6675,14 @@ spec:
                                     description: The number of consecutive locally
                                       originated failures before ejection occurs.
                                     maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  failurePercentageThreshold:
+                                    description: The failure percentage to use when
+                                      determining failure percentage-based outlier
+                                      detection.
+                                    maximum: 100
                                     minimum: 0
                                     nullable: true
                                     type: integer
@@ -7265,6 +7338,13 @@ spec:
                         minimum: 0
                         nullable: true
                         type: integer
+                      failurePercentageThreshold:
+                        description: The failure percentage to use when determining
+                          failure percentage-based outlier detection.
+                        maximum: 100
+                        minimum: 0
+                        nullable: true
+                        type: integer
                       interval:
                         description: Time interval between ejection sweep analysis.
                         type: string
@@ -7746,6 +7826,13 @@ spec:
                               description: The number of consecutive locally originated
                                 failures before ejection occurs.
                               maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            failurePercentageThreshold:
+                              description: The failure percentage to use when determining
+                                failure percentage-based outlier detection.
+                              maximum: 100
                               minimum: 0
                               nullable: true
                               type: integer

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1260,8 +1260,15 @@ type OutlierDetection struct {
 	// +protoc-gen-crd:list-value-validation:Minimum=100
 	// +protoc-gen-crd:list-value-validation:Maximum=599
 	OutlierDetectionHttpErrorCodes []uint32 `protobuf:"varint,10,rep,packed,name=outlier_detection_http_error_codes,json=outlierDetectionHttpErrorCodes,proto3" json:"outlier_detection_http_error_codes,omitempty"`
-	unknownFields                  protoimpl.UnknownFields
-	sizeCache                      protoimpl.SizeCache
+	// The failure percentage to use when determining failure percentage-based outlier detection. If
+	// the failure percentage of a given host is greater than or equal to this value, it will be
+	// ejected. Defaults to 85.
+	//
+	// +kubebuilder:validation:Maximum=100
+	// +kubebuilder:validation:Minimum=0
+	FailurePercentageThreshold *wrappers.UInt32Value `protobuf:"bytes,11,opt,name=failure_percentage_threshold,json=failurePercentageThreshold,proto3" json:"failure_percentage_threshold,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *OutlierDetection) Reset() {
@@ -1361,6 +1368,13 @@ func (x *OutlierDetection) GetMinHealthPercent() int32 {
 func (x *OutlierDetection) GetOutlierDetectionHttpErrorCodes() []uint32 {
 	if x != nil {
 		return x.OutlierDetectionHttpErrorCodes
+	}
+	return nil
+}
+
+func (x *OutlierDetection) GetFailurePercentageThreshold() *wrappers.UInt32Value {
+	if x != nil {
+		return x.FailurePercentageThreshold
 	}
 	return nil
 }
@@ -3556,7 +3570,7 @@ const file_networking_v1alpha3_destination_rule_proto_rawDesc = "" +
 	"\x0fH2UpgradePolicy\x12\v\n" +
 	"\aDEFAULT\x10\x00\x12\x12\n" +
 	"\x0eDO_NOT_UPGRADE\x10\x01\x12\v\n" +
-	"\aUPGRADE\x10\x02\"\xd6\x05\n" +
+	"\aUPGRADE\x10\x02\"\xb6\x06\n" +
 	"\x10OutlierDetection\x121\n" +
 	"\x12consecutive_errors\x18\x01 \x01(\x05B\x02\x18\x01R\x11consecutiveErrors\x12J\n" +
 	"\"split_external_local_origin_errors\x18\b \x01(\bR\x1esplitExternalLocalOriginErrors\x12g\n" +
@@ -3568,7 +3582,8 @@ const file_networking_v1alpha3_destination_rule_proto_rawDesc = "" +
 	"\x14max_ejection_percent\x18\x04 \x01(\x05R\x12maxEjectionPercent\x12,\n" +
 	"\x12min_health_percent\x18\x05 \x01(\x05R\x10minHealthPercent\x12J\n" +
 	"\"outlier_detection_http_error_codes\x18\n" +
-	" \x03(\rR\x1eoutlierDetectionHttpErrorCodes\"\xe4\x03\n" +
+	" \x03(\rR\x1eoutlierDetectionHttpErrorCodes\x12^\n" +
+	"\x1cfailure_percentage_threshold\x18\v \x01(\v2\x1c.google.protobuf.UInt32ValueR\x1afailurePercentageThreshold\"\xe4\x03\n" +
 	"\x11ClientTLSSettings\x12H\n" +
 	"\x04mode\x18\x01 \x01(\x0e24.istio.networking.v1alpha3.ClientTLSSettings.TLSmodeR\x04mode\x12-\n" +
 	"\x12client_certificate\x18\x02 \x01(\tR\x11clientCertificate\x12\x1f\n" +
@@ -3699,47 +3714,48 @@ var file_networking_v1alpha3_destination_rule_proto_depIdxs = []int32{
 	36, // 27: istio.networking.v1alpha3.OutlierDetection.consecutive_5xx_errors:type_name -> google.protobuf.UInt32Value
 	34, // 28: istio.networking.v1alpha3.OutlierDetection.interval:type_name -> google.protobuf.Duration
 	34, // 29: istio.networking.v1alpha3.OutlierDetection.base_ejection_time:type_name -> google.protobuf.Duration
-	3,  // 30: istio.networking.v1alpha3.ClientTLSSettings.mode:type_name -> istio.networking.v1alpha3.ClientTLSSettings.TLSmode
-	37, // 31: istio.networking.v1alpha3.ClientTLSSettings.insecure_skip_verify:type_name -> google.protobuf.BoolValue
-	29, // 32: istio.networking.v1alpha3.LocalityLoadBalancerSetting.distribute:type_name -> istio.networking.v1alpha3.LocalityLoadBalancerSetting.Distribute
-	30, // 33: istio.networking.v1alpha3.LocalityLoadBalancerSetting.failover:type_name -> istio.networking.v1alpha3.LocalityLoadBalancerSetting.Failover
-	37, // 34: istio.networking.v1alpha3.LocalityLoadBalancerSetting.enabled:type_name -> google.protobuf.BoolValue
-	37, // 35: istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.enabled:type_name -> google.protobuf.BoolValue
-	32, // 36: istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.failover:type_name -> istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.Failover
-	36, // 37: istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.min_cluster_size:type_name -> google.protobuf.UInt32Value
-	38, // 38: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.port:type_name -> istio.networking.v1alpha3.PortSelector
-	7,  // 39: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.load_balancer:type_name -> istio.networking.v1alpha3.LoadBalancerSettings
-	9,  // 40: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.connection_pool:type_name -> istio.networking.v1alpha3.ConnectionPoolSettings
-	10, // 41: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.outlier_detection:type_name -> istio.networking.v1alpha3.OutlierDetection
-	11, // 42: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.tls:type_name -> istio.networking.v1alpha3.ClientTLSSettings
-	0,  // 43: istio.networking.v1alpha3.TrafficPolicy.ProxyProtocol.version:type_name -> istio.networking.v1alpha3.TrafficPolicy.ProxyProtocol.VERSION
-	35, // 44: istio.networking.v1alpha3.TrafficPolicy.RetryBudget.percent:type_name -> google.protobuf.DoubleValue
-	34, // 45: istio.networking.v1alpha3.TrafficPolicy.RetryBudget.budget_interval:type_name -> google.protobuf.Duration
-	23, // 46: istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.http_cookie:type_name -> istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.HTTPCookie
-	21, // 47: istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.ring_hash:type_name -> istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.RingHash
-	22, // 48: istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.maglev:type_name -> istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.MagLev
-	34, // 49: istio.networking.v1alpha3.LoadBalancerSettings.BackendUtilizationLB.weight_stabilization_period:type_name -> google.protobuf.Duration
-	34, // 50: istio.networking.v1alpha3.LoadBalancerSettings.BackendUtilizationLB.weight_expiration_period:type_name -> google.protobuf.Duration
-	34, // 51: istio.networking.v1alpha3.LoadBalancerSettings.BackendUtilizationLB.weight_update_period:type_name -> google.protobuf.Duration
-	34, // 52: istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.HTTPCookie.ttl:type_name -> google.protobuf.Duration
-	24, // 53: istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.HTTPCookie.attributes:type_name -> istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.HTTPCookie.Attribute
-	34, // 54: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.connect_timeout:type_name -> google.protobuf.Duration
-	27, // 55: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.tcp_keepalive:type_name -> istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.TcpKeepalive
-	34, // 56: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.max_connection_duration:type_name -> google.protobuf.Duration
-	34, // 57: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.idle_timeout:type_name -> google.protobuf.Duration
-	34, // 58: istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.idle_timeout:type_name -> google.protobuf.Duration
-	2,  // 59: istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.h2_upgrade_policy:type_name -> istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.H2UpgradePolicy
-	28, // 60: istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.http2_keep_alive:type_name -> istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.ConnectionKeepalive
-	34, // 61: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.TcpKeepalive.time:type_name -> google.protobuf.Duration
-	34, // 62: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.TcpKeepalive.interval:type_name -> google.protobuf.Duration
-	34, // 63: istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.ConnectionKeepalive.interval:type_name -> google.protobuf.Duration
-	34, // 64: istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.ConnectionKeepalive.timeout:type_name -> google.protobuf.Duration
-	31, // 65: istio.networking.v1alpha3.LocalityLoadBalancerSetting.Distribute.to:type_name -> istio.networking.v1alpha3.LocalityLoadBalancerSetting.Distribute.ToEntry
-	66, // [66:66] is the sub-list for method output_type
-	66, // [66:66] is the sub-list for method input_type
-	66, // [66:66] is the sub-list for extension type_name
-	66, // [66:66] is the sub-list for extension extendee
-	0,  // [0:66] is the sub-list for field type_name
+	36, // 30: istio.networking.v1alpha3.OutlierDetection.failure_percentage_threshold:type_name -> google.protobuf.UInt32Value
+	3,  // 31: istio.networking.v1alpha3.ClientTLSSettings.mode:type_name -> istio.networking.v1alpha3.ClientTLSSettings.TLSmode
+	37, // 32: istio.networking.v1alpha3.ClientTLSSettings.insecure_skip_verify:type_name -> google.protobuf.BoolValue
+	29, // 33: istio.networking.v1alpha3.LocalityLoadBalancerSetting.distribute:type_name -> istio.networking.v1alpha3.LocalityLoadBalancerSetting.Distribute
+	30, // 34: istio.networking.v1alpha3.LocalityLoadBalancerSetting.failover:type_name -> istio.networking.v1alpha3.LocalityLoadBalancerSetting.Failover
+	37, // 35: istio.networking.v1alpha3.LocalityLoadBalancerSetting.enabled:type_name -> google.protobuf.BoolValue
+	37, // 36: istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.enabled:type_name -> google.protobuf.BoolValue
+	32, // 37: istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.failover:type_name -> istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.Failover
+	36, // 38: istio.networking.v1alpha3.ZoneAwareLoadBalancerSetting.min_cluster_size:type_name -> google.protobuf.UInt32Value
+	38, // 39: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.port:type_name -> istio.networking.v1alpha3.PortSelector
+	7,  // 40: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.load_balancer:type_name -> istio.networking.v1alpha3.LoadBalancerSettings
+	9,  // 41: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.connection_pool:type_name -> istio.networking.v1alpha3.ConnectionPoolSettings
+	10, // 42: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.outlier_detection:type_name -> istio.networking.v1alpha3.OutlierDetection
+	11, // 43: istio.networking.v1alpha3.TrafficPolicy.PortTrafficPolicy.tls:type_name -> istio.networking.v1alpha3.ClientTLSSettings
+	0,  // 44: istio.networking.v1alpha3.TrafficPolicy.ProxyProtocol.version:type_name -> istio.networking.v1alpha3.TrafficPolicy.ProxyProtocol.VERSION
+	35, // 45: istio.networking.v1alpha3.TrafficPolicy.RetryBudget.percent:type_name -> google.protobuf.DoubleValue
+	34, // 46: istio.networking.v1alpha3.TrafficPolicy.RetryBudget.budget_interval:type_name -> google.protobuf.Duration
+	23, // 47: istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.http_cookie:type_name -> istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.HTTPCookie
+	21, // 48: istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.ring_hash:type_name -> istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.RingHash
+	22, // 49: istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.maglev:type_name -> istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.MagLev
+	34, // 50: istio.networking.v1alpha3.LoadBalancerSettings.BackendUtilizationLB.weight_stabilization_period:type_name -> google.protobuf.Duration
+	34, // 51: istio.networking.v1alpha3.LoadBalancerSettings.BackendUtilizationLB.weight_expiration_period:type_name -> google.protobuf.Duration
+	34, // 52: istio.networking.v1alpha3.LoadBalancerSettings.BackendUtilizationLB.weight_update_period:type_name -> google.protobuf.Duration
+	34, // 53: istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.HTTPCookie.ttl:type_name -> google.protobuf.Duration
+	24, // 54: istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.HTTPCookie.attributes:type_name -> istio.networking.v1alpha3.LoadBalancerSettings.ConsistentHashLB.HTTPCookie.Attribute
+	34, // 55: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.connect_timeout:type_name -> google.protobuf.Duration
+	27, // 56: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.tcp_keepalive:type_name -> istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.TcpKeepalive
+	34, // 57: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.max_connection_duration:type_name -> google.protobuf.Duration
+	34, // 58: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.idle_timeout:type_name -> google.protobuf.Duration
+	34, // 59: istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.idle_timeout:type_name -> google.protobuf.Duration
+	2,  // 60: istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.h2_upgrade_policy:type_name -> istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.H2UpgradePolicy
+	28, // 61: istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.http2_keep_alive:type_name -> istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.ConnectionKeepalive
+	34, // 62: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.TcpKeepalive.time:type_name -> google.protobuf.Duration
+	34, // 63: istio.networking.v1alpha3.ConnectionPoolSettings.TCPSettings.TcpKeepalive.interval:type_name -> google.protobuf.Duration
+	34, // 64: istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.ConnectionKeepalive.interval:type_name -> google.protobuf.Duration
+	34, // 65: istio.networking.v1alpha3.ConnectionPoolSettings.HTTPSettings.ConnectionKeepalive.timeout:type_name -> google.protobuf.Duration
+	31, // 66: istio.networking.v1alpha3.LocalityLoadBalancerSetting.Distribute.to:type_name -> istio.networking.v1alpha3.LocalityLoadBalancerSetting.Distribute.ToEntry
+	67, // [67:67] is the sub-list for method output_type
+	67, // [67:67] is the sub-list for method input_type
+	67, // [67:67] is the sub-list for extension type_name
+	67, // [67:67] is the sub-list for extension extendee
+	0,  // [0:67] is the sub-list for field type_name
 }
 
 func init() { file_networking_v1alpha3_destination_rule_proto_init() }

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1225,6 +1225,13 @@ type OutlierDetection struct {
 	// if the value of `consecutiveGatewayErrors` is greater than or equal to
 	// the value of `consecutive5xxErrors`, `consecutiveGatewayErrors` will have
 	// no effect.
+	//
+	// Because this threshold only counts *consecutive* failures, a host whose
+	// errors are interleaved with successful requests may never reach it even
+	// if its overall failure rate is high, e.g. a host that fails every other
+	// request will never accumulate 5 consecutive errors. Use
+	// `failurePercentageThreshold` to eject hosts based on failure rate over
+	// the analysis `interval` instead of requiring consecutive failures.
 	Consecutive_5XxErrors *wrappers.UInt32Value `protobuf:"bytes,7,opt,name=consecutive_5xx_errors,json=consecutive5xxErrors,proto3" json:"consecutive_5xx_errors,omitempty"`
 	// Time interval between ejection sweep analysis. format:
 	// 1h/1m/1s/1ms. MUST be >=1ms. Default is 10s.
@@ -1263,6 +1270,10 @@ type OutlierDetection struct {
 	// The failure percentage to use when determining failure percentage-based outlier detection. If
 	// the failure percentage of a given host is greater than or equal to this value, it will be
 	// ejected. Defaults to 85.
+	//
+	// Unlike `consecutive5xxErrors` and `consecutiveGatewayErrors`, this does not require failures
+	// to occur back-to-back, so it will still eject a host whose failure rate is high but whose
+	// errors are interspersed with successful requests.
 	//
 	// +kubebuilder:validation:Maximum=100
 	// +kubebuilder:validation:Minimum=0

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1627,6 +1627,12 @@ used separately or together. Because the errors counted by
 if the value of <code>consecutiveGatewayErrors</code> is greater than or equal to
 the value of <code>consecutive5xxErrors</code>, <code>consecutiveGatewayErrors</code> will have
 no effect.</p>
+<p>Because this threshold only counts <em>consecutive</em> failures, a host whose
+errors are interleaved with successful requests may never reach it even
+if its overall failure rate is high, e.g. a host that fails every other
+request will never accumulate 5 consecutive errors. Use
+<code>failurePercentageThreshold</code> to eject hosts based on failure rate over
+the analysis <code>interval</code> instead of requiring consecutive failures.</p>
 
 </td>
 </tr>
@@ -1702,6 +1708,9 @@ HTTP status codes are counted as errors toward those thresholds.</p>
 <p>The failure percentage to use when determining failure percentage-based outlier detection. If
 the failure percentage of a given host is greater than or equal to this value, it will be
 ejected. Defaults to 85.</p>
+<p>Unlike <code>consecutive5xxErrors</code> and <code>consecutiveGatewayErrors</code>, this does not require failures
+to occur back-to-back, so it will still eject a host whose failure rate is high but whose
+errors are interspersed with successful requests.</p>
 
 </td>
 </tr>

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1694,6 +1694,17 @@ HTTP status codes are counted as errors toward those thresholds.</p>
 
 </td>
 </tr>
+<tr id="OutlierDetection-failure_percentage_threshold">
+<td><div class="field"><div class="name"><code><a href="#OutlierDetection-failure_percentage_threshold">failurePercentageThreshold</a></code></div>
+<div class="type"><a href="#google-protobuf-UInt32Value">UInt32Value</a></div>
+</div></td>
+<td>
+<p>The failure percentage to use when determining failure percentage-based outlier detection. If
+the failure percentage of a given host is greater than or equal to this value, it will be
+ejected. Defaults to 85.</p>
+
+</td>
+</tr>
 </tbody>
 </table>
 </section>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -960,6 +960,14 @@ message OutlierDetection {
   // +protoc-gen-crd:list-value-validation:Minimum=100
   // +protoc-gen-crd:list-value-validation:Maximum=599
   repeated uint32 outlier_detection_http_error_codes = 10;
+
+  // The failure percentage to use when determining failure percentage-based outlier detection. If
+  // the failure percentage of a given host is greater than or equal to this value, it will be
+  // ejected. Defaults to 85.
+  //
+  // +kubebuilder:validation:Maximum=100
+  // +kubebuilder:validation:Minimum=0
+  google.protobuf.UInt32Value failure_percentage_threshold = 11;
 }
 
 // SSL/TLS related settings for upstream connections. See Envoy's [TLS

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -920,6 +920,13 @@ message OutlierDetection {
   // if the value of `consecutiveGatewayErrors` is greater than or equal to
   // the value of `consecutive5xxErrors`, `consecutiveGatewayErrors` will have
   // no effect.
+  //
+  // Because this threshold only counts *consecutive* failures, a host whose
+  // errors are interleaved with successful requests may never reach it even
+  // if its overall failure rate is high, e.g. a host that fails every other
+  // request will never accumulate 5 consecutive errors. Use
+  // `failurePercentageThreshold` to eject hosts based on failure rate over
+  // the analysis `interval` instead of requiring consecutive failures.
   google.protobuf.UInt32Value consecutive_5xx_errors = 7;
 
   // Time interval between ejection sweep analysis. format:
@@ -964,6 +971,10 @@ message OutlierDetection {
   // The failure percentage to use when determining failure percentage-based outlier detection. If
   // the failure percentage of a given host is greater than or equal to this value, it will be
   // ejected. Defaults to 85.
+  //
+  // Unlike `consecutive5xxErrors` and `consecutiveGatewayErrors`, this does not require failures
+  // to occur back-to-back, so it will still eject a host whose failure rate is high but whose
+  // errors are interspersed with successful requests.
   //
   // +kubebuilder:validation:Maximum=100
   // +kubebuilder:validation:Minimum=0


### PR DESCRIPTION
`consecutive_5xx_errors` only fires on back-to-back failures, if failures are interleaved with successes (e.g., failure, success, failure, success...) the counter keeps resetting to zero and a host sitting at 50% failure rate can run indefinitely without being ejected. 