### PR TITLE
feat: add caCertCredentialName to ClientTLSSettings for Gateway API mTLS

### DIFF
--- a/kubernetes/customresourcedefinitions.gen.yaml
+++ b/kubernetes/customresourcedefinitions.gen.yaml
@@ -1800,6 +1800,11 @@ spec:
                                 description: TLS related settings for connections
                                   to the upstream service.
                                 properties:
+                                  caCertCredentialName:
+                                    description: The name of the secret or the configmap
+                                      that holds CA certificates used to verify the
+                                      server's certificate.
+                                    type: string
                                   caCertificates:
                                     description: 'OPTIONAL: The path to the file containing
                                       certificate authority certificates to use in
@@ -1895,6 +1900,11 @@ spec:
                           description: TLS related settings for connections to the
                             upstream service.
                           properties:
+                            caCertCredentialName:
+                              description: The name of the secret or the configmap
+                                that holds CA certificates used to verify the server's
+                                certificate.
+                              type: string
                             caCertificates:
                               description: 'OPTIONAL: The path to the file containing
                                 certificate authority certificates to use in verifying
@@ -2945,6 +2955,11 @@ spec:
                           description: TLS related settings for connections to the
                             upstream service.
                           properties:
+                            caCertCredentialName:
+                              description: The name of the secret or the configmap
+                                that holds CA certificates used to verify the server's
+                                certificate.
+                              type: string
                             caCertificates:
                               description: 'OPTIONAL: The path to the file containing
                                 certificate authority certificates to use in verifying
@@ -3038,6 +3053,10 @@ spec:
                     description: TLS related settings for connections to the upstream
                       service.
                     properties:
+                      caCertCredentialName:
+                        description: The name of the secret or the configmap that
+                          holds CA certificates used to verify the server's certificate.
+                        type: string
                       caCertificates:
                         description: 'OPTIONAL: The path to the file containing certificate
                           authority certificates to use in verifying a presented server
@@ -4267,6 +4286,11 @@ spec:
                                 description: TLS related settings for connections
                                   to the upstream service.
                                 properties:
+                                  caCertCredentialName:
+                                    description: The name of the secret or the configmap
+                                      that holds CA certificates used to verify the
+                                      server's certificate.
+                                    type: string
                                   caCertificates:
                                     description: 'OPTIONAL: The path to the file containing
                                       certificate authority certificates to use in
@@ -4362,6 +4386,11 @@ spec:
                           description: TLS related settings for connections to the
                             upstream service.
                           properties:
+                            caCertCredentialName:
+                              description: The name of the secret or the configmap
+                                that holds CA certificates used to verify the server's
+                                certificate.
+                              type: string
                             caCertificates:
                               description: 'OPTIONAL: The path to the file containing
                                 certificate authority certificates to use in verifying
@@ -5412,6 +5441,11 @@ spec:
                           description: TLS related settings for connections to the
                             upstream service.
                           properties:
+                            caCertCredentialName:
+                              description: The name of the secret or the configmap
+                                that holds CA certificates used to verify the server's
+                                certificate.
+                              type: string
                             caCertificates:
                               description: 'OPTIONAL: The path to the file containing
                                 certificate authority certificates to use in verifying
@@ -5505,6 +5539,10 @@ spec:
                     description: TLS related settings for connections to the upstream
                       service.
                     properties:
+                      caCertCredentialName:
+                        description: The name of the secret or the configmap that
+                          holds CA certificates used to verify the server's certificate.
+                        type: string
                       caCertificates:
                         description: 'OPTIONAL: The path to the file containing certificate
                           authority certificates to use in verifying a presented server
@@ -6734,6 +6772,11 @@ spec:
                                 description: TLS related settings for connections
                                   to the upstream service.
                                 properties:
+                                  caCertCredentialName:
+                                    description: The name of the secret or the configmap
+                                      that holds CA certificates used to verify the
+                                      server's certificate.
+                                    type: string
                                   caCertificates:
                                     description: 'OPTIONAL: The path to the file containing
                                       certificate authority certificates to use in
@@ -6829,6 +6872,11 @@ spec:
                           description: TLS related settings for connections to the
                             upstream service.
                           properties:
+                            caCertCredentialName:
+                              description: The name of the secret or the configmap
+                                that holds CA certificates used to verify the server's
+                                certificate.
+                              type: string
                             caCertificates:
                               description: 'OPTIONAL: The path to the file containing
                                 certificate authority certificates to use in verifying
@@ -7879,6 +7927,11 @@ spec:
                           description: TLS related settings for connections to the
                             upstream service.
                           properties:
+                            caCertCredentialName:
+                              description: The name of the secret or the configmap
+                                that holds CA certificates used to verify the server's
+                                certificate.
+                              type: string
                             caCertificates:
                               description: 'OPTIONAL: The path to the file containing
                                 certificate authority certificates to use in verifying
@@ -7972,6 +8025,10 @@ spec:
                     description: TLS related settings for connections to the upstream
                       service.
                     properties:
+                      caCertCredentialName:
+                        description: The name of the secret or the configmap that
+                          holds CA certificates used to verify the server's certificate.
+                        type: string
                       caCertificates:
                         description: 'OPTIONAL: The path to the file containing certificate
                           authority certificates to use in verifying a presented server

--- a/networking/v1alpha3/destination_rule.pb.go
+++ b/networking/v1alpha3/destination_rule.pb.go
@@ -1493,6 +1493,17 @@ type ClientTLSSettings struct {
 	// Otherwise the field will be applicable only at gateways, and
 	// sidecars will continue to use the certificate paths.
 	CredentialName string `protobuf:"bytes,7,opt,name=credential_name,json=credentialName,proto3" json:"credential_name,omitempty"`
+	// The name of the secret or the configmap that holds CA certificates used to
+	// verify the server's certificate. Allows sourcing the trust bundle
+	// independently from `credentialName`.
+	//
+	// Applies to `SIMPLE` and `MUTUAL` TLS modes. Should be empty when using `ISTIO_MUTUAL`.
+	//
+	// **NOTE:** This field is applicable at sidecars only if
+	// `DestinationRule` has a `workloadSelector` specified.
+	// Otherwise the field will be applicable only at gateways, and
+	// sidecars will continue to use the certificate paths.
+	CaCertCredentialName string `protobuf:"bytes,10,opt,name=ca_cert_credential_name,json=caCertCredentialName,proto3" json:"ca_cert_credential_name,omitempty"`
 	// A list of alternate names to verify the subject identity in the
 	// certificate. If specified, the proxy will verify that the server
 	// certificate's subject alt name matches one of the specified values.
@@ -1581,6 +1592,13 @@ func (x *ClientTLSSettings) GetCaCertificates() string {
 func (x *ClientTLSSettings) GetCredentialName() string {
 	if x != nil {
 		return x.CredentialName
+	}
+	return ""
+}
+
+func (x *ClientTLSSettings) GetCaCertCredentialName() string {
+	if x != nil {
+		return x.CaCertCredentialName
 	}
 	return ""
 }
@@ -3593,14 +3611,16 @@ const file_networking_v1alpha3_destination_rule_proto_rawDesc = "" +
 	"\x12min_health_percent\x18\x05 \x01(\x05R\x10minHealthPercent\x12J\n" +
 	"\"outlier_detection_http_error_codes\x18\n" +
 	" \x03(\rR\x1eoutlierDetectionHttpErrorCodes\x12^\n" +
-	"\x1cfailure_percentage_threshold\x18\v \x01(\v2\x1c.google.protobuf.UInt32ValueR\x1afailurePercentageThreshold\"\xe4\x03\n" +
+	"\x1cfailure_percentage_threshold\x18\v \x01(\v2\x1c.google.protobuf.UInt32ValueR\x1afailurePercentageThreshold\"\x9b\x04\n" +
 	"\x11ClientTLSSettings\x12H\n" +
 	"\x04mode\x18\x01 \x01(\x0e24.istio.networking.v1alpha3.ClientTLSSettings.TLSmodeR\x04mode\x12-\n" +
 	"\x12client_certificate\x18\x02 \x01(\tR\x11clientCertificate\x12\x1f\n" +
 	"\vprivate_key\x18\x03 \x01(\tR\n" +
 	"privateKey\x12'\n" +
 	"\x0fca_certificates\x18\x04 \x01(\tR\x0ecaCertificates\x12'\n" +
-	"\x0fcredential_name\x18\a \x01(\tR\x0ecredentialName\x12*\n" +
+	"\x0fcredential_name\x18\a \x01(\tR\x0ecredentialName\x125\n" +
+	"\x17ca_cert_credential_name\x18\n" +
+	" \x01(\tR\x14caCertCredentialName\x12*\n" +
 	"\x11subject_alt_names\x18\x05 \x03(\tR\x0fsubjectAltNames\x12\x10\n" +
 	"\x03sni\x18\x06 \x01(\tR\x03sni\x12L\n" +
 	"\x14insecure_skip_verify\x18\b \x01(\v2\x1a.google.protobuf.BoolValueR\x12insecureSkipVerify\x12\x15\n" +

--- a/networking/v1alpha3/destination_rule.pb.html
+++ b/networking/v1alpha3/destination_rule.pb.html
@@ -1841,6 +1841,22 @@ sidecars will continue to use the certificate paths.</p>
 
 </td>
 </tr>
+<tr id="ClientTLSSettings-ca_cert_credential_name">
+<td><div class="field"><div class="name"><code><a href="#ClientTLSSettings-ca_cert_credential_name">caCertCredentialName</a></code></div>
+<div class="type">string</div>
+</div></td>
+<td>
+<p>The name of the secret or the configmap that holds CA certificates used to
+verify the server&rsquo;s certificate. Allows sourcing the trust bundle
+independently from <code>credentialName</code>.</p>
+<p>Applies to <code>SIMPLE</code> and <code>MUTUAL</code> TLS modes. Should be empty when using <code>ISTIO_MUTUAL</code>.</p>
+<p><strong>NOTE:</strong> This field is applicable at sidecars only if
+<code>DestinationRule</code> has a <code>workloadSelector</code> specified.
+Otherwise the field will be applicable only at gateways, and
+sidecars will continue to use the certificate paths.</p>
+
+</td>
+</tr>
 <tr id="ClientTLSSettings-subject_alt_names">
 <td><div class="field"><div class="name"><code><a href="#ClientTLSSettings-subject_alt_names">subjectAltNames</a></code></div>
 <div class="type">string[]</div>

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -1096,6 +1096,18 @@ message ClientTLSSettings {
   // sidecars will continue to use the certificate paths.
   string credential_name = 7;
 
+  // The name of the secret or the configmap that holds CA certificates used to
+  // verify the server's certificate. Allows sourcing the trust bundle
+  // independently from `credentialName`.
+  //
+  // Applies to `SIMPLE` and `MUTUAL` TLS modes. Should be empty when using `ISTIO_MUTUAL`.
+  //
+  // **NOTE:** This field is applicable at sidecars only if
+  // `DestinationRule` has a `workloadSelector` specified.
+  // Otherwise the field will be applicable only at gateways, and
+  // sidecars will continue to use the certificate paths.
+  string ca_cert_credential_name = 10;
+
   // A list of alternate names to verify the subject identity in the
   // certificate. If specified, the proxy will verify that the server
   // certificate's subject alt name matches one of the specified values.

--- a/releasenotes/notes/61403.yaml
+++ b/releasenotes/notes/61403.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - https://github.com/istio/istio/issues/61403
+releaseNotes:
+  - |
+    **Added** `caCertCredentialName` field in `ClientTLSSettings` to reference a Secret/ConfigMap that holds CA certificates for upstream mTLS


### PR DESCRIPTION
Mostly looking for initial feedback and discussion on this plan for implementing ClientAndServer TLS mode for XBackend, with this API change being a pre-requisite.

Will be accompanied by a PR for https://github.com/istio/istio/issues/61403, and also relates to https://github.com/istio/istio/issues/61515.

---

Proposing adding a `caCertCredentialName` field to ClientTLSSettings, like the existing `caCertCredentialName` under ServerTLSSettings #3544, for storing the CA trust bundle reference when using ClientAndServer TLS mode on XBackend,  which frees up `credentialName` to store the XBackend `clientCertificateRef`.

The logic used for configuring the `credentialName` for XBackend ServerOnly mode (which is [already implemented](https://github.com/istio/istio/pull/61012)) is reused from BackendTLSPolicy; BackendTLSPolicy only uses SIMPLE TLS. Here is a scenario for establishing an mTLS connection which summarizes the current issue with implementing ClientAndServer TLS mode for XBackend:

1. Client (Gateway) connects to server (represented by XBackend).
2. Server presents it's cert.
3. Client verifies the cert is signed by using it's own CA trust bundle (delivered by istiod via SDS, held in a K8s ConfigMap for XBackend).

	* Here we face a problem; istiod *always* derives the client's trust bundle name as `credentialName` + "-cacert". In the case of XBackend, that means we ignore the ConfigMap declared on the XBackend custom resource under tls.validation.caCertificateRefs.

	* For the XBackend ServerOnly TLS mode (SIMPLE TLS), this is fine. We use ClientTLSSettings.credentialName to store the ConfigMap CA cert ref, since there is no client cert ref needed for ServerOnly mode with one-way TLS.
	
	* For ClientAndServer mode, however, there is no field in Istio's ClientTLSSettings to separately carry the client's CA certificate reference. The only relevant credential field in ClientTLSSettings is credentialName, which we **must** use to store the XBackend tls.clientCertificateRef (as it is a required field for ClientAndServer mode).
	
		* As an aside, istiod needs to authorize SDS requests using `VerifiedCertificateReferences`; this list includes the Gateway's *server* certificate refs as authorized resources, but not the XBackend clientCertificateRef.
		
	* Since there is no Secret at \<cert name> + "-cacert", we can't verify the server's cert. We fail here.
	
4. The server requests the client's cert (mTLS part).
5. Client presents it's cert (which was configured under tls.clientCertificateRef)
6. The server verifies the cert against it's own CA, which is configured on the backend pod itself or otherwise not our concern.